### PR TITLE
Fix #249, key error when using `refresh=False` arg

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -568,7 +568,7 @@ class ALDocument(DADict):
     if refresh:
       main_doc = self.getitem_fresh(key)
     else:
-      main_doc = self.elements[key]
+      main_doc = self[key]
 
     if isinstance(main_doc, DAFileCollection):
       main_doc = main_doc.pdf


### PR DESCRIPTION
Close #249. Use `.as_pdf( refresh=False )` with a document. See no errors.