### PR TITLE
Add document method to display pdf thumbnail while avoiding layout shift

### DIFF
--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -50,6 +50,18 @@ continue button field: as_foo_defaults
 question: |
   Get condensed bundle functions defaults
 subquestion: |
+
+  multi_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail() }
+
+  multi_bundle_1.as_dimensioned_thumbnail( width=400 )
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400 ) }
+
+  multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 )
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 ) }
   
   multi_bundle_1.as_pdf()
   
@@ -64,6 +76,10 @@ subquestion: |
   ${ multi_bundle_1.as_zip() }
   
   ---
+
+  single_pdf_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ single_pdf_bundle_1.as_dimensioned_thumbnail() }
   
   single_pdf_bundle_1.as_pdf()
   
@@ -78,6 +94,10 @@ subquestion: |
   ${ single_pdf_bundle_1.as_zip() }
   
   ---
+
+  single_docx_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ single_docx_bundle_1.as_dimensioned_thumbnail() }
   
   single_docx_bundle_1.as_pdf()
   


### PR DESCRIPTION
Closes #311. It uses an undocumented da function, `html_filter()` to get the html string we need. Not sure about the method name. You can open `test_aldocument.yml` to see it working on the first page. Just to make sure it's clear, to work, this has to hard-code the size of the thumbnail images.

I wanted to add `alt_text` as an argument too, but wasn't exactly sure how to make it work here. I needed a sensible default, but couldn't tell if it should be `None` or an empty string. We may want to think about alt text for our document displays, by the way.

I also considered having a `width_height_ratio` parameter or something, but wasn't sure how to implement that in a way that was clear. Thoughts appreciated.