### PR TITLE
Address question improvements

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -466,18 +466,18 @@ fields:
     none of the above: |
       Somewhere else
     disable others: True      
-  - ${ x.address.address_label}: x.mailing_address.address
+  - ${ x.address.address_label }: x.mailing_address.address
     address autocomplete: True
-  - ${ x.address.unit_label}: x.mailing_address.unit
+  - ${ x.address.unit_label }: x.mailing_address.unit
     required: False
-  - ${ x.address.city_label}: x.mailing_address.city
-  - ${ x.address.state_label}: x.mailing_address.state
+  - ${ x.address.city_label }: x.mailing_address.city
+  - ${ x.address.state_label }: x.mailing_address.state
     code: |
       states_list(country_code=AL_DEFAULT_COUNTRY)
     default: ${ AL_DEFAULT_STATE }
-  - ${ x.address.zip_label}: x.mailing_address.zip
+  - ${ x.address.zip_label }: x.mailing_address.zip
     required: False      
-  - ${ x.address.country_label}: x.mailing_address.country
+  - ${ x.address.country_label }: x.mailing_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
 ---

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -706,6 +706,29 @@ fields:
   - code: |
       other_parties[i].name_fields(person_or_business='unsure')
 ---
+id: generic address
+generic object: ALAddress
+sets:
+  - x.address
+  - x.city
+  - x.zip
+  - x.unit
+  - x.state
+  - x.country
+question: |
+  What is the ${ x.object_name() }?
+fields:
+  - code: |
+      x.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)  
+comment: |
+  This is left as just object_name() rather than "address of object_name()" because
+  commonly the word "address" would be included in the variable name.
+
+  You should generally consider overriding this question with one that will be easier
+  to read. This is here just as a placeholder. It will be difficult to translate and
+  the variable name will not always make sense to show the user even with the help
+  of object_name().
+---
 # TODO: consider removing default state
 # BUT: could be helpful to model how to set a default state
 sets:

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -425,34 +425,61 @@ fields:
       users[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
 ---
 id: your mailing address
-sets:
-  - users[0].mailing_address.address
-  - users[0].mailing_address.city
-  - users[0].mailing_address.zip
-  - users[0].mailing_address.unit
-  - users[0].mailing_address.state
-  - users[0].mailing_address.country
-  
 question: |
   What is your mailing address?
 fields:
-  - code: |
-      users[0].mailing_address.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
+  - My mailing address is: users[0].mailing_address
+    datatype: object_radio
+    choices:
+      - users[0].address
+    object labeler: |
+      lambda y: y.on_one_line()      
+    none of the above: |
+      Somewhere else
+    disable others: True      
+  - ${ users[0].address.address_label}: users[0].mailing_address.address
+    address autocomplete: True
+  - ${ users[0].address.unit_label}: users[0].mailing_address.unit
+    required: False
+  - ${ users[0].address.city_label}: users[0].mailing_address.city
+  - ${ users[0].address.state_label}: users[0].mailing_address.state
+    code: |
+      states_list(country_code=AL_DEFAULT_COUNTRY)
+    default: ${ AL_DEFAULT_STATE }
+  - ${ users[0].address.zip_label}: users[0].mailing_address.zip
+    required: False      
+  - ${ users[0].address.country_label}: users[0].mailing_address.country
+    code: countries_list()
+    default: ${ AL_DEFAULT_COUNTRY }
 ---
 generic object: ALIndividual
 id: any mailing address
-sets:
-  - x.mailing_address.address
-  - x.mailing_address.city
-  - x.mailing_address.zip
-  - x.mailing_address.state
-  - x.mailing_address.unit
-  - x.mailing_address.country 
 question: |
-  What is ${x}'s mailing address?
+  What is ${ x }'s mailing address?
 fields:
-  - code: |
-      x.mailing_address.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
+  - ${ x }'s mailing address is: x.mailing_address
+    datatype: object_radio
+    choices:
+      - x.address
+    object labeler: |
+      lambda y: y.on_one_line()      
+    none of the above: |
+      Somewhere else
+    disable others: True      
+  - ${ x.address.address_label}: x.mailing_address.address
+    address autocomplete: True
+  - ${ x.address.unit_label}: x.mailing_address.unit
+    required: False
+  - ${ x.address.city_label}: x.mailing_address.city
+  - ${ x.address.state_label}: x.mailing_address.state
+    code: |
+      states_list(country_code=AL_DEFAULT_COUNTRY)
+    default: ${ AL_DEFAULT_STATE }
+  - ${ x.address.zip_label}: x.mailing_address.zip
+    required: False      
+  - ${ x.address.country_label}: x.mailing_address.country
+    code: countries_list()
+    default: ${ AL_DEFAULT_COUNTRY }
 ---
 id: your contact information
 question: |


### PR DESCRIPTION
These two changes make the address field questions in ql_baseline just a little more robust. They [won't affect any existing repositories](https://github.com/search?p=1&q=org%3ASuffolkLITLab+mailing_address&type=Code).

No rush but might be nice to include with the next point release that has some more urgent fixes. Should be safe to merge with minimal review as it only adds new questions, doesn't replace any existing questions.

Here's a small test interview you can use:

```yaml
---
include:
  - al_package.yml
---
objects:
  - school_address: ALAddress
---
code: |
  AL_DEFAULT_COUNTRY = "GB"
---
#mandatory: True
question: |
  Mailing address
subquestion: |
  ${ users[0].mailing_address.block() }
---
#mandatory: True
question: |
  ${ defendants[0] }'s mailing address
subquestion: |
  ${ defendants[0].mailing_address }
---
mandatory: True
question: |
  ${ school_address.block() }
```