### PR TITLE
Fix #319, add an MVP menu item to start a new session

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -45,6 +45,24 @@ features:
   question back button: True
   progress bar: True
 ---
+initial: True
+code: |
+  # Set the dropdown/hamburger menu items
+  # by default we just add a "Start over" link
+  if _internal.get('steps') > 1:
+    menu_items = al_menu_items
+---
+code: |
+  al_menu_items = [
+    {"url": url_ask(['al_start_over_confirmation','al_start_over']),
+    "label": "Start over"
+    },
+  ]
+---
+event: al_start_over
+code: |
+  command('new_session')
+---
 code: |
   send_icon = "envelope"
 ---
@@ -262,3 +280,27 @@ content: |
   
   "${all_variables(special='metadata').get('title','').rstrip()}" includes code 
   from the [Document Assembly Line project](https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/). 
+---
+id: start a new session
+question: |
+  Do you want to start over?
+subquestion: |
+  % if not user_logged_in():
+  You may lose access to your current answers. Make sure you have downloaded
+  any forms that you need.
+  % else:
+  You can still access your current answers by visiting the "My interviews"
+  page.
+  % endif
+  
+  Click "Start over" to start a new copy of the form you are working on,
+  or "Back" if you want to keep working.
+back button label: |
+  Back
+continue button label: |
+  Start over
+continue button field: al_start_over_confirmation
+  
+
+
+


### PR DESCRIPTION
This adds a first draft of a "Start over" link. The link requires confirmation, warns the user that the interview will be lost if they are not logged in, and creates a new session rather than restarting and erasing the user's existing data.

![image](https://user-images.githubusercontent.com/7645641/138900772-60a6770f-6fe5-4a3a-b7c3-3246b07a7bac.png)

![image](https://user-images.githubusercontent.com/7645641/138901442-e5e2df6f-48de-4611-9e2c-9905660820a5.png)

I added a new data structure, al_menu_items, to make it possible for the list of menu items to be extended by other users. It is only triggered after interview "steps" is > 1 (approximately after the second screen of the interview).