### PR TITLE
Fix #120, no email sent when editable checkbox not present

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -82,7 +82,7 @@ subquestion: |
   #### Your files are ready to download below
   ${ al_user_bundle.download_list_html() }
   
-  ${ al_user_bundle.send_button_html(show_editable_checkbox=True) }
+  ${ al_user_bundle.send_button_html(show_editable_checkbox=False) }
 ---
 question: |
   Try a big text field

--- a/docassemble/AssemblyLine/data/static/aldocument.js
+++ b/docassemble/AssemblyLine/data/static/aldocument.js
@@ -4,7 +4,13 @@
  * email an ALDocumentBundle
  */
 function aldocument_send_action(event_name, wants_editable_id, email_id) {
-  editable = $('#' + wants_editable_id)[0].checked
-  email = $('#' + email_id)[0].value
-  da_action_perform(event_name, {editable: editable, email: email})
+  var editable = false;
+  
+  var editable_choice_node = $('#' + wants_editable_id);
+  if ( editable_choice_node && editable_choice_node[0] ) {
+    editable = $('#' + wants_editable_id)[0].checked;
+  }
+  
+  var email = $('#' + email_id)[0].value;
+  da_action_perform(event_name, {editable: editable, email: email});
 };


### PR DESCRIPTION
Fixes #120. This uses the first option suggested in #120.

> For now I went with option 1, though I'm not convinced it's the best option. It's just faster for me at this time in my life - for option 2 I need to look into what other attributes need to be set to disable the checkbox appropriately and accessibly.