### PR TITLE
Replace CourtFormsOnline w/ AL_ORGANIZATION_TITLE

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -8,6 +8,14 @@ code: |
   # Defaults to checking for a possible name from global docassemble config
   al_app_name = get_config('appname', get_config('external hostname','CourtFormsOnline.org'))
 ---
+code: |
+  # The name of your organization. Defaults to a similar value as `al_app_name`,
+  # but is still distinct
+  AL_ORGANIZATION_TITLE = get_config('appname', 'CourtFormsOnline')
+---
+code: |
+  AL_ORGANIZATION_HOMEPAGE = get_config('app homepage', 'https://courtformsonline.org')
+---
 ###########################
 # localization and internationalization / i18n settings
 ---
@@ -19,9 +27,6 @@ code: |
 ---
 code: |
   AL_DEFAULT_LANGUAGE = "en"
----
-code: |
-  AL_ORGANIZATION_TITLE = get_config('appname', 'CourtFormsOnline')   
 ---
 ###############################
 # Features

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -177,8 +177,7 @@ fields:
   - Message: share_interview_answers_message
     datatype: area
     default: |
-      Hi, I wanted to share my progress on a form on ,
-      "${ AL_ORGANIZATION_TITLE }".
+      Hi, I wanted to share my progress on a form on "${ AL_ORGANIZATION_TITLE }".
       If you click this link, you can follow along or finish the form for me.
     js show if: |
       val("al_how_share_link") === "email_or_sms" && val("al_sharing_type") === "share_answers"      

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -4,13 +4,13 @@ objects:
 ---
 default screen parts:
   title: |
-    ${ AL_ORGANIZATION_TITLE }
+    ${ all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE) }
   short title: |
-    ${ AL_ORGANIZATION_TITLE }
+    ${ all_variables(special='metadata').get('short title', AL_ORGANIZATION_TITLE) }
   title url: |
-    ${ AL_ORGANIZATION_HOMEPAGE }
+    ${ all_variables(special='metadata').get('title url', AL_ORGANIZATION_HOMEPAGE) }
   exit url: |
-    ${ AL_ORGANIZATION_HOMEPAGE }
+    ${ all_variables(special='metadata').get('exit url', AL_ORGANIZATION_HOMEPAGE) }
   logo: |
     <div class="title-container">
       <div class="al-logo">

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,11 +1,11 @@
 # TODO: come up with a nice-looking generic placeholder icon/label to go here
 metadata:
   title: |
-    CourtFormsOnline: MassAccess
+    ${ AL_ORGANIZATION_TITLE }: MassAccess
   short title: |
-    CourtFormsOnline
-  title url: https://courtformsonline.org  
-  exit url: https://courtformsonline.org
+    ${ AL_ORGANIZATION_TITLE }
+  title url: ${ AL_ORGANIZATION_HOMEPAGE }
+  exit url: ${ AL_ORGANIZATION_HOMEPAGE }
 ---
 objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png")
@@ -170,15 +170,15 @@ fields:
     datatype: area
     default: |
       Hi, I wanted to let you know about a free website that I learned about:
-      "${single_paragraph(all_variables(special='metadata').get('title','Court Forms Online'))}". I think this might
+      "${single_paragraph(all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE))}". I think this might
       help you, too. Check it out at the link in this message:       
     js show if: |
       val("al_how_share_link") === "email_or_sms" && val("al_sharing_type") === "tell_friend"
   - Message: share_interview_answers_message
     datatype: area
     default: |
-      Hi, I wanted to share my progress on a form on Court Forms Online,
-      "${single_paragraph(all_variables(special='metadata').get('title','Court Forms Online'))}".
+      Hi, I wanted to share my progress on a form on ,
+      "${single_paragraph(all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE))}".
       If you click this link, you can follow along or finish the form for me.
     js show if: |
       val("al_how_share_link") === "email_or_sms" && val("al_sharing_type") === "share_answers"      
@@ -246,7 +246,7 @@ content: |
 ---
 template: al_share_answers_message_template
 subject: |
-  Court Forms Online form from ${ al_share_form_from_name }
+  ${ AL_ORGANIZATION_TITLE } form from ${ al_share_form_from_name }
 content: |
   ${ share_interview_answers_message }
   Click the link below to view and edit ${ al_share_form_from_name }'s
@@ -256,7 +256,7 @@ content: |
 ---
 template: al_tell_a_friend_message_template
 subject: |
