### PR TITLE
Safer html concats

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -61,11 +61,13 @@ def table_row( title:str, button_htmls:List[str] = []) -> str:
   Uses the provided title and list of button html strings to
   return the row of an AL document-styled table in HTML format.
   """
-  html = '\n\t<tr>'
-  # html += '\n\t\t<td><i class="fas fa-file"></i>&nbsp;&nbsp;</td>'
-  # TODO: Need to replace with proper CSS
-  html += '\n\t\t<td class="al_doc_title"><strong>' + title + '</strong></td>'
-  html += '\n\t\t<td class="al_buttons">'
+  html = (
+    f'\n\t<tr>'
+    # '\n\t\t<td><i class="fas fa-file"></i>&nbsp;&nbsp;</td>'
+    # TODO: Need to replace with proper CSS
+    f'\n\t\t<td class="al_doc_title"><strong>{title}</strong></td>'
+    f'\n\t\t<td class="al_buttons">'
+  )
   for button in button_htmls:
     html += button
   html += '</td>'
@@ -781,11 +783,11 @@ class ALDocumentBundle(DAList):
     files = self.enabled_documents(refresh=refresh)
     if len(files) == 1:
       # This case is simplest--we do not need to process the document at this level
-      log_if_debug('Storing bundle for just one document ' + self.title + ' at ' + self.instanceName + '.cache.' + safe_key)
+      log_if_debug(f'Storing bundle for just one document {self.title} at {self.instanceName}.cache.{safe_key}')
       pdf = files[0].as_pdf(key=key, refresh=refresh)
       pdf.title = self.title
     else:
-      log_if_debug('Storing bundle ' + self.title + ' at ' + self.instanceName + '.cache.' + safe_key)
+      log_if_debug(f'Storing bundle {self.title} at {self.instanceName}.cache.{safe_key}')
       pdf = pdf_concatenate([document.as_pdf(key=key, refresh=refresh) for document in files], filename=self.filename + ending)
     pdf.title = self.title
     setattr(self.cache, safe_key, pdf)

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -976,9 +976,11 @@ class ALDocumentBundle(DAList):
     else:
       buttons = [doc_download_button]
 
-    html ='<table class="al_table merged_docs" id="' + html_safe_str(self.instanceName) + '">'
-    html += table_row(self.title, buttons)
-    html += '\n</table>'
+    html = ( 
+      f'<table class="al_table merged_docs" id="{html_safe_str(self.instanceName)}">'
+      f'{table_row(self.title, buttons)}'
+      f'\n</table>'
+    )
 
     return html
 
@@ -990,37 +992,38 @@ class ALDocumentBundle(DAList):
     Optionally, display a checkbox that allows someone to decide whether or not to
     include an editable (Word) copy of the file, iff it is available.
     """
-    name = re.sub(r'[^A-Za-z0-9]+','_', self.instanceName)  # safe name for classes and ids
+    name = html_safe_str(self.instanceName)  
     al_wants_editable_input_id = '_ignore_al_wants_editable_' + name
     al_email_input_id = '_ignore_al_doc_email_' + name
-    al_send_button_id = "al_send_email_button_" + name
+    al_send_button_id = 'al_send_email_button_' + name
 
-    javascript_string = "javascript:aldocument_send_action('" + \
-      self.attr_name('send_email_action_event') + \
-      "','" + al_wants_editable_input_id + "','" + \
-      al_email_input_id + "')"
+    javascript_string = (
+      f"javascript:aldocument_send_action("
+      f"'{self.attr_name('send_email_action_event')}',"
+      f"'{al_wants_editable_input_id}','{al_email_input_id}')"
+    )
 
-    return_str = '''
-  <div class="al_send_bundle '''+name+'''" id="al_send_bundle_'''+name+'''" name="al_send_bundle_'''+name+'''">
+    return_str = f'''
+  <div class="al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
     <h5 id="al_doc_email_header">Get a copy of the documents in email</h5> 
     '''
     if show_editable_checkbox:
-      return_str += '''
+      return_str += f'''
     <div class="form-check-container">
       <div class="form-check">
-        <input class="form-check-input" type="checkbox" class="al_wants_editable" id="'''+al_wants_editable_input_id+'''">
-        <label class="al_wants_editable form-check-label" for="'''+al_wants_editable_input_id+'''">'''\
-          + word("Include an editable copy") + '''
+        <input class="form-check-input" type="checkbox" class="al_wants_editable" id="{al_wants_editable_input_id}">
+        <label class="al_wants_editable form-check-label" for="{al_wants_editable_input_id}">{word("Include an editable copy")}
         </label>
       </div>
     </div>
   '''
-    return_str += '''
+    return_str += f'''
   <div class="al_email_container">
-    <span class="al_email_address '''+name+''' form-group row da-field-container da-field-container-datatype-email">
-      <label for="'''+al_email_input_id+'''" class="al_doc_email col-form-label da-form-label datext-right">Email</label>
-      <input value="''' + (user_info().email if user_logged_in() else '') + '" alt="Input box" class="form-control" type="email" size="35" name="'+al_email_input_id+'" id="'+al_email_input_id+'''">
-    </span>''' + action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id) + "\n" + '''
+    <span class="al_email_address {name} form-group row da-field-container da-field-container-datatype-email">
+      <label for="{al_email_input_id}" class="al_doc_email col-form-label da-form-label datext-right">Email</label>
+      <input value="{user_info().email if user_logged_in() else ''}" alt="Input box" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+    </span>{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}
+
   </div>
   '''
     return_str += '</div>'  # al_send_bundle


### PR DESCRIPTION
Came across a bug in production today where, somehow, something was ending up as `None` in the HTML table. Full error is below. In general, I'm leaning towards making more things formatted strings, as I've seen the "`None` can't concatenate with `str`" error a few times now, and it's failing on trivial things like logs most of the time.

Tested in Playground, email still sends correctly and, to my knowledge, the tables all look right still.

```

Traceback (most recent call last):
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/webapp/server.py", line 11985, in run_interview
    return index(refer=['run_dispatch', dispatch])
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/webapp/server.py", line 7532, in index
    interview.assemble(user_dict, interview_status, old_user_dict, force_question=special_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 7870, in assemble
    raise the_error
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 7659, in assemble
    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 8354, in askfor
    return question.ask(user_dict, old_user_dict, the_x, iterators, missing_var, origMissingVariable)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 4855, in ask
    subquestion = self.subcontent.text(user_dict)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/parse.py", line 1371, in text
    return(self.template.render(**the_user_dict))
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/mako/template.py", line 451, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/mako/runtime.py", line 828, in _render
    _render_context(template, callable_, context, *args,
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/mako/runtime.py", line 864, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/base/mako/runtime.py", line 890, in _exec_template
    callable_(context, *args, **kwargs)
  File "memory:0x7f8dcdeebcd0", line 38, in render_body
  File "/usr/share/docassemble/local3.8/lib/python3.8/site-packages/docassemble/AssemblyLine/al_document.py", line 1018, in send_button_html
    return_str += '''
TypeError: can only concatenate str (not "NoneType") to str

The referer URL was https://courtformsonline.org/appeals/
```