### PR TITLE
Refresh `enabled` status of ALDocument objects once per page load

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -466,7 +466,7 @@ class ALDocument(DADict):
           Here is some content
 
           % if i == 'final':
-          users[0].signature
+          ${ users[0].signature }
           % elif i == 'preview':
           [ Your signature here ]
           % endif

--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -3,10 +3,10 @@ include:
   - al_package.yml
 ---
 code: |
-  AL_DEFAULT_COUNTRY = "CA"
+  AL_DEFAULT_COUNTRY = "US"
 ---
 code: |
-  AL_DEFAULT_STATE = "ON"
+  AL_DEFAULT_STATE = "MA"
 ---
 metadata:
   title: |
@@ -31,9 +31,6 @@ objects:
 ---
 mandatory: True
 code: |
-  # big_text_field
-  # debug_safe_value
-  
   al_intro_screen
   test_label_functions
   feature_tests_1
@@ -50,9 +47,6 @@ code: |
   children.gather()
   preview_screen
   basic_questions_signature_flow
-  dummy_template.enabled = False
-  one_enabled_doc_test
-  dummy_template.enabled = True
   many_bundles_test
   end
 ---
@@ -80,7 +74,7 @@ code: |
 id: test behavior of some features
 continue button field: feature_tests_1
 question: |
-  Features test 1
+  Test custom audio element behavior on help button
 help: |
   Show help screen
 ---
@@ -92,11 +86,11 @@ subquestion: |
   Take a look at the files below. When you are ready, click "next"
   to continue and add your signature.
     
-  ${ dummy_template.as_pdf(key='preview') }
-  
   ${ al_user_bundle.as_pdf(key='preview') }
-  
-  [Edit](${url_action('users[0].name.first')})
+
+  [Edit mako_template status](${ url_action('mako_template_enabled') })
+
+  [Edit user's name](${url_action('users[0].name.first')})
 ---
 need: al_user_bundle
 id: test end screen
@@ -128,14 +122,6 @@ subquestion: |
   
   ${ al_single_doc_bundle.download_list_html() }
 ---
-need: al_user_bundle
-id: one enabled doc
-continue button field: one_enabled_doc_test
-question: |
-  One enabled file
-subquestion: |
-  ${ al_user_bundle.download_list_html() }
----
 question: |
   Try a big text field
 subquestion: |
@@ -144,29 +130,26 @@ fields:
   - Write something: big_text_field
     datatype: area
 ---
-continue button field: debug_safe_value
-question: |
-  Test
-subquestion: |
-  #### Safe
-  
-  > ${ dummy_template.safe_value('big_text_field', preserve_newlines=True) }
-  
-  #### Overflow
-  
-  > ${ dummy_template.overflow_value('big_text_field', preserve_newlines=True) }
-  
----
 objects:
-  # Dummy template will use the generic addendum
-  - dummy_template: ALDocument.using(title="Dummy template", filename="dummy_template", has_addendum=True, enabled=True, default_overflow_message=" [See addendum]")
+  # Mako template will use the generic addendum
+  - mako_template: ALDocument.using(title="Mako template", filename="mako_template", has_addendum=True, default_overflow_message=" [See addendum]")
   # `has_addendum` should be taken care of by a default attr
   - word_template: ALDocument.using(title="Word Template", filename="word_template", enabled=True)
 ---
+id: Mako template
+question: |
+  Enable Mako template?
+yesno: mako_template_enabled
+---
+code: |
+  # You must use an intermediate value to set the enabled status, because it is not 
+  # cached longer than one page load. You do not need to explicitly reconsider it.
+  mako_template.enabled = mako_template_enabled 
+---
 objects:
-  - al_user_bundle: ALDocumentBundle.using(elements=[dummy_template, word_template, static_test], filename="user_bundle.pdf", title="All forms to download for your records")
-  - al_court_bundle: ALDocumentBundle.using(elements=[dummy_template, word_template], filename='court_bundle.pdf', title='All forms to send to the court')
-  - al_single_doc_bundle: ALDocumentBundle.using(elements=[dummy_template], filename="one_file_bundle.pdf", title="One file")
+  - al_user_bundle: ALDocumentBundle.using(elements=[mako_template, word_template, static_template], filename="user_bundle.pdf", title="All forms to download for your records")
+  - al_court_bundle: ALDocumentBundle.using(elements=[mako_template, word_template], filename='court_bundle.pdf', title='All forms to send to the court')
+  - al_single_doc_bundle: ALDocumentBundle.using(elements=[mako_template], filename="one_file_bundle.pdf", title="One file")
 ---
 code: |
   # This is used in the subject of the email template when someone
@@ -174,13 +157,15 @@ code: |
   metadata_title = "AssemblyLine Question Test"
 ---
 code: |
-  dummy_template.overflow_fields['big_text_field'].overflow_trigger = 200
-  dummy_template.overflow_fields['children'].overflow_trigger = 2
-  dummy_template.overflow_fields.gathered = True
+  mako_template.overflow_fields['big_text_field'].overflow_trigger = 200
+  mako_template.overflow_fields['children'].overflow_trigger = 2
+  mako_template.overflow_fields.gathered = True
 ---
 attachment:
-  variable name: dummy_template[i]
+  variable name: mako_template[i]
   content: |
+    # Mako template
+    
     You live at ${ users[0].address.on_one_line() }
     
     Your phone number(s) are: ${ users[0].phone_numbers() }.
@@ -191,14 +176,14 @@ attachment:
 
     Here is the safe value of "big_text_field":
     
-    > ${ dummy_template.safe_value('big_text_field') }
+    > ${ mako_template.safe_value('big_text_field') }
 
     % if len(children):
     Here is some information about your first 2 children:
 
     Name | Age
     -----|----
-    % for child in dummy_template.safe_value('children'):
+    % for child in mako_template.safe_value('children'):
     ${ child } | ${ child.age_in_years() }
     % endfor
     % endif
@@ -216,7 +201,7 @@ attachment:
   filename: sample_word_template.docx
 ---
 objects:
-  - static_test: ALStaticDocument.using(title="Test Static Document", filename="lt1-pullout-10-getting-organized.pdf", enabled=True)
+  - static_template: ALStaticDocument.using(title="Test Static Document", filename="lt1-pullout-10-getting-organized.pdf", enabled=True)
 ---
 id: end if we need it
 event: end


### PR DESCRIPTION
Fixes #211 

This PR adds logic to store the enabled status of an ALDocument on the .cache attribute, which is reconsidered fresh on page loads (only when the attribute is needed on that page). That allows someone to dynamically change whether a document is included in the final download bundle or not by making changes on a review screen.

Side effect: you should not directly ask the user a question that sets the value of `my_doc.enabled`: instead, you can use an intermediate variable and set the value in a code block that references the intermediate variable. The code block will not be stale.

I also took the chance to do some small refactors in the al_question_test.yml file as I had to run it many times. I renamed some variables for clarity and removed some unused sections.