### PR TITLE
Try to prevent workflow run on tag pushes

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -2,6 +2,8 @@ name: Test the interview
 
 on:
   push:
+    tags-ignore:
+      - v*
   workflow_dispatch:
     inputs:
       extra_languages:


### PR DESCRIPTION
Based on https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags. May inform https://github.com/SuffolkLITLab/ALKiln/issues/380.

Not sure how we test this without just pushing to `main`.