### PR TITLE
Gender enhancements

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -274,6 +274,12 @@ class ALIndividual(Individual):
     return self.gender == 'female'
   
   @property
+  def gender_other(self):
+    """Provide True/False for 'other' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on for forms without more inclusive options."""
+    return ((self.gender != 'male') and (self.gender != 'female'))
+  
+  @property
   def gender_nonbinary(self):
     """Provide True/False for 'nonbinary' gender to assist with checkbox filling
     in PDFs with "skip undefined" turned on."""

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -302,7 +302,7 @@ class ALIndividual(Individual):
   def gender_self_described(self):
     """Provide True/False for 'self-described' gender to assist with checkbox filling
     in PDFs with "skip undefined" turned on."""    
-    return self.gender == 'self-described'    
+    return not (self.gender in ['prefer-not-to-say','male','female','unknown','nonbinary'])
   
   def contact_fields(self):
     """

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -283,7 +283,6 @@ class ALIndividual(Individual):
   def gender_nonbinary(self):
     """Provide True/False for 'nonbinary' gender to assist with checkbox filling
     in PDFs with "skip undefined" turned on."""
-    
     return self.gender == 'nonbinary'
   
   @property

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -236,6 +236,7 @@ class ALIndividual(Individual):
         {str(self.gender_nonbinary_label): 'nonbinary'},
         {str(self.gender_prefer_not_to_say_label): 'prefer-not-to-say'},
         {str(self.gender_prefer_self_described_label): 'self-described'},
+        {str(self.gender_unknown_label): 'unknown'},
     ]
     self_described_input = {"label": str(self.gender_self_described_label),
                             "field": self.attr_name('gender'),
@@ -259,7 +260,44 @@ class ALIndividual(Individual):
         },
         self_described_input
       ]
-              
+      
+  @property
+  def gender_male(self):
+    """Provide True/False for 'male' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""
+    return self.gender == 'male'
+  
+  @property
+  def gender_female(self):
+    """Provide True/False for 'female' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""
+    return self.gender == 'female'
+  
+  @property
+  def gender_nonbinary(self):
+    """Provide True/False for 'nonbinary' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""
+    
+    return self.gender == 'nonbinary'
+  
+  @property
+  def gender_unknown(self):
+    """Provide True/False for 'unknown' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""
+    return self.gender == 'unknown'
+  
+  @property
+  def gender_undisclosed(self):
+    """Provide True/False for 'prefer-not-to-say' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""
+    return self.gender == 'prefer-not-to-say'  
+  
+  @property
+  def gender_self_described(self):
+    """Provide True/False for 'self-described' gender to assist with checkbox filling
+    in PDFs with "skip undefined" turned on."""    
+    return self.gender == 'self-described'    
+  
   def contact_fields(self):
     """
     Return field prompts for other contact info

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -339,11 +339,6 @@ content: |
   Some forms require you to select either "Male" or "Female". If you do not select
   "Male" or "Female", your form may include an empty checkbox.
 ---
-generic object: ALIndividual
-template: x.gender_female_label
-content: |
-  Female
----
 generic object: ALAddress
 template: x.state_label
 # See https://docassemble.org/docs/functions.html#subdivision_type

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -750,12 +750,6 @@ code: |
   # what date to list on the form.  
   signature_date = today()
 ---
-generic object: ALIndividual
-code: |
-  x.gender_female = x.gender == 'female'
-  x.gender_male = x.gender == 'male'
-  x.gender_other = ((x.gender != 'male') and (x.gender != 'female'))
----
 sets:
   - x.gender
 id: gender

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -329,6 +329,11 @@ content: |
   Self-described gender
 ---
 generic object: ALIndividual
+template: x.gender_unknown_label
+content: |
+  Unknown
+---
+generic object: ALIndividual
 template: x.gender_help_text
 content: |
   Some forms require you to select either "Male" or "Female". If you do not select


### PR DESCRIPTION
Fix #279 Fix #278 

Add an "unknown" option for gender (as forms in some provinces in Canada now provide)

Make all of the gender options work better as checkboxes in PDF forms. Currently, we provide a `x.gender_male` and `x.gender_female` attribute which is defined in a code block. That method doesn't work when you assemble a PDF that has `skip undefined` turned on, unless you explicitly trigger it in your interview order block. This PR makes the `gender_male` field into a method with the `@property` decorator, which is backwards compatible with the code block but works with `skip undefined`, and only requires that `gender` is defined explicitly.

I also added matching properties for each available gender choice for inclusive PDF forms.

A small test interview below shows that the new methods work with `skip undefined`.

[what_gender.pdf](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/files/7171274/what_gender.pdf)
[gender_tests.yml.txt](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/files/7171281/gender_tests.yml.txt)
