### PR TITLE
Moved 'continue button field' from templ to ques

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1048,6 +1048,7 @@ fields:
     show if: 
       code: |
         device() and not device().is_pc
+continue button field: saw_signature_qrcode
 ---
 template: help_using_qr_code_template
 subject: |
@@ -1057,7 +1058,6 @@ content: |
   the camera app. The link
   may "float" up from the screen into a small icon you can tap.
   If your phone does not do this, use the text option instead.
-continue button field: saw_signature_qrcode
 ---
 id: signature phone followup
 question: |


### PR DESCRIPTION
Causes the question to be skipped, suprised that templates can have
continue button fields.