### PR TITLE
Ask address of the user to help find the court

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -674,6 +674,8 @@ comment: |
   the address where the incident took place. Especially
   if this is a responsive case.
 code: |
+  # Force the address question to be asked if it hasn't been asked yet
+  users[0].address
   addresses_to_search = [users[0].address]
 ---
 comment: |

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -675,7 +675,7 @@ comment: |
   if this is a responsive case.
 code: |
   # Force the address question to be asked if it hasn't been asked yet
-  users[0].address
+  users[0].address.address
   addresses_to_search = [users[0].address]
 ---
 comment: |


### PR DESCRIPTION
https://github.com/SuffolkLITLab/docassemble-assemblylinewizard/issues/121#issuecomment-769230682 has most of the background for this change. 

We should consider that this will **force the user to give their address**, even if the form doesn't need it, which seems iffy. Some other (more complicated) ways of fixing this missing address issue:
* have a different address ask screen that doesn't mark the address as required, but instead indicates that entering their address will help them later in the interview but isn't necessary for the form itself (do courts always need the address of the user? We might eventually want it when we gather interview stats)
* Add an intermediate `id: choose a court (no address given)` screen that looks like `id:choose a court (no matching courts found)`, but also asks for an optional address, and if the address is entered, runs another search, and then goes to either `(no matching courts found)` or `(courts matching provided address were found)` screens.
* Just mark the linked issue above as Not a Bug, and force interview writers to add `users[0].address` before any questions that trigger court location questions if they want the court selector to be narrowed.