### PR TITLE
New choice labels

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -91,23 +91,26 @@ class ALIndividual(Individual):
     """
     if person_or_business == 'person':
       return [
-        {"label": self.first_name_label, "field": self.attr_name('name.first')},
-        {"label": self.middle_name_label, "field": self.attr_name('name.middle'), "required": False},
-        {"label": self.last_name_label, "field": self.attr_name("name.last")},
-        {"label": self.suffix_label, "field": self.attr_name("name.suffix"), "choices": name_suffix(), "required": False}
+        {"label": str(self.first_name_label), "field": self.attr_name('name.first')},
+        {"label": str(self.middle_name_label), "field": self.attr_name('name.middle'), "required": False},
+        {"label": str(self.last_name_label), "field": self.attr_name("name.last")},
+        {"label": str(self.suffix_label), "field": self.attr_name("name.suffix"), "choices": name_suffix(), "required": False}
       ]
     elif person_or_business == 'business':
       # Note: we don't make use of the name.text field for simplicity
       # TODO: this could be reconsidered`, but name.text tends to lead to developer error
       return [
-        {"label": self.business_name_label, "field": self.attr_name('name.first')}
+        {"label": str(self.business_name_label), "field": self.attr_name('name.first')}
       ]
     else:
+      # Note: the labels are template block objects: if they are keys,
+      # they should be converted to strings first
       show_if_indiv = {"variable": self.attr_name("person_type"), "is": "ALIndividual"}
       show_if_business = {"variable": self.attr_name("person_type"), "is": "business"}
       return [
-        {"label": self.person_type_label, "field": self.attr_name('person_type'),
-         "choices": [{self.individual_choice_label: "ALIndividual"}, {self.business_choice_label: "business"}],
+        {"label": str(self.person_type_label), "field": self.attr_name('person_type'),
+         "choices": [{str(self.individual_choice_label): "ALIndividual"},
+                     {str(self.business_choice_label): "business"}],
          "input type": "radio", "required": True},
         # Individual questions
         {"label": self.first_name_label, "field": self.attr_name('name.first'),

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -100,14 +100,14 @@ class ALIndividual(Individual):
       # Note: we don't make use of the name.text field for simplicity
       # TODO: this could be reconsidered`, but name.text tends to lead to developer error
       return [
-        {"label": self.business_name_text, "field": self.attr_name('name.first')}
+        {"label": self.business_name_label, "field": self.attr_name('name.first')}
       ]
     else:
       show_if_indiv = {"variable": self.attr_name("person_type"), "is": "ALIndividual"}
       show_if_business = {"variable": self.attr_name("person_type"), "is": "business"}
       return [
         {"label": self.person_type_label, "field": self.attr_name('person_type'),
-         "choices": [{"Person": "ALIndividual"}, {"Business or organization": "business"}], 
+         "choices": [{self.individual_choice_label: "ALIndividual"}, {self.business_choice_label: "business"}],
          "input type": "radio", "required": True},
         # Individual questions
         {"label": self.first_name_label, "field": self.attr_name('name.first'),
@@ -145,6 +145,7 @@ class ALIndividual(Individual):
     """
     Return field prompts for other contact info
     """
+    pass
 
 def section_links(nav):
   """Returns a list of clickable navigation links without animation."""

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -204,7 +204,17 @@ content: |
 generic object: ALIndividual
 template: x.business_name_label
 content: |
-  Name of organization or business
+  Name of business or organization
+---
+generic object: ALIndividual
+template: x.individual_choice_label
+content: |
+  Person
+---
+generic object: ALIndividual
+template: x.business_choice_label
+content: |
+  Business or organization
 ---
 generic object: ALIndividual
 template: x.address_address_label


### PR DESCRIPTION
Allows downstream interviews (specifically for the Civil Docketing Statement at the moment) to modify the labels shown for business vs person choices, and fixes a small bug (looking for `self.business_name_text` instead of `self.business_name_label`).

Tested on the Civil Docketing statement interview on dev, going to merge.