### PR TITLE
Adds all needed vars to exhibits tests

### DIFF
--- a/docassemble/AssemblyLine/data/sources/test_aldocument.feature
+++ b/docassemble/AssemblyLine/data/sources/test_aldocument.feature
@@ -31,6 +31,16 @@ Scenario: User can upload exhibits
     | x[i].pages | test_alexhibit_pdf_1.pdf | exhibit_doc_defaults_1.exhibits[1].title |
     | x[i].pages.target_number | 2 | exhibit_doc_defaults_1.exhibits[1].pages.there_is_another |
     | x[i].pages[j] | test_alexhibit_png_1.png | exhibit_doc_defaults_1.exhibits[1].pages[1] |
+    | x.has_exhibits | True | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[0].title | Defaults 1 | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[0].pages | test_alexhibit_docx_1.docx | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[i].pages.target_number | 2 | exhibit_doc_custom_1.exhibits[0].pages.there_is_another |
+    | x[i].pages[j] | test_alexhibit_jpg_1.jpg | exhibit_doc_custom_1.exhibits[0].pages[1] |
+    | x.target_number | 2 | exhibit_doc_custom_1.exhibits.there_is_another |
+    | x[i].title | Defaults 2 | exhibit_doc_custom_1.exhibits[1].title |
+    | x[i].pages | test_alexhibit_pdf_1.pdf | exhibit_doc_custom_1.exhibits[1].title |
+    | x[i].pages.target_number | 2 | exhibit_doc_custom_1.exhibits[1].pages.there_is_another |
+    | x[i].pages[j] | test_alexhibit_png_1.png | exhibit_doc_custom_1.exhibits[1].pages[1] |
 
 @alexhibits @e2
 Scenario: User adds only a docx exhibit
@@ -43,4 +53,9 @@ Scenario: User adds only a docx exhibit
     | x[0].pages | test_alexhibit_docx_1.docx | exhibit_doc_defaults_1.exhibits.has_exhibits |
     | x[i].pages.target_number | 1 | exhibit_doc_defaults_1.exhibits[0].pages.there_is_another |
     | x.target_number | 1 | exhibit_doc_defaults_1.exhibits.there_is_another |
+    | x.has_exhibits | True | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[0].title | DOCX only | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[0].pages | test_alexhibit_docx_1.docx | exhibit_doc_custom_1.exhibits.has_exhibits |
+    | x[i].pages.target_number | 1 | exhibit_doc_custom_1.exhibits[0].pages.there_is_another |
+    | x.target_number | 1 | exhibit_doc_custom_1.exhibits.there_is_another |
     


### PR DESCRIPTION
There's a kiln bug going on that's been letting these incomplete
tests pass. Because of the nature of the bug, the tests were,
strangely enough, doing what we wanted them to do anyway, but
this should prepare us for when that bug is fixed.