### PR TITLE
Bumpversion reliant

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.18
+current_version = 2.0.19
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<test>\d+))?
 serialize = 
 	{major}.{minor}.{patch}.{test}
@@ -8,7 +8,7 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
-search = {current_version}'
-replace = {new_version}'
+search = '{current_version}'
+replace = '{new_version}'
 
 [bumpversion:file:docassemble/AssemblyLine/__init__.py]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# 2.0.18
+# v2.0.18
 
 The first tagged release of Assembly Line
 
-# 2.0.0
+# v2.0.0
 
 The first version of Assembly Line. Started at version 2, since this is a continuation of [MAVirtualCourt](https://github.com/SuffolkLITLab/MAVirtualCourt).

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -18,6 +18,26 @@
 # * major is a breaking change, either internally or externally
 # For more info about semantic versioning (aka semver), see https://semver.org/
 
+real_run=true
+
+while [ -n "$1" ]; do
+  case "$1" in
+  -n | --dry-run)
+    real_run=false
+    shift
+    ;;
+  --)
+    shift # double dash makes for parameters
+    break
+    ;;
+  *)
+    break # found not an option: just continue
+    ;;
+  esac
+done
+
+
+# Set after, because we can't iterate through things without getting to the end
 set -euo pipefail
 
 ### Make sure you have all the necessary commands installed and env vars set
@@ -27,7 +47,7 @@ twine --help 2>&1 > /dev/null
 test ! -z $TWINE_USERNAME
 test ! -z $TWINE_PASSWORD
 test ! -z $TEAMS_BUMP_WEBHOOK
-test ! -z $1
+test ! -z $1 || echo "You need to pass in test, patch, minor, or major" || exit 1
 git fetch --all
 
 # TODO(brycew): should we restrict this to only work on default branches?
@@ -40,29 +60,31 @@ then
 fi
 
 ### Makes git commit and tag
+if $real_run
+then
+  new_version=$(bumpversion --list --config-file .bumpversion.cfg "$1" | grep new_version | cut -d= -f 2)
+else
+  new_version=$(bumpversion --list --dry-run --verbose --config-file .bumpversion.cfg "$1" | grep new_version | cut -d= -f 2)
+fi
+
 if [ "$1" = "minor" ] || [ "$1" = "major" ] 
 then
-  echo What has changed about this "$1" version?
-  read -r release_update
-  new_version=$(bumpversion --list --config-file .bumpversion.cfg "$1" | grep new_version | cut -d= -f 2)
-  echo -e "# Version v$new_version\n\n$release_update\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
-  git add CHANGELOG.md && git commit --amend -C HEAD
-else
-  new_version=$(bumpversion --list --config-file .bumpversion.cfg "$1" | grep new_version | cut -d= -f 2)
+  echo What has changed about this "$1" version? Press ctrl-d to finish, ctrl-c to cancel
+  release_update=$(</dev/stdin)
+  if $real_run
+  then
+    echo -e "# Version v$new_version\n\n$release_update\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+    git add CHANGELOG.md && git commit --amend -C HEAD
+  fi
 fi
-git push
-git push --tags
 
 ### Make and update Pypi package
 rm -rf build dist ./*.egg-info
 python3 setup.py sdist
-# Needs TWINE_USERNAME and TWINE_PASSWORD
-twine upload --repository 'pypi' dist/* --non-interactive
-rm -rf build dist ./*.egg-info
 
 ### Auto get project and repo name to put in Teams message
-remote_url=$(git remote -v | cut -f2 | cut -d ' ' -f1)
-repo_name=$(basename -s "$remote_url")
+remote_url=$(git remote get-url --push origin ) 
+repo_name=$(basename -s ".git" "$remote_url")
 org_name=$(basename "$(dirname "$remote_url")")
 if [[ "$org_name" = *@* ]]; then
   # Likely an SSH URL. Split at the ':'
@@ -121,6 +143,35 @@ sed -e "s/{{version}}/$new_version/g; s/{{project_name}}/$project_name/g; s/{{or
 }
 EOF
 
-curl -H "Content-Type:application/json" -d "@/tmp/teams_msg_to_send.json" "$TEAMS_BUMP_WEBHOOK"
+if $real_run
+then
+  ## Push and save stuff at the very end of the script
+  git push
+  git push --tags
+  # Only push to pypi and announce on non-test bumps
+  if [ ! "$1" = "test" ]
+  then
+    # Needs TWINE_USERNAME and TWINE_PASSWORD
+    twine upload --repository 'pypi' dist/* --non-interactive
+    curl -H "Content-Type:application/json" -d "@/tmp/teams_msg_to_send.json" "$TEAMS_BUMP_WEBHOOK"
+  fi
+  rm -rf build dist ./*.egg-info
+
+else
+  if [ "$1" = "minor" ] || [ "$1" = "major" ] 
+  then
+    echo "Changelog would be:"
+    echo -e "# v$new_version\n\n$release_update\n\n$(cat CHANGELOG.md)"
+  fi
+
+  if [ ! "$1" = "test" ]
+  then
+    echo "Would push to Pypi"
+    echo "Teams message JSON is: $(cat /tmp/teams_msg_to_send.json)"
+  else
+    echo "Would NOT push to Pypi or announce to Teams"
+  fi
+
+fi
 rm "/tmp/teams_msg_to_send.json"
 

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -18,8 +18,15 @@
 # * major is a breaking change, either internally or externally
 # For more info about semantic versioning (aka semver), see https://semver.org/
 
-set -eu
+set -euo pipefail
 
+### Make sure you have all the necessary commands installed and env vars set
+git --help 2>&1 > /dev/null
+bumpversion --help 2>&1 > /dev/null
+twine --help 2>&1 > /dev/null
+test ! -z $TWINE_USERNAME
+test ! -z $TWINE_PASSWORD
+test ! -z $TEAMS_BUMP_WEBHOOK
 
 ### Makes git commit and tag
 if [ "$1" = "minor" ] || [ "$1" = "major" ] 


### PR DESCRIPTION
Adds help text, dry-run capabilities, and lots more error checking to make sure things don't break, including:
* making sure all variables and required commands are defined
* fetching from remote and not allowing you to bump if you are behind the remote's version of your current branch.
* multiline changelog messages

 If unexpected things happen, it can't rollback to how it was before running, but there are at least more tools to reduce that possibility.

Also, it won't make announcements to Teams on patches, just on minor or major releases. 

Fixes #122. 