### PR TITLE
Close #31, add zip row to table. Tweak and improve css.

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Dict, List, Union
 from docassemble.base.functions import DANav
-from docassemble.base.util import log, word, DADict, DAList, DAObject, DAFile, DAFileCollection, DAFileList, defined, value, pdf_concatenate, DAOrderedDict, action_button_html, include_docx_template, user_logged_in, user_info, action_argument, send_email, docx_concatenate, reconsider, get_config, space_to_underscore, LatitudeLongitude
+from docassemble.base.util import log, word, DADict, DAList, DAObject, DAFile, DAFileCollection, DAFileList, defined, value, pdf_concatenate, zip_file, DAOrderedDict, action_button_html, include_docx_template, user_logged_in, user_info, action_argument, send_email, docx_concatenate, reconsider, get_config, space_to_underscore, LatitudeLongitude
 
 __all__ = ['ALAddendumField', 'ALAddendumFieldDict', 'ALDocumentBundle', 'ALDocument', 'ALDocumentBundleDict','safeattr','label','key']
 
@@ -43,24 +43,33 @@ def html_safe_str(the_string: str) -> str:
   """
   return re.sub( r'[^A-Za-z0-9]+', '_', the_string )
 
-def table_row( title, view_file:DAFile, download_file:DAFile=None, view_icon:str="eye", download_icon:str="download") -> str:
+#def table_row( title, view_file:DAFile, download_file:DAFile=None, view_icon:str="eye", download_icon:str="download") -> str:
+def table_row( title:str, buttons:list = []) -> str:
   """
-  Uses the provided DAFile/DAFileCollection objects to build the row of a table in HTML format that allows
-  you to both view and download an ALDocument.
+  Uses the provided title and buttons to return the row of an AL document-
+  styled table in HTML format.
   """
-  if not download_file:
-    download_file = view_file
   html = '\n\t<tr>'
   # html += '\n\t\t<td><i class="fas fa-file"></i>&nbsp;&nbsp;</td>'
   # TODO: Need to replace with proper CSS
-  html += '\n\t\t<td><strong>' + title + '</strong></td>'
-  html += '\n\t\t<td>'
-  html += action_button_html( view_file.url_for(), label=word("View"), size="md", icon=view_icon, color="secondary" )
-  html += action_button_html( download_file.url_for(attachment=True), size="md", label=word("Download"), icon=download_icon, color="primary" )
+  html += '\n\t\t<td class="al_doc_title"><strong>' + title + '</strong></td>'
+  html += '\n\t\t<td class="al_buttons">'
+  for button in buttons:
+    html += button
   html += '</td>'
   html += '\n\t</tr>'
 
   return html
+
+def view_button( file:DAFile, label:str = "View", icon:str = "eye" ) -> str:
+  return action_button_html( file.url_for(attachment=False), label=word(label), icon=icon, color="secondary", size="md", classname='al_view' )
+
+def download_button( file:DAFile, label:str = "Download", icon:str = "download" ) -> str:
+  return action_button_html( file.url_for(attachment=True), label=word(label), icon=icon, color="primary", size="md", classname='al_download' )
+
+def zip_button( file:DAFile, label:str = "Download zip", icon:str = "file-archive" ) -> str:
+  return action_button_html( file.url_for(attachment=False), label=word(label), icon=icon, color="primary", size="md", classname='al_zip' )
+
 
 class ALAddendumField(DAObject):
   """
@@ -646,6 +655,32 @@ class ALDocumentBundle(DAList):
     setattr(self.cache, safe_key, pdf)
     return pdf
 
+  def as_zip(self, key:str = 'final', refresh:bool = True, title:str = '') -> DAFile:
+    '''Returns a zip file containing the whole bundle'''
+    log_if_debug(f'Calling as_zip() for { str( self.title )}')
+
+    zip_key = f'{ space_to_underscore( key )}_zip'
+
+    # Speed up performance if can (docs say `zip_file` works like `pdf_concatenate`)
+    if hasattr(self.cache, zip_key):
+      log_if_debug(f'Returning cached version of { str( self.title )} zip')
+      return getattr(self.cache,  zip_key)
+
+    # strip out a possible '.pdf' ending then add '.zip'
+    zipname = self.filename
+    if zipname.endswith( ".pdf" ):
+      zipname = zipname[:-len( ".pdf" )]
+    zip = zip_file( self.as_pdf( key=key, refresh=refresh ), filename=f'{ zipname }.zip' )
+    if title == '':
+      zip.title = self.title
+    else:
+      zip.title = title
+    
+    setattr(self.cache, zip_key, zip)
+    log_if_debug(f'Stored {self.title} zip at {self.instanceName}.cache.{zip_key}')
+    
+    return zip
+  
   def preview(self, refresh:bool=True) -> DAFile:
     return self.as_pdf(key='preview', refresh=refresh)
 
@@ -701,7 +736,7 @@ class ALDocumentBundle(DAList):
       editable.append(doc.docx if hasattr(doc, 'docx') else doc.pdf)
     return editable
 
