### PR TITLE
Take 2 of layout shift handling. Mimics and uses DAFile's .show()...

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Suffolk Legal Innovation and Technology Lab
+Copyright (c) 2022 Suffolk Legal Innovation and Technology Lab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -50,18 +50,13 @@ continue button field: as_foo_defaults
 question: |
   Get condensed bundle functions defaults
 subquestion: |
-
-  multi_bundle_1.as_dimensioned_thumbnail()
+  multi_bundle_1.show()
   
-  ${ multi_bundle_1.as_dimensioned_thumbnail() }
-
-  multi_bundle_1.as_dimensioned_thumbnail( width=400 )
+  ${ multi_bundle_1.show() }
   
-  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400 ) }
-
-  multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 )
+  multi_bundle_1.show( ratio=2/1 ). This should look the same after loading, but should cause layout shift.
   
-  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 ) }
+  ${ multi_bundle_1.show( ratio=2/1 ) }
   
   multi_bundle_1.as_pdf()
   
@@ -77,9 +72,9 @@ subquestion: |
   
   ---
 
-  single_pdf_bundle_1.as_dimensioned_thumbnail()
+  single_pdf_bundle_1.show()
   
-  ${ single_pdf_bundle_1.as_dimensioned_thumbnail() }
+  ${ single_pdf_bundle_1.show() }
   
   single_pdf_bundle_1.as_pdf()
   
@@ -95,9 +90,9 @@ subquestion: |
   
   ---
 
-  single_docx_bundle_1.as_dimensioned_thumbnail()
+  single_docx_bundle_1.show()
   
-  ${ single_docx_bundle_1.as_dimensioned_thumbnail() }
+  ${ single_docx_bundle_1.show() }
   
   single_docx_bundle_1.as_pdf()
   

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -50,6 +50,18 @@ continue button field: as_foo_defaults
 question: |
   Get condensed bundle functions defaults
 subquestion: |
+
+  multi_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail() }
+
+  multi_bundle_1.as_dimensioned_thumbnail( width=400 )
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400 ) }
+
+  multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 )
+  
+  ${ multi_bundle_1.as_dimensioned_thumbnail( width=400, height=100 ) }
   
   multi_bundle_1.as_pdf()
   
@@ -64,6 +76,10 @@ subquestion: |
   ${ multi_bundle_1.as_zip() }
   
   ---
+
+  single_pdf_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ single_pdf_bundle_1.as_dimensioned_thumbnail() }
   
   single_pdf_bundle_1.as_pdf()
   
@@ -78,6 +94,10 @@ subquestion: |
   ${ single_pdf_bundle_1.as_zip() }
   
   ---
+
+  single_docx_bundle_1.as_dimensioned_thumbnail()
+  
+  ${ single_docx_bundle_1.as_dimensioned_thumbnail() }
   
   single_docx_bundle_1.as_pdf()
   


### PR DESCRIPTION
[Edit: I've made a PR upstream, so it may be worth waiting for that to resolve.]

...behavior, so it may be more familiar to the developer in that way and otherwise handles ratio more directly. Most people probably won't have to mess with the nuts and bolts anyway.

Closes #311.

Still doesn't calculate the dimensions of the document itself. Haven't researched that yet and this is a decent MVP. An upstream update may or may not have to wait until we can get the dimensions of other filetypes as well.