### PR TITLE
Make review_all_sections handle partially gathered ALDocumentBundles

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -543,7 +543,7 @@ class ALDocument(DADict):
   
   def init(self, *pargs, **kwargs):
     super(ALDocument, self).init(*pargs, **kwargs)
-    self.initializeAttribute('overflow_fields',ALAddendumFieldDict)
+    self.initializeAttribute('overflow_fields', ALAddendumFieldDict)
     if not hasattr(self, 'default_overflow_message'):
       self.default_overflow_message = '...'
     if not hasattr(self, 'has_addendum'):
@@ -714,10 +714,6 @@ class ALStaticDocument(DAStaticFile):
   
   def as_pdf(self, key:str='final', refresh:bool=True) -> DAStaticFile:
     return pdf_concatenate(self)
-    if self._is_pdf():
-      return self
-    else:
-      return pdf_concatenate(self)
     
   def as_docx(self, key:str='final', refresh:bool=True) -> Union[DAStaticFile, DAFile]:
     """
@@ -765,14 +761,14 @@ class ALDocumentBundle(DAList):
 
   def init(self, *pargs, **kwargs):
     super().init(*pargs, **kwargs)
-    if not hasattr(self, 'auto_gather'):
-      self.auto_gather=False
-    if not hasattr(self, 'gathered'):
-      self.gathered=True
+    if 'auto_gather' not in kwargs:
+      self.auto_gather = False
+    if 'gathered' not in kwargs:
+      self.gathered = True
     self.initializeAttribute('cache', DALazyAttribute)
     self.always_enabled = hasattr(self, 'enabled') and self.enabled
     # Pre-cache some DALazyTemplates we set up to aid translation that won't
-    # vary at runtime    
+    # vary at runtime
 
   def as_pdf(self, key:str='final', refresh:bool=True) -> Optional[DAFile]:
     """Returns the Bundle as a single PDF DAFile, or None if none of the documents are enabled."""
@@ -803,6 +799,10 @@ class ALDocumentBundle(DAList):
     pdf.title = self.title
     setattr(self.cache, safe_key, pdf)
     return pdf
+
+  def __str__(self):
+    # Could be triggered in many different places unintenionally: don't refresh
+    return self.as_pdf(refresh=False)
 
   def as_zip(self, key:str = 'final', refresh:bool = True, title:str = '') -> DAFile:
     '''Returns a zip file containing the whole bundle'''

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -800,9 +800,9 @@ class ALDocumentBundle(DAList):
     setattr(self.cache, safe_key, pdf)
     return pdf
 
-  def __str__(self):
+  def __str__(self) -> str:
     # Could be triggered in many different places unintenionally: don't refresh
-    return self.as_pdf(refresh=False)
+    return str(self.as_pdf(refresh=False))
 
   def as_zip(self, key:str = 'final', refresh:bool = True, title:str = '') -> DAFile:
     '''Returns a zip file containing the whole bundle'''

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1239,7 +1239,7 @@ question: |
   Review of your answers
 subquestion: |
   
-  ${showifdef('al_court_bundle')}
+  ${showifdef("al_court_bundle.as_pdf(key='final')")}
 
   % if defined('form_delivery_complete'):
   **Warning: your form has already been delivered.** Any changes you make

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1516,3 +1516,8 @@ attachment:
   field code:
     exhibits: raw(x.exhibits)
     include_exhibit_cover_pages: raw(x.include_exhibit_cover_pages)
+---
+generic object: ALDocumentBundle
+code: |
+  x.there_is_another = False
+---

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1239,7 +1239,7 @@ question: |
   Review of your answers
 subquestion: |
   
-  ${showifdef("al_court_bundle.as_pdf(key='final')")}
+  ${showifdef('al_court_bundle')}
 
   % if defined('form_delivery_complete'):
   **Warning: your form has already been delivered.** Any changes you make


### PR DESCRIPTION
Fixes https://github.com/SuffolkLITLab/docassemble-MAHousingTRO/issues/12, which has been showing up in the live error reports for a while.

The issue was that it's using the [`review_all_sections` screen in `ql_baseline.yml`](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/blob/9c99a360e385846ec7a259bf7c391fe505b950fa/docassemble/AssemblyLine/data/questions/ql_baseline.yml#L1237-L1258). Due to [a bad refactor on my part](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/commit/f694d8157d9d3e116bf841d394e32ab1404754dc), the `al_court_bundle.__str__()` method was being triggered, using DAList's implementation of it, which would run `._trigger_gather()`.

This should have been avoided because [we already set `gathered=True` and `auto_gather=False`](https://github.com/SuffolkLITLab/docassemble-AssemblyLine/blob/9c99a360e385846ec7a259bf7c391fe505b950fa/docassemble/AssemblyLine/al_document.py#L771). However, we only do that if those attributes aren't present after initialization, and they are [set in the DAList constructor](https://github.com/jhpyle/docassemble/blob/cecd0cb1163718f508b3b43c134e8460e93b5609/docassemble_base/docassemble/base/util.py#L1319), so our code was never getting executed. Instead, we should set `auto_gather` and `gathered` base on the kwargs passed in or our defaults, not the DAList defaults.

Additionally, `showifdef` doesn't allow expressions that call functions at all, so we had to add our own `__str__` method as opposed to just displaying `as_pdf()` (`__str__` calls `as_pdf()` internally now).

Finally, to fix interview sessions with already running court bundles, I added a generic block that sets `there_is_another=False` for all `ALDocumentBundle`s. 