### PR TITLE
328 cache dalazytemplate

### DIFF
--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -2,11 +2,6 @@
 include:
   - al_package.yml
 ---
-generic object: ALDocumentBundle
-template: x.zip_label
-content: |
-  Download zip
----
 metadata:
   title: |
     Test ALDocument class


### PR DESCRIPTION
Fix #328 

This caches the value of some of the newly translatable strings on the first run of `download_list_html` and `send_button_html`. Previously, when the DALazyTemplates were being reevaluated it was causing many extra calls to the `as_pdf()` method in rendering the page, which caused more frequent timeouts. I think this was responsible for some of the recent automated test errors with the `test_aldocument.yml` file.

We really need to address background generation of documents though! This is still much slower than it should be.