### PR TITLE
Close #40, and invisible sought var data to the dev DOM

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -2,9 +2,6 @@
 include:
   - al_package.yml
 ---
-objects:
-  - your_children_past_benefits: DADict.using(object_type=DAObject)
----
 mandatory: True
 code: |
   al_user_bundle

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -2,6 +2,9 @@
 include:
   - al_package.yml
 ---
+objects:
+  - your_children_past_benefits: DADict.using(object_type=DAObject)
+---
 mandatory: True
 code: |
   al_user_bundle

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -18,6 +18,7 @@ default screen parts:
     % if get_config('debug'):
     `id: ${ user_info().question_id }`  
     `Package: ${ user_info().package } ${ package_version_number }; ${ al_version }`
+    <div data-variable="${ encode_name(user_info().variable) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
     % endif
 ---
 features:

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -18,7 +18,7 @@ default screen parts:
     % if get_config('debug'):
     `id: ${ user_info().question_id }`  
     `Package: ${ user_info().package } ${ package_version_number }; ${ al_version }`
-    <div data-variable="${ encode_name(user_info().variable) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
     % endif
 ---
 features:


### PR DESCRIPTION
Close #40. You can test with [al_question_test.yml](https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALSoughtVar%3Aal_question_test.yml#page1) for a simple variable name and with [a test I made](https://apps-dev.suffolklitlab.org/interview?i=docassemble.playground12ALSoughtVar%3Atest.yml#page1) for a more complex variable name. It doesn't matter much as the variable name gets encoded.