### PR TITLE
Return `None` when a bundle has no enabled documents.

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1,7 +1,7 @@
 import re
 import os
 import mimetypes
-from typing import Any, Dict, List, Union, Callable
+from typing import Any, Dict, List, Union, Callable, Optional
 from docassemble.base.util import log, word, DADict, DAList, DAObject, DAFile, DAFileCollection, DAFileList, defined, value, pdf_concatenate, zip_file, DAOrderedDict, action_button_html, include_docx_template, user_logged_in, user_info, send_email, docx_concatenate, get_config, space_to_underscore, DAStaticFile, alpha
 
 __all__ = ['ALAddendumField',
@@ -774,7 +774,8 @@ class ALDocumentBundle(DAList):
     # Pre-cache some DALazyTemplates we set up to aid translation that won't
     # vary at runtime    
 
-  def as_pdf(self, key:str='final', refresh:bool=True) -> DAFile:
+  def as_pdf(self, key:str='final', refresh:bool=True) -> Optional[DAFile]:
+    """Returns the Bundle as a single PDF DAFile, or None if none of the documents are enabled."""
     safe_key = space_to_underscore(key)
 
     log_if_debug('Calling the as_pdf() method for bundle ' + str(self.title))

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -788,7 +788,10 @@ class ALDocumentBundle(DAList):
     else:
       ending = '.pdf'
     files = self.enabled_documents(refresh=refresh)
-    if len(files) == 1:
+    if len(files) == 0:
+      # In the case of no enabled files, avoid errors
+      return None
+    elif len(files) == 1:
       # This case is simplest--we do not need to process the document at this level
       log_if_debug(f'Storing bundle for just one document {self.title} at {self.instanceName}.cache.{safe_key}')
       pdf = files[0].as_pdf(key=key, refresh=refresh)

--- a/docassemble/AssemblyLine/data/sources/test_aldocument.feature
+++ b/docassemble/AssemblyLine/data/sources/test_aldocument.feature
@@ -43,4 +43,13 @@ Scenario: User adds only a docx exhibit
     | x[0].pages | test_alexhibit_docx_1.docx | exhibit_doc_defaults_1.exhibits.has_exhibits |
     | x[i].pages.target_number | 1 | exhibit_doc_defaults_1.exhibits[0].pages.there_is_another |
     | x.target_number | 1 | exhibit_doc_defaults_1.exhibits.there_is_another |
+
+@alexhibits @e3
+Scenario: User uploads 0 files
+  And the max seconds for each step is 200
+  Given I start the interview at "test_alexhibit"
+  And I get to "end alexhibit tests" with this data:
+    | var | value | trigger |
+    | x.has_exhibits | False | exhibit_doc_defaults_1.exhibits.has_exhibits |
+    | x.has_exhibits | False | exhibit_doc_custom_1.exhibits.has_exhibits |
     


### PR DESCRIPTION
How would a developer handle this situation? Maybe we should add that to the documentation. Closes #264