### PR TITLE
Close #252, alcourts tests MVP

### DIFF
--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -1,7 +1,7 @@
 #####################################
 # Package for a very simple / MVP list of courts that is mostly signature compatible w/ MACourts for now
 
-from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, DAStaticFile, markdown_to_html, prevent_dependency_satisfaction, DAObject, DAList, DADict, log, space_to_underscore, defined
+from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, DAStaticFile, markdown_to_html, prevent_dependency_satisfaction, DAObject, DAList, DADict, log, space_to_underscore
 from docassemble.base.legal import Court
 import pandas as pd
 import os
@@ -45,7 +45,7 @@ class ALCourt(Court):
       list.
       """
       # Avoid forcing the interview to define the court's address
-      if defined( self.attr_name('address.city') ):
+      if hasattr( self, 'address' ) and hasattr( self.address, 'city' ):
         if self.address.city in str(self.name):
           return str(self.name)
         else:
@@ -58,19 +58,7 @@ class ALCourt(Court):
       Returns a markdown formatted string with the name and address of the court.
       More concise version without description; suitable for a responsive case.
       """
-      label = f'**{ self.short_label() }**'
-      
-      # Handle inconsistent user-defined court data
-      # If address has not been left blank
-      if (( defined( self.attr_name('address.address') )
-          or defined( self.attr_name('address.city') ))
-          and self.address.on_one_line() != ', ' ):
-        # Handle no street address first line
-        street_normalized = re.sub( r'^, ', '', self.address.on_one_line() )
-        # Handle missing city name
-        address = re.sub( r', ,', ',', street_normalized )
-        label += f'[BR]{ address }'
-      return label
+      return f'**{ self.short_label() }**[BR]{ self.address.on_one_line() }'
     
     def short_description(self)->str:
       """
@@ -78,7 +66,10 @@ class ALCourt(Court):
       the description of the court, for inclusion in the results page with radio
       buttons.
       """
