### PR TITLE
Issue #239.

### DIFF
--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -15,7 +15,8 @@
 }
 @media only screen and (max-width: 766px) {
     .title {
-        display: normal; /*none
+        /*display: none */
+        font-weight: normal;
     }
   /*
     .ma_icon {


### PR DESCRIPTION
Sorry, I was too quick. 

With this fix and https://github.com/SuffolkLITLab/docassemble-MassAccess/pull/1, you should see the effect like this:
![image](https://user-images.githubusercontent.com/20231649/136230891-5cee1142-d4cb-4834-a5b1-42925825f93c.png)
