### PR TITLE
Cleanup some awkward language with people lists - fix #64

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -418,37 +418,71 @@ comment: |
   That will be very context-specific.
 question: |
   % if al_form_type in ['starts_case','existing_case','appeal']:
-  How many children are involved in this case?
+  Are any children involved in this case?
   % else:
-  How many children are involved in this matter?
+  Are any children involved in this matter?
   % endif  
 fields:
-  - no label: children.target_number
+  - no label: children.there_are_any
+    datatype: yesnoradio
+  - How many?: children.target_number
     datatype: integer
+    show if: children.there_are_any
+validation code: |
+  if not children.there_are_any:
+    children.target_number = 0
 ---
+# Customize this question if you know whose children they are in your interview!
+# this is just a very generic way to ask.
+id: children names without birthdate
+sets:
+  - children[0].name.first
+  - children[0].name.last
+question: |
+  % if hasattr(children, 'ask_number') and children.ask_number and children.target_number == 1:
+  Child's name
+  % else:
+  Name of first child
+  % endif
+fields:
+  - code: |
+      children[0].name_fields()
+---
+# Customize this question if you know whose children they are in your interview!
+# this is just a very generic way to ask.
 id: children names without birthdate
 sets:
   - children[i].name.first
   - children[i].name.last
 question: |
-  Name of the ${ ordinal(i) } child
+  Name of ${ ordinal(i) } child
 fields:
   - code: |
       children[i].name_fields()
 ---
 id: how many witnesses
 question: |
-  How many witnesses are there?
+  Do you have any witnesses?
 fields:
+  - no label: witnesses.there_are_any
+    datatype: yesnoradio
   - no label: witnesses.target_number
     datatype: integer
+    show if: witnesses.there_are_any
+validation code: |
+  if not witnesses.there_are_any:
+    witnesses.target_number = 0
 ---
 sets:
   - witnesses[i].name.first
   - witnesses[i].name.last
 id: names of witnesses
 question: |
+  % if hasattr(witnesses, 'ask_number') and witnesses.ask_number and witnesses.target_number == 1:
+  Witness name
+  % else:
   Name of the ${ ordinal(i) } witness
+  % endif
 fields:
   - code: |
       witnesses[i].name_fields()
@@ -456,8 +490,23 @@ fields:
 generic object: ALPeopleList
 id: any other people
 question: |
-  Do you have any other ${ x.object_name() } to tell us about?
+  Do you have any other ${ noun_plural(x.object_name()) } to tell us about?
 yesno: x.there_is_another  
+---
+id: name of the first person
+sets:
+  - x[0].name.first
+  - x[0].name.last
+generic object: ALPeopleList
+question: |
+  % if hasattr(x, 'ask_number') and x.ask_number and x.target_number == 1:
+  Name of ${ noun_plural(x.object_name(),1) }
+  % else:
+  Name of your ${ ordinal(i) } ${ noun_plural(x.object_name(),1) }
+  % endif
+fields:
+  - code: |
+      x[i].name_fields()
 ---
 id: names of people
 sets:
@@ -465,7 +514,7 @@ sets:
   - x[i].name.last
 generic object: ALPeopleList
 question: |
-  Name of your ${ ordinal(i) } ${x.object_name()}
+  Name of the ${ ordinal(i) } ${ noun_plural(x.object_name(), 1) }
 fields:
   - code: |
       x[i].name_fields()
@@ -495,6 +544,7 @@ fields:
       other_parties[i].name_fields(person_or_business='unsure')
 ---
 # TODO: consider removing default state
+# BUT: could be helpful to model how to set a default state
 sets:
   - x.address.address
   - x.address.city


### PR DESCRIPTION
fix #64 

Made the PeopleList questions for children, witnesses, and generic people more responsive.

Don't ask "How many" right away...first ask if there are any.
If the list uses target_number and the target is 1, don't ask about the "first", "second", etc. Instead ask for "name of the x"

Use noun_plural with x.object_name() so that nouns are currectly pluralized/made singular in the right contexts. "Do you have any other witnesses", "name of the first witness" etc.. These will work in English and Spanish but not other languages, so we may not be able to use these questions in all interviews. Still a useful default for English and Spanish interviews.