### PR TITLE
Close #82, pause audio when buttons or links are pressed. Adds try/ca…

### DIFF
--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -6,7 +6,7 @@ $(document).on('daPageLoad', function() {
     var $audio_nodes = $('.daaudio-control');
     var id_count = 1;
     for ( var audio_node of $audio_nodes ) {
-      al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count, $audio_nodes );
+      al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
       id_count++;
     }
   } catch ( error ) { console.log( 'AL audio intantiation error:', error ) }

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -1,13 +1,16 @@
-$(document).on('daPageLoad', function() {
-  var $audio_nodes = $('.daaudio-control');
-  var id_count = 1;
-  for ( var audio_node of $audio_nodes ) {
-    al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
-    id_count++;
-  }
-});
+// Do not overwrite already created al_js object. This may be relevant as our js gets built out.
+if ( !al_js ) { var al_js = {}; }
 
-var al_js = {};
+$(document).on('daPageLoad', function() {
+  try {
+    var $audio_nodes = $('.daaudio-control');
+    var id_count = 1;
+    for ( var audio_node of $audio_nodes ) {
+      al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count, $audio_nodes );
+      id_count++;
+    }
+  } catch ( error ) { console.log( 'AL audio intantiation error:', error ) }
+});
 
 // We are not providing a way to rewind or scan through the audio.
 // TODO: Show user the audio still needs to load:
@@ -15,60 +18,81 @@ var al_js = {};
 // - https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play
 al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
   /* Create the custom controls for this specific audio element
-  * and give the new controls container the requested `id` tag. */
+  * and give the new controls container the requested `id` tag.
+  * Return functions to control audio playback for this node. */
+  var controls = {
+    play: function () {}, pause: function () {},
+    restart: function () {}, stop_and_reset: function () {},
+  };
+  
   if (!audio_node) {
     // Some screens, like the signature screen, don't have screen readers.
-    return;
+    return controls;
   }
   
   // Hide the normal controls and show the new controls
   audio_node.removeAttribute('controls');
   audio_node.style.display = 'none';
   var $audio_container = $($(audio_node).closest('.daaudiovideo-control'));
-  $audio_container.addClass( 'al_custom_media_controls' );
+  $audio_container.addClass( 'al_custom_media_controls al_audio_controls' );
   $('<div id="' + id + '" class="btn-group">' +
         audio_contents_html +
   '</div>').appendTo( $audio_container );
   
   // Start of all the right selectors
   var id_s = '#' + id + ' ';
-  // 'play' position should be play OR pause OR restart
+  // There are currently two icons displaying at the same time.
+  // The first is one of play OR pause OR restart. The last is always the stop icon.
   $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
   $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
   
-  var is_loading = true
-  $(id_s + '.play').first().on( 'click', function() {  // pause & stop
-    audio_node.play().then(function(){ is_loading = false });
-    $(id_s + '.pause').first().attr('aria-hidden', 'false').show();
-    $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
-    $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
-  });
-  
-  $(id_s + '.restart').first().on( 'click', function() {  // pause & stop
-    audio_node.play();
-    $(id_s + '.pause').first().attr('aria-hidden', 'false').show();
-    $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
-    $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
-  });
-  
-  $(id_s + '.pause').first().on( 'click', function() {  // play & stop
-    audio_node.pause()
-    $(id_s + '.play').first().attr('aria-hidden', 'false').show();
-    $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
-    $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
-  });
-  
-  var stop_and_reset = function () {
-    audio_node.pause();
-    audio_node.currentTime = 0;
-    $(id_s + '.restart').first().attr('aria-hidden', 'false').show();
-    $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
-    $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
+  var is_loading = true;  // TODO: Add indication that audio is loading and remove var
+  controls.play = function () {
+    try {
+      audio_node.play().then(function(){ is_loading = false; });
+      // pause & stop buttons should be visible
+      $(id_s + '.pause').first().attr('aria-hidden', 'false').show();
+      $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
+      $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
+    } catch ( error ) { console.log( 'AL audio play error:', error ) }
+  }
+  controls.restart = controls.play;
+  controls.pause = function() {
+    try {
+      audio_node.pause()
+      // play & stop buttons should be visible
+      $(id_s + '.play').first().attr('aria-hidden', 'false').show();
+      $(id_s + '.restart').first().attr('aria-hidden', 'true').hide();
+      $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
+    } catch ( error ) { console.log( 'AL audio pause error:', error ) }
+  }
+  controls.stop_and_reset = function () {
+    try {
+      audio_node.pause();
+      audio_node.currentTime = 0;
+      $(id_s + '.restart').first().attr('aria-hidden', 'false').show();
+      $(id_s + '.play').first().attr('aria-hidden', 'true').hide();
+      $(id_s + '.pause').first().attr('aria-hidden', 'true').hide();
+    } catch ( error ) { console.log( 'AL audio stop error:', error ) }
   }
   
-  $(id_s + '.stop').first().on( 'click', stop_and_reset );
-  $(audio_node).on( 'ended', stop_and_reset );
+  $(id_s + '.play').first().on( 'click tap', controls.play );
+  $(id_s + '.restart').first().on( 'click tap', controls.restart );
+  $(id_s + '.pause').first().on( 'click tap', controls.pause );
+  $(id_s + '.stop').first().on( 'click tap', controls.stop_and_reset );
+  $(audio_node).on( 'ended', controls.stop_and_reset );
   
+  // When any button or link is pressed
+  $('button, a').on( 'click tap', function ( event ) {
+    try {
+      // If the button or link is not in an audio control itself, pause the playback
+      var audio_parent = $(event.target).closest( '.al_audio_controls' );
+      if ( audio_parent.length === 0 ) { controls.pause(); }
+    } catch ( error ) { console.log( 'AL audio button pause error:', error ) }
+  });
+  
+  // Returns ability to control the playback of these nodes externally
+  return controls;
 };  // Ends al_js.audio_minimal_controls()
 
 // The DOM structure for every AL audio element with custom controls

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.0.7'],
+      install_requires=['docassemble.ALToolbox>=0.0.11'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
…tch as that's now our practice. Refactoring seemed needed for one possible solution, but I can change most of it back since this went in another direction.

Also adds listening for the `tap` event. I thought jQuery covered taps with `click`, but I checked up on that and it doesn't seem clear that jQuery handles that.

Sorry I did so many things at once. If it's too much I can separate out the changes.

Closes #82.