-  ${ al_share_form_from_name } wants to tell you about Court Forms Online
+  ${ al_share_form_from_name } wants to tell you about ${ AL_ORGANIZATION_TITLE }
 content: |
   ${ tell_a_friend_message }
   ${ interview_url(i=user_info().filename, style="short", new_session=1) }

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,16 +1,16 @@
-# TODO: come up with a nice-looking generic placeholder icon/label to go here
-metadata:
-  title: |
-    ${ AL_ORGANIZATION_TITLE }: MassAccess
-  short title: |
-    ${ AL_ORGANIZATION_TITLE }
-  title url: ${ AL_ORGANIZATION_HOMEPAGE }
-  exit url: ${ AL_ORGANIZATION_HOMEPAGE }
 ---
 objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png")
 ---
 default screen parts:
+  title: |
+    ${ AL_ORGANIZATION_TITLE }
+  short title: |
+    ${ AL_ORGANIZATION_TITLE }
+  title url: |
+    ${ AL_ORGANIZATION_HOMEPAGE }
+  exit url: |
+    ${ AL_ORGANIZATION_HOMEPAGE }
   logo: |
     <div class="title-container">
       <div class="al-logo">

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -178,7 +178,7 @@ fields:
     datatype: area
     default: |
       Hi, I wanted to share my progress on a form on ,
-      "${single_paragraph(all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE))}".
+      "${ AL_ORGANIZATION_TITLE }".
       If you click this link, you can follow along or finish the form for me.
     js show if: |
       val("al_how_share_link") === "email_or_sms" && val("al_sharing_type") === "share_answers"      

--- a/docassemble/AssemblyLine/data/questions/feedback.yml
+++ b/docassemble/AssemblyLine/data/questions/feedback.yml
@@ -3,11 +3,11 @@ include:
   - docassemble.GithubFeedbackForm:feedback.yml
 ---
 metadata:
-  title: CourtFormsOnline Feedback Form
+  title: ${ AL_ORGANIZATION_TITLE } Feedback Form
   short title: Feedback
 ---
 code: |
-  al_feedback_form_title = "CourtFormsOnline Feedback Form"  
+  al_feedback_form_title = f"{AL_ORGANIZATION_TITLE} Feedback Form"
 ---
 code: |
   # This email will be used ONLY if there is no valid GitHub config

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -25,12 +25,12 @@ objects:
 id: basic questions intro screen
 decoration: form-lineal
 question: |
-  ${interview_short_title}: Court Forms Online
+  ${interview_short_title}: ${ AL_ORGANIZATION_TITLE}
 subquestion: |
   % if form_approved_for_email_filing:
-  The Court Forms Online Project can help you complete and file court forms in 3 steps:
+  The ${ AL_ORGANIZATION_TITLE } Project can help you complete and file court forms in 3 steps:
   % else:
-  The Court Forms Online Project can help you complete and download forms in 3 steps:
+  The ${ AL_ORGANIZATION_TITLE } Project can help you complete and download forms in 3 steps:
   % endif
   
   Step 1. Answer questions that will fill in your form for you.  
@@ -56,7 +56,7 @@ subquestion: |
   (:comment-alt:) in the navigation bar to connect to a live advocate for help.
   % endif
 fields:
-  - To continue, you must accept our [terms of use](https://courtformsonline.org/privacy/): acknowledged_information_use
+  - To continue, you must accept our [terms of use](${ AL_ORGANIZATION_HOME_PAGE }/privacy/): acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1
@@ -813,7 +813,7 @@ fields:
 id: accept terms of use
 decoration: form-lineal
 question: |
-  ${interview_short_title}: CourtFormsOnline
+  ${interview_short_title}: ${ AL_ORGANIZATION_TITLE }
 subquestion: |
   % if form_approved_for_email_filing:
   This website can be used to complete and deliver forms directly to the
@@ -841,7 +841,7 @@ subquestion: |
   % endif
 
 fields:
-  - To continue, you must accept the [terms of use](https://courtformsonline.org/privacy/): acknowledged_information_use
+  - To continue, you must accept the [terms of use](${ AL_ORGANIZATION_HOMEPAGE }/privacy/): acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -56,7 +56,7 @@ subquestion: |
   (:comment-alt:) in the navigation bar to connect to a live advocate for help.
   % endif
 fields:
-  - To continue, you must accept our [terms of use](${ AL_ORGANIZATION_HOME_PAGE }/privacy/): acknowledged_information_use
+  - To continue, you must accept our [terms of use](${ AL_ORGANIZATION_HOMEPAGE }/privacy/): acknowledged_information_use
     datatype: checkboxes
     none of the above: False    
     minlength: 1


### PR DESCRIPTION
Also replaced https://courtformsonline.org with AL_ORGANIZATION_HOMEPAGE

Decided to just use `CourtFormsOnline` everywhere to be consistent. Open to trying to edit things if we think that `Court Forms Online` (with spaces) is still useful.

Note also that prod doesn't have the variable "app hompage" in the config yet, so we're still depending on that default value. 

Fixes #346.