### PR TITLE
Fix #77, audio not resetting when done

### DIFF
--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -53,13 +53,16 @@ al_js.audio_minimal_controls = function( audio_node, id ) {
     $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
   });
   
-  $(id_s + '.stop').first().on( 'click', function() {  // restart & stop
+  var stop_and_reset = function () {
     audio_node.pause();
     audio_node.currentTime = 0;
     $(id_s + '.restart').first().attr('aria-hidden', 'false').show();
     $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
     $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
-  });
+  }
+  
+  $(id_s + '.stop').first().on( 'click', stop_and_reset );
+  $(audio_node).on( 'ended', stop_and_reset );
   
 };  // Ends al_js.audio_minimal_controls()
 


### PR DESCRIPTION
Fixes #77.

Test performed:
- [ ] Start test interview
- [ ] Press 'play', icon changes to 'pause'
- [ ] Wait till audio is done
- [ ] Icon changes to 'restart'
- [ ] Tapping the icon starts the reading from the beginning

I think 'restart' is better than showing 'play' again because it gives folks some indication that this is a different situation than when they just paused the audio. It's the same reason 'stop' makes the 'restart' icon appear.