### PR TITLE
Add more time to custom max timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ screenshot_*.jpg
 downloads_*
 *_lang_*.feature
 *_report_*
+_al_test_project_name.json
 .history
 __pycache__/

--- a/docassemble/AssemblyLine/data/sources/test_aldocument.feature
+++ b/docassemble/AssemblyLine/data/sources/test_aldocument.feature
@@ -3,7 +3,7 @@ Feature: ALDocument classes
 
 @aldocs @d1
 Scenario: No ALDocument page errors
-  And the max seconds for each step is 150
+  And the max seconds for each step is 200
   Given I start the interview at "test_aldocument"
   And I get to "end aldocument tests" with this data:
     | var | value | trigger |
@@ -17,7 +17,7 @@ Scenario: No ALDocument page errors
 
 @alexhibits @e1
 Scenario: User can upload exhibits
-  And the max seconds for each step is 150
+  And the max seconds for each step is 200
   Given I start the interview at "test_alexhibit"
   And I get to "end alexhibit tests" with this data:
     | var | value | trigger |
@@ -34,7 +34,7 @@ Scenario: User can upload exhibits
 
 @alexhibits @e2
 Scenario: User adds only a docx exhibit
-  And the max seconds for each step is 150
+  And the max seconds for each step is 200
   Given I start the interview at "test_alexhibit"
   And I get to "end alexhibit tests" with this data:
     | var | value | trigger |


### PR DESCRIPTION
We've had at least one incident of the tests not waiting quite long enough for the page to load all files. This will lengthen failing tests, but will also reduce false fails. Our group's conversations about this have led me to believe that the latter this approach the one we prefer.

I also adjusted the `.gitignore` to line up with the latest version of the testing framework. It's only an issue when running tests locally, but this will avoid accidentally checking in an unnecessary file under those circumstances.