### PR TITLE
Name fields with business option

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -102,7 +102,7 @@ class ALIndividual(Individual):
       return [
         {"label": self.person_type_label, "field": self.attr_name('person_type'),
          "choices": [{"Person": "ALIndividual"}, {"Business or organization": "business"}], 
-         "input type": radio, "required": True},
+         "input type": "radio", "required": True},
         # Individual questions
         {"label": self.first_name_label, "field": self.attr_name('name.first'),
          "show if": show_if_indiv},

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -101,7 +101,7 @@ class ALIndividual(Individual):
       show_if_business = {"variable": self.attr_name("person_type"), "is": "business"}
       return [
         {"label": self.person_type_label, "field": self.attr_name('person_type'),
-         "choices": [{"ALIndividual": "Person"}, {"business": "Business or organization"}], "required": True},
+         "choices": [{"Person": "ALIndividual"}, {"Business or organization": "business"}], "required": True},
         # Individual questions
         {"label": self.first_name_label, "field": self.attr_name('name.first'),
          "show if": show_if_indiv},

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -78,22 +78,42 @@ class ALIndividual(Individual):
     return '%d days' % (int(dd.days),)
   
   # This design helps us translate the prompts for common fields just once
-  def name_fields(self, uses_parts=True):
+  def name_fields(self, person_or_business:str = 'person'):
     """
-    Return suitable field prompts for a name. 
+    Return suitable field prompts for a name. If `uses_parts` is None, adds the 
+    proper "show ifs" and uses both the parts and the single entry
     """
-    if uses_parts:
+    if person_or_business == 'person':
       return [
         {"label": self.first_name_label, "field": self.attr_name('name.first')},
         {"label": self.middle_name_label, "field": self.attr_name('name.middle'), "required": False},
         {"label": self.last_name_label, "field": self.attr_name("name.last")},
         {"label": self.suffix_label, "field": self.attr_name("name.suffix"), "choices": name_suffix(), "required": False}
       ]
-    else:
+    elif person_or_business == 'business':
       # Note: we don't make use of the name.text field for simplicity
       # TODO: this could be reconsidered`, but name.text tends to lead to developer error
       return [
-        {"label": self.name_text, "field": self.attr_name('name.first')}
+        {"label": self.business_name_text, "field": self.attr_name('name.first')}
+      ]
+    else:
+      show_if_indiv = {"variable": self.attr_name("person_type"), "is": "ALIndividual"}
+      show_if_business = {"variable": self.attr_name("person_type"), "is": "business"}
+      return [
+        {"label": self.person_type_label, "field": self.attr_name('person_type'),
+         "choices": [{"ALIndividual": "Person"}, {"business": "Business or organization"}], "required": True},
+        # Individual questions
+        {"label": self.first_name_label, "field": self.attr_name('name.first'),
+         "show if": show_if_indiv},
+        {"label": self.middle_name_label, "field": self.attr_name('name.middle'), "required": False,
+         "show if": show_if_indiv},
+        {"label": self.last_name_label, "field": self.attr_name("name.last"),
+         "show if": show_if_indiv},
+        {"label": self.suffix_label, "field": self.attr_name("name.suffix"), "choices": name_suffix(), "required": False,
+         "show if": show_if_indiv},
+        # Business names
+        {"label": self.business_name_label, "field": self.attr_name('name.first'),
+         "show if": show_if_business} 
       ]
  
   def address_fields(self, country_code="US", default_state=None, show_country=False):

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -101,7 +101,8 @@ class ALIndividual(Individual):
       show_if_business = {"variable": self.attr_name("person_type"), "is": "business"}
       return [
         {"label": self.person_type_label, "field": self.attr_name('person_type'),
-         "choices": [{"Person": "ALIndividual"}, {"Business or organization": "business"}], "required": True},
+         "choices": [{"Person": "ALIndividual"}, {"Business or organization": "business"}], 
+         "input type": radio, "required": True},
         # Individual questions
         {"label": self.first_name_label, "field": self.attr_name('name.first'),
          "show if": show_if_indiv},

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -5,6 +5,7 @@ include:
 mandatory: True
 code: |
   al_user_bundle
+  other_parties.gather()
   users.gather()
   users[0].address.address
   children.gather()

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -469,6 +469,8 @@ question: |
   % endif
 yesno: other_parties.there_is_another  
 ---
+sets:
+  - other_parties[i].name.first
 id: names of opposing parties
 question: |
   % if users==plaintiffs:
@@ -479,7 +481,7 @@ question: |
   % endif
 fields:
   - code: |
-    other_parties[i].name_fields(person_or_business='unsure')
+      other_parties[i].name_fields(person_or_business='unsure')
 ---
 # TODO: consider removing default state
 sets:

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -201,6 +201,16 @@ content: |
   Suffix
 ---
 generic object: ALIndividual
+template: x.person_type_label
+content: |
+  Is this a person, or a business?
+---
+generic object: ALIndividual
+template: x.business_name_label
+content: |
+  Name of organization or business
+---
+generic object: ALIndividual
 template: x.address_address_label
 content: |
   Street address
@@ -468,30 +478,8 @@ question: |
   Name of ${ ordinal(i) } **plaintiff** or petitioner in this matter
   % endif
 fields:
-  - Are they a person, or a business?: other_parties[i].person_type
-    input type: radio
-    choices:
-      - Business or organization: business
-      - Person: ALIndividual
-  - First name: other_parties[i].name.first
-    show if:
-      variable: other_parties[i].person_type
-      is: "ALIndividual"
-  - Last name: other_parties[i].name.last
-    show if:
-      variable: other_parties[i].person_type      
-      is: "ALIndividual"
-  - Suffix: other_parties[i].name.suffix
-    code: |
-      name_suffix()
-    show if:
-      variable: other_parties[i].person_type      
-      is: "ALIndividual"
-    required: False      
-  - Name of organization or business: other_parties[i].name.first
-    show if:
-      variable: other_parties[i].person_type
-      is: business
+  - code: |
+    other_parties[i].name_fields(person_or_business='unsure')
 ---
 # TODO: consider removing default state
 sets:


### PR DESCRIPTION
Refactored the existing code a bit to also allow people to ask for `show if`'d code for business or people. Existing question structure was taken from the `other_parties` default question, but needed it for `users` as well for some changes in the [Civil docketing statement](https://github.com/SuffolkLITLab/docassemble-AppealsCivilDocketingStatement/issues/12). 