-  def download_list_html(self, key:str='final', format:str='pdf', view:bool=True, refresh:bool=True) -> str:
+  def download_list_html(self, key:str='final', format:str='pdf', view:bool=True, refresh:bool=True, include_zip:bool = True) -> str:
     """
     Returns string of a table to display a list
     of pdfs with 'view' and 'download' buttons.
@@ -719,11 +754,18 @@ class ALDocumentBundle(DAList):
 
     for doc in self:
       if doc.enabled:
-        the_file = doc.as_pdf() # should trigger cache
         if format=='docx':
-          html += table_row(doc.title, the_file, download_file=doc.as_docx(key=key))
+          doc_dwnld_button = download_button( doc.as_docx(key=key) )
         else:
-          html += table_row(doc.title, the_file, download_file=the_file)
+          doc_dwnld_button = download_button( doc.as_pdf(key=key) )
+        buttons = [ view_button(doc.as_pdf()), doc_dwnld_button ]
+        html += table_row( doc.title, buttons )
+    
+    # Add a zip file row if there's more than one doc
+    if len(self) > 1:
+      zip = self.as_zip()
+      html += table_row( zip.title, zip_button( zip ))
+      
     html += '\n</table>'
 
     # Discuss: Do we want a table with the ability to have a merged pdf row?

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -762,7 +762,7 @@ class ALDocumentBundle(DAList):
         html += table_row( doc.title, buttons )
     
     # Add a zip file row if there's more than one doc
-    if len(self) > 1:
+    if len(self) > 1 and include_zip:
       zip = self.as_zip()
       html += table_row( zip.title, zip_button( zip ))
       

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -44,17 +44,17 @@ def html_safe_str(the_string: str) -> str:
   return re.sub( r'[^A-Za-z0-9]+', '_', the_string )
 
 #def table_row( title, view_file:DAFile, download_file:DAFile=None, view_icon:str="eye", download_icon:str="download") -> str:
-def table_row( title:str, buttons:list = []) -> str:
+def table_row( title:str, button_htmls:List[str] = []) -> str:
   """
-  Uses the provided title and buttons to return the row of an AL document-
-  styled table in HTML format.
+  Uses the provided title and list of button html strings to
+  return the row of an AL document-styled table in HTML format.
   """
   html = '\n\t<tr>'
   # html += '\n\t\t<td><i class="fas fa-file"></i>&nbsp;&nbsp;</td>'
   # TODO: Need to replace with proper CSS
   html += '\n\t\t<td class="al_doc_title"><strong>' + title + '</strong></td>'
   html += '\n\t\t<td class="al_buttons">'
-  for button in buttons:
+  for button in button_htmls:
     html += button
   html += '</td>'
   html += '\n\t</tr>'

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -670,7 +670,8 @@ class ALDocumentBundle(DAList):
     zipname = self.filename
     if zipname.endswith( ".pdf" ):
       zipname = zipname[:-len( ".pdf" )]
-    zip = zip_file( self.as_pdf( key=key, refresh=refresh ), filename=f'{ zipname }.zip' )
+    docs = [doc.as_pdf(key=key, refresh=refresh) for doc in self.enabled_documents()]
+    zip = zip_file( docs, filename=f'{ zipname }.zip' )
     if title == '':
       zip.title = self.title
     else:

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -93,9 +93,26 @@ question: |
   Hello, ${ users }
 subquestion: |
   #### Your files are ready to download below
+  
+  ---
+  
+  **Standard Table**
+  
   ${ al_user_bundle.download_list_html() }
   
   ${ al_user_bundle.send_button_html(show_editable_checkbox=False) }
+  
+  ---
+  
+  **No zip**
+  
+  ${ al_user_bundle.download_list_html( include_zip=False ) }
+  
+  ---
+  
+  **Single file**
+  
+  ${ al_single_doc_bundle.download_list_html() }
 ---
 question: |
   Try a big text field
@@ -127,6 +144,7 @@ objects:
 objects:
   - al_user_bundle: ALDocumentBundle.using(elements=[dummy_template, word_template], filename="user_bundle.pdf", title="All forms to download for your records")
   - al_court_bundle: ALDocumentBundle.using(elements=[dummy_template, word_template], filename='court_bundle.pdf', title='All forms to send to the court')
+  - al_single_doc_bundle: ALDocumentBundle.using(elements=[dummy_template], filename="one_file_bundle.pdf", title="One file")
 ---
 code: |
   # This is used in the subject of the email template when someone

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -47,11 +47,6 @@ td.text-left:first-child {
 
 /* BW hotfixes 2/9/2021 */
 /* LY 5/2021 Add media requirement to skip it for horizontal alignment mobile mode */
-@media only screen and (min-width: 700px) {
-  .da-subquestion .btn {
-    min-width: 120px;
-  }
-} 
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;
 }
@@ -64,20 +59,21 @@ td.text-left:first-child {
   margin: 0.5rem 0;
 }
 
-#al_user_bundle a.btn-darevisit {
-  margin-bottom: 0;
-}
 /* LY 5/2021 Align buttons horizontally */
-#al_user_bundle a.btn {
+.al_table .al_buttons .btn {
   position: relative;
-  margin: 0.1rem;
-  /*float: right;
-  margin: 0.5rem 0; */
+  margin: 0;
+  margin-bottom: 0.1rem;
+  /* Avoid icons being on their own lines */
+  white-space: nowrap;
 }
 
-#al_user_bundle a.btn:nth-child(1) {
-  margin-bottom: 0;
-  margin-left:0.5rem;
+/* On wide screens, let titles wrap, but let buttons stay horizontal */
+/* On small screens, wrap buttons and let titles have the room they need */
+@media only screen and (min-width: 450px) {
+  .al_table .al_buttons {
+    white-space: nowrap;
+  }
 }
 
 #al_user_bundle td div {


### PR DESCRIPTION
Closes #31 if accepted. It's one way to do it. I abstracted a little differently, so let me know if you want to chat about it.

Now that there was longer text to see in the title cell, the buttons arrangement wasn't looking as good, so I tweaked that css a bit.

[Also ran into a bit of weirdness where using `.enabled_documents()` triggered da to look for `al_user_bundle.there_is_another` or something like that. Not sure if it's a bug or if we're just not supposed to use that method.]