### PR TITLE
Fix #68, custom audio elem gone when page help button is pressed

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -9,6 +9,7 @@ modules:
 ---
 mandatory: True
 code: |
+  feature_tests_1
   al_user_bundle
   other_parties.gather()
   users.gather()
@@ -17,6 +18,20 @@ code: |
   children.gather()
   preview_screen
   basic_questions_signature_flow
+---
+# I would just use `audio_test`, but I think this may be expanded.
+# For example, it may also be used to test the 'escape' button, etc.
+id: test behavior of some features
+field: feature_tests_1
+question: |
+  Page to test certain features
+subquestion: |
+  Currently testing:
+  
+  - Custom audio element reading behavior is correct
+  - Custom audio element shows on both regular screen and on help screen
+help: |
+  Show help screen
 ---
 id: preview
 continue button field: preview_screen

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -22,7 +22,7 @@ code: |
 # I would just use `audio_test`, but I think this may be expanded.
 # For example, it may also be used to test the 'escape' button, etc.
 id: test behavior of some features
-field: feature_tests_1
+continue button field: feature_tests_1
 question: |
   Page to test certain features
 subquestion: |

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -19,8 +19,6 @@ code: |
   preview_screen
   basic_questions_signature_flow
 ---
-# I would just use `audio_test`, but I think this may be expanded.
-# For example, it may also be used to test the 'escape' button, etc.
 id: test behavior of some features
 continue button field: feature_tests_1
 question: |

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -2,10 +2,7 @@ $(document).on('daPageLoad', function() {
   var $audio_nodes = $('.daaudio-control');
   var id_count = 1;
   for ( var audio_node of $audio_nodes ) {
-    (function () {
-      console.log( audio_node.constructor.name );
-      al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
-    })();
+    al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
     id_count++;
   }
   

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -1,5 +1,14 @@
 $(document).on('daPageLoad', function() {
-  al_js.audio_minimal_controls( $('.daaudio-control')[0], 'page_reader_substitute' );
+  var $audio_nodes = $('.daaudio-control');
+  var id_count = 1;
+  for ( var audio_node of $audio_nodes ) {
+    (function () {
+      console.log( audio_node.constructor.name );
+      al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
+    })();
+    id_count++;
+  }
+  
 });
 
 var al_js = {};
@@ -8,7 +17,7 @@ var al_js = {};
 // TODO: Show user the audio still needs to load:
 // - https://stackoverflow.com/questions/9337300/html5-audio-load-event,
 // - https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play
-al_js.audio_minimal_controls = function( audio_node, id ) {
+al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
   /* Create the custom controls for this specific audio element
   * and give the new controls container the requested `id` tag. */
   if (!audio_node) {
@@ -19,7 +28,7 @@ al_js.audio_minimal_controls = function( audio_node, id ) {
   // Hide the normal controls and show the new controls
   audio_node.removeAttribute('controls');
   audio_node.style.display = 'none';
-  var $audio_container = $($('.daaudiovideo-control')[0]);
+  var $audio_container = $($(audio_node).closest('.daaudiovideo-control'));
   $audio_container.addClass( 'al_custom_media_controls' );
   $('<div id="' + id + '" class="btn-group">' +
         audio_contents_html +


### PR DESCRIPTION
Fixes #68. For the page event, I would just call it `audio_test`, but I think this may be expanded. For example, it may also be used to test the 'escape' button, etc.

Test performed:
- [ ] Open test interview.
- [ ] See correct custom audio element
- [ ] Test behavior of audio element
- [ ] Tap 'Help'
- [ ] Test behavior of audio element