### PR TITLE
Safer idempotent email template

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -20,17 +20,26 @@ code: |
     log(word('E-mail failed'), 'error')
 ---
 generic object: ALDocumentBundle
+code: |
+  # Used in the email subject line when email is triggered on download screen.
+  # This defaults to the interview title. For example, if the 
+  # interview title is "Guardianship Helper", the email
+  # subject would be "Your Guardianship Helper document from CourtFormsOnline is ready".
+  # Customize this if you prefer something like "Your guardianship document is ready"
+  x.document_label = all_variables(special='titles').get('title', all_variables(special='metadata').get('title', 'assembled'))
+---
+generic object: ALDocumentBundle
 template: x.send_email_template
-# TODO: there may be a better default than "metadata_title".
-# In general, we could improve this template
 subject: |
   % if len(x) > 1:
-  Your "${ metadata_title}" document from ${ al_app_name } is ready
+  Your ${ x.document_label  } document from ${ al_app_name } is ready
   % else:
-  Your "${ metadata_title }" documents from ${ al_app_name } are ready
+  Your ${ x.document_label } documents from ${ al_app_name } are ready
   % endif
 content: |
-  Please find the document for ${ users } attached.
+  Your ${ x.document_label } document is attached.
+  
+  Visit ${ AL_ORGANIZATION_HOMEPAGE } to learn more.
 ---
 generic object: ALDocumentBundle
 template: x.get_email_copy

--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -26,15 +26,15 @@ code: |
   # interview title is "Guardianship Helper", the email
   # subject would be "Your Guardianship Helper document from CourtFormsOnline is ready".
   # Customize this if you prefer something like "Your guardianship document is ready"
-  x.document_label = all_variables(special='titles').get('title', all_variables(special='metadata').get('title', 'assembled'))
+  x.document_label = str(all_variables(special='titles').get('title', all_variables(special='metadata').get('title', 'assembled'))).strip()
 ---
 generic object: ALDocumentBundle
 template: x.send_email_template
 subject: |
   % if len(x) > 1:
-  Your ${ x.document_label  } document from ${ al_app_name } is ready
+  Your ${ x.document_label } documents from ${ al_app_name } is ready
   % else:
-  Your ${ x.document_label } documents from ${ al_app_name } are ready
+  Your ${ x.document_label } document from ${ al_app_name } are ready
   % endif
 content: |
   Your ${ x.document_label } document is attached.

--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -32,9 +32,9 @@ generic object: ALDocumentBundle
 template: x.send_email_template
 subject: |
   % if len(x) > 1:
-  Your ${ x.document_label } documents from ${ al_app_name } is ready
+  Your ${ x.document_label } documents from ${ al_app_name } are ready
   % else:
-  Your ${ x.document_label } document from ${ al_app_name } are ready
+  Your ${ x.document_label } document from ${ al_app_name } is ready
   % endif
 content: |
   Your ${ x.document_label } document is attached.


### PR DESCRIPTION
We were running into a problem where an interview that used `x.send_email()` without defining `users[0].name.first` would silently fail. It seems that an action needs to be idempotent as far as gathering information that the user inputs, but it can safely trigger code blocks that aren't defined yet.

Took the chance to also slightly clean up the template. We were using `metadata_title` which obscurely used a title defined in the "first" entry in the `interview_metadata` dictionary. That variable wasn't visibly used anywhere else and would be hard to relate to the actual interview someone is running. Also added the new `AL_ORGANIZATION_HOMEPAGE` to the bottom of the email template and made it possible to customize just the `document_label` on a per-bundle basis without having to create your own email template.

Sample interview that can trigger the failed behavior on old AssemblyLine: (uncommenting lines for `users[0]` should let it succeed, but that shouldn't be required)

```yaml
---
include:
  - docassemble.AssemblyLine:al_package_unstyled.yml
---
objects:
  - test_doc: ALStaticDocument.using(filename="help_for_obligor_parents.pdf", enabled=True, title="ABC")
---
objects:
  - test_bundle: ALDocumentBundle.using(filename="download", title="bundle", enabled=True, elements=[test_doc])
---
#mandatory: True
#code: |
#  users[0] = ALIndividual(name=IndividualName(first="Bob", last="smith"))
#  users.there_is_another=False
---
mandatory: True
question: |
  Send me
subquestion: |
  ${ test_bundle.send_button_html() }
```

This resolves a production bug in https://courtformsonline.org/income/#child_support_obligor