-      return f'{ self.short_label_and_address() }[BR]{ self.description }'
+      all_info = f'**{ self.short_label() }**'
+      if hasattr( self, 'address' ):
+        all_info = f'{ all_info }[BR]{ self.address.on_one_line() }'
+      return f'{ all_info }[BR]{ self.description }'
   
     def from_row(self, df_row, ensure_lat_long=True)->None:
       """

--- a/docassemble/AssemblyLine/data/questions/test_alcourts.yml
+++ b/docassemble/AssemblyLine/data/questions/test_alcourts.yml
@@ -116,7 +116,7 @@ fields:
     required: False
 ---
 # TODO: test `.from_row()`, `.geolocate()`
-id: court_with_all_fields_result
+id: court_with_just_name_result
 question: |
   Court info when all fields filled
 subquestion: |
@@ -152,7 +152,7 @@ code: |
 code: |
   missing_street.description = 'Description of the court that has just its name filled in defined by the developer.'
 ---
-id: court with just name
+id: missing street
 question: |
   User leaves out street address
 fields:
@@ -170,7 +170,7 @@ fields:
     required: False
 ---
 # TODO: test `.from_row()`, `.geolocate()`
-id: court_with_all_fields_result
+id: missing_street_result
 question: |
   Court info when all fields filled
 subquestion: |
@@ -206,7 +206,7 @@ code: |
 code: |
   missing_city.description = 'Description of the court that has just its name filled in defined by the developer.'
 ---
-id: court with just name
+id: missing city
 question: |
   User leaves out city
 fields:
@@ -224,7 +224,7 @@ fields:
     required: False
 ---
 # TODO: test `.from_row()`, `.geolocate()`
-id: court_with_all_fields_result
+id: missing_city_result
 question: |
   Court info when all fields filled
 subquestion: |

--- a/docassemble/AssemblyLine/data/questions/test_alcourts.yml
+++ b/docassemble/AssemblyLine/data/questions/test_alcourts.yml
@@ -1,0 +1,253 @@
+---
+include:
+  - al_package.yml
+---
+metadata:
+  title: |
+    Test courts classes
+---
+# TODO: When the testing framework implements the back button,
+# reduce this to one page only and test more missing field
+# info and with name that contains city name.
+mandatory: True
+code: |
+  court_with_all_fields_name
+  court_with_all_fields_result
+
+  court_with_just_name_name
+  court_with_just_name_result
+  
+  missing_street_name
+  missing_street_result
+  
+  missing_city_name
+  missing_city_result
+
+  end_alcourt_tests
+---
+# User fills in all fields
+---
+objects:
+  - court_with_all_fields_address: Address
+---
+depends on:
+  - court_with_all_fields_name
+  - court_with_all_fields_address
+need:
+  - court_with_all_fields_name
+  - court_with_all_fields_address
+code: |
+  court_with_all_fields = ALCourt('court_with_all_fields')
+  court_with_all_fields.name = court_with_all_fields_name
+  court_with_all_fields.address = court_with_all_fields_address
+---
+code: |
+  court_with_all_fields.description = 'Description of the court that has all its fields filled in defined by the developer.'
+---
+id: court with all fields
+question: |
+  User fills all fields
+fields:
+  - Name: court_with_all_fields_name
+  - Address: court_with_all_fields_address.address
+    address autocomplete: True
+    required: False
+  - Suite: court_with_all_fields_address.unit
+    required: False
+  - City: court_with_all_fields_address.city
+    required: False
+  - State: court_with_all_fields_address.state
+    required: False
+  - Postal code: court_with_all_fields_address.zip
+    required: False
+---
+# TODO: test `.from_row()`, `.geolocate()`
+id: court_with_all_fields_result
+question: |
+  Court info when all fields filled
+subquestion: |
+  `court_with_all_fields.short_label()`:
+  
+  ${ court_with_all_fields.short_label() }
+  
+  `court_with_all_fields.short_label_and_address()`:
+  
+  ${ court_with_all_fields.short_label_and_address() }
+  
+  `court_with_all_fields.short_description()`:
+  
+  ${ court_with_all_fields.short_description() }
+continue button field: court_with_all_fields_result
+---
+# Just name address filled in
+---
+objects:
+  - court_with_just_name_address: Address
+---
+depends on:
+  - court_with_just_name_name
+  - court_with_just_name_address
+need:
+  - court_with_just_name_name
+  - court_with_just_name_address
+code: |
+  court_with_just_name = ALCourt('court_with_just_name')
+  court_with_just_name.name = court_with_just_name_name
+  court_with_just_name.address = court_with_just_name_address
+---
+code: |
+  court_with_just_name.description = 'Description of the court that has just its name filled in defined by the developer.'
+---
+id: court with just name
+question: |
+  User inputs just name
+fields:
+  - Name: court_with_just_name_name
+  - Address: court_with_just_name_address.address
+    address autocomplete: True
+    required: False
+  - Suite: court_with_just_name_address.unit
+    required: False
+  - City: court_with_just_name_address.city
+    required: False
+  - State: court_with_just_name_address.state
+    required: False
+  - Postal code: court_with_just_name_address.zip    
+    required: False
+---
+# TODO: test `.from_row()`, `.geolocate()`
+id: court_with_all_fields_result
+question: |
+  Court info when all fields filled
+subquestion: |
+  `court_with_just_name.short_label()`:
+  
+  ${ court_with_just_name.short_label() }
+  
+  `court_with_just_name.short_label_and_address()`:
+  
+  ${ court_with_just_name.short_label_and_address() }
+  
+  `court_with_just_name.short_description()`:
+  
+  ${ court_with_just_name.short_description() }
+continue button field: court_with_just_name_result
+---
+# Missing first line of street address
+---
+objects:
+  - missing_street_address: Address
+---
+depends on:
+  - missing_street_name
+  - missing_street_address
+need:
+  - missing_street_name
+  - missing_street_address
+code: |
+  missing_street = ALCourt('missing_street')
+  missing_street.name = missing_street_name
+  missing_street.address = missing_street_address
+---
+code: |
+  missing_street.description = 'Description of the court that has just its name filled in defined by the developer.'
+---
+id: court with just name
+question: |
+  User leaves out street address
+fields:
+  - Name: missing_street_name
+  - Address: missing_street_address.address
+    address autocomplete: True
+    required: False
+  - Suite: missing_street_address.unit
+    required: False
+  - City: missing_street_address.city
+    required: False
+  - State: missing_street_address.state
+    required: False
+  - Postal code: missing_street_address.zip    
+    required: False
+---
+# TODO: test `.from_row()`, `.geolocate()`
+id: court_with_all_fields_result
+question: |
+  Court info when all fields filled
+subquestion: |
+  `missing_street.short_label()`:
+  
+  ${ missing_street.short_label() }
+  
+  `missing_street.short_label_and_address()`:
+  
+  ${ missing_street.short_label_and_address() }
+  
+  `missing_street.short_description()`:
+  
+  ${ missing_street.short_description() }
+continue button field: missing_street_result
+---
+# Missing city name
+---
+objects:
+  - missing_city_address: Address
+---
+depends on:
+  - missing_city_name
+  - missing_city_address
+need:
+  - missing_city_name
+  - missing_city_address
+code: |
+  missing_city = ALCourt('missing_city')
+  missing_city.name = missing_city_name
+  missing_city.address = missing_city_address
+---
+code: |
+  missing_city.description = 'Description of the court that has just its name filled in defined by the developer.'
+---
+id: court with just name
+question: |
+  User leaves out city
+fields:
+  - Name: missing_city_name
+  - Address: missing_city_address.address
+    address autocomplete: True
+    required: False
+  - Suite: missing_city_address.unit
+    required: False
+  - City: missing_city_address.city
+    required: False
+  - State: missing_city_address.state
+    required: False
+  - Postal code: missing_city_address.zip    
+    required: False
+---
+# TODO: test `.from_row()`, `.geolocate()`
+id: court_with_all_fields_result
+question: |
+  Court info when all fields filled
+subquestion: |
+  `missing_city.short_label()`:
+  
+  ${ missing_city.short_label() }
+  
+  `missing_city.short_label_and_address()`:
+  
+  ${ missing_city.short_label_and_address() }
+  
+  `missing_city.short_description()`:
+  
+  ${ missing_city.short_description() }
+continue button field: missing_city_result
+---
+id: end alcourt tests
+event: end_alcourt_tests
+question: The end of ALCourt tests
+subquestion: |
+  Tests still needed:
+  
+  - ALCourt `.geolocate()`
+  - ALCourt `.from_row()`
+  - ALCourtLoader functionality
+---

--- a/docassemble/AssemblyLine/data/questions/test_alcourts.yml
+++ b/docassemble/AssemblyLine/data/questions/test_alcourts.yml
@@ -7,21 +7,15 @@ metadata:
     Test courts classes
 ---
 # TODO: When the testing framework implements the back button,
-# reduce this to one page only and test more missing field
-# info and with name that contains city name.
+# consider reducing this to one page only and simply going back
+# and forth.
 mandatory: True
 code: |
   court_with_all_fields_name
   court_with_all_fields_result
-
-  court_with_just_name_name
-  court_with_just_name_result
   
-  missing_street_name
-  missing_street_result
-  
-  missing_city_name
-  missing_city_result
+  name_contains_city_name
+  name_contains_city_result
 
   end_alcourt_tests
 ---
@@ -79,167 +73,59 @@ subquestion: |
   ${ court_with_all_fields.short_description() }
 continue button field: court_with_all_fields_result
 ---
-# Just name address filled in
+# Court name includes city
 ---
 objects:
-  - court_with_just_name_address: Address
+  - name_contains_city_address: Address
 ---
 depends on:
-  - court_with_just_name_name
-  - court_with_just_name_address
+  - name_contains_city_name
+  - name_contains_city_address
 need:
-  - court_with_just_name_name
-  - court_with_just_name_address
+  - name_contains_city_name
+  - name_contains_city_address
 code: |
-  court_with_just_name = ALCourt('court_with_just_name')
-  court_with_just_name.name = court_with_just_name_name
-  court_with_just_name.address = court_with_just_name_address
+  name_contains_city = ALCourt('name_contains_city')
+  name_contains_city.name = name_contains_city_name
+  name_contains_city.address = name_contains_city_address
 ---
 code: |
-  court_with_just_name.description = 'Description of the court that has just its name filled in defined by the developer.'
+  name_contains_city.description = 'Description of the court that has just its name filled in defined by the developer.'
 ---
-id: court with just name
+id: name has city
 question: |
-  User inputs just name
+  Name contains city name
 fields:
-  - Name: court_with_just_name_name
-  - Address: court_with_just_name_address.address
+  - Name: name_contains_city_name
+  - Address: name_contains_city_address.address
     address autocomplete: True
     required: False
-  - Suite: court_with_just_name_address.unit
+  - Suite: name_contains_city_address.unit
     required: False
-  - City: court_with_just_name_address.city
+  - City: name_contains_city_address.city
     required: False
-  - State: court_with_just_name_address.state
+  - State: name_contains_city_address.state
     required: False
-  - Postal code: court_with_just_name_address.zip    
+  - Postal code: name_contains_city_address.zip    
     required: False
 ---
 # TODO: test `.from_row()`, `.geolocate()`
-id: court_with_just_name_result
+id: name_contains_city_result
 question: |
   Court info when all fields filled
 subquestion: |
-  `court_with_just_name.short_label()`:
+  `name_contains_city.short_label()`:
   
-  ${ court_with_just_name.short_label() }
+  ${ name_contains_city.short_label() }
   
-  `court_with_just_name.short_label_and_address()`:
+  `name_contains_city.short_label_and_address()`:
   
-  ${ court_with_just_name.short_label_and_address() }
+  ${ name_contains_city.short_label_and_address() }
   
-  `court_with_just_name.short_description()`:
+  `name_contains_city.short_description()`:
   
-  ${ court_with_just_name.short_description() }
-continue button field: court_with_just_name_result
----
-# Missing first line of street address
----
-objects:
-  - missing_street_address: Address
----
-depends on:
-  - missing_street_name
-  - missing_street_address
-need:
-  - missing_street_name
-  - missing_street_address
-code: |
-  missing_street = ALCourt('missing_street')
-  missing_street.name = missing_street_name
-  missing_street.address = missing_street_address
----
-code: |
-  missing_street.description = 'Description of the court that has just its name filled in defined by the developer.'
----
-id: missing street
-question: |
-  User leaves out street address
-fields:
-  - Name: missing_street_name
-  - Address: missing_street_address.address
-    address autocomplete: True
-    required: False
-  - Suite: missing_street_address.unit
-    required: False
-  - City: missing_street_address.city
-    required: False
-  - State: missing_street_address.state
-    required: False
-  - Postal code: missing_street_address.zip    
-    required: False
----
-# TODO: test `.from_row()`, `.geolocate()`
-id: missing_street_result
-question: |
-  Court info when all fields filled
-subquestion: |
-  `missing_street.short_label()`:
-  
-  ${ missing_street.short_label() }
-  
-  `missing_street.short_label_and_address()`:
-  
-  ${ missing_street.short_label_and_address() }
-  
-  `missing_street.short_description()`:
-  
-  ${ missing_street.short_description() }
-continue button field: missing_street_result
----
-# Missing city name
----
-objects:
-  - missing_city_address: Address
----
-depends on:
-  - missing_city_name
-  - missing_city_address
-need:
-  - missing_city_name
-  - missing_city_address
-code: |
-  missing_city = ALCourt('missing_city')
-  missing_city.name = missing_city_name
-  missing_city.address = missing_city_address
----
-code: |
-  missing_city.description = 'Description of the court that has just its name filled in defined by the developer.'
----
-id: missing city
-question: |
-  User leaves out city
-fields:
-  - Name: missing_city_name
-  - Address: missing_city_address.address
-    address autocomplete: True
-    required: False
-  - Suite: missing_city_address.unit
-    required: False
-  - City: missing_city_address.city
-    required: False
-  - State: missing_city_address.state
-    required: False
-  - Postal code: missing_city_address.zip    
-    required: False
----
-# TODO: test `.from_row()`, `.geolocate()`
-id: missing_city_result
-question: |
-  Court info when all fields filled
-subquestion: |
-  `missing_city.short_label()`:
-  
-  ${ missing_city.short_label() }
-  
-  `missing_city.short_label_and_address()`:
-  
-  ${ missing_city.short_label_and_address() }
-  
-  `missing_city.short_description()`:
-  
-  ${ missing_city.short_description() }
-continue button field: missing_city_result
+  ${ name_contains_city.short_description() }
+continue button field: name_contains_city_result
 ---
 id: end alcourt tests
 event: end_alcourt_tests


### PR DESCRIPTION
Also does some transformation of the address if needed since it can come from user input. I can change that back if desired.

Having multiple pages this way ends up letting the test run faster. When we have a testing step for tapping the 'Back' button, we can get rid of some of these pages.

Close #252