### PR TITLE
Add assembly_line.yml as an alias for al_package.yml

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_package.yml
+++ b/docassemble/AssemblyLine/data/questions/al_package.yml
@@ -1,3 +1,7 @@
+################
+# Deprecated as of 1/11/2022
+# When enough packages point to assembly_line.yml, this file should turn into an alias
+# that just includes assembly_line.yml
 ---
 include:
   - al_settings.yml

--- a/docassemble/AssemblyLine/data/questions/al_package.yml
+++ b/docassemble/AssemblyLine/data/questions/al_package.yml
@@ -1,34 +1,4 @@
-################
-# Deprecated as of 1/11/2022
-# When enough packages point to assembly_line.yml, this file should turn into an alias
-# that just includes assembly_line.yml
+# Deprecated; use assembly_line.yml instead
 ---
 include:
-  - al_settings.yml
-  - al_code.yml
-  - al_saved_sessions.yml  
-  - al_visual.yml
-  - al_document.yml
-  - ql_baseline.yml
----
-modules:
-  - docassemble.ALToolbox.misc
-  - docassemble.ALToolbox.copy_button
-  - .al_general
-  - .al_document
-  - .al_courts
-  - docassemble.GithubFeedbackForm.github_issue
----  
-#############################
-# Variables used in most interviews:
-# * trial_court
-# * all_courts
-# * allowed_courts
-
-###########################
-# Changes from MAVirtualCourt package
-# * renamed courts[0] trial_court
-# * added variable al_form_type: enum, "starts_case", "existing_case", "appeal", "letter", "out_of_court", "other"
-# * renamed user_role to user_started_case
-# * made courts an object, not list and renamed to trial_court; appellate courts should override
-# * replaced macourts variable with all_courts
+  - assembly_line.yml

--- a/docassemble/AssemblyLine/data/questions/al_package_unstyled.yml
+++ b/docassemble/AssemblyLine/data/questions/al_package_unstyled.yml
@@ -1,20 +1,4 @@
-comment: |
-  The purpose of this YAML file is to allow you to make use of all of the Assembly
-  Line standard questions, etc. with one include, but eliminate all code that 
-  changes the visual appearance of your interview.
+# DEPRECATED - use assembly_line_unstyled instead
 ---
 include:
-  - ql_baseline.yml
-  - al_settings.yml
-  - al_code.yml
-  - al_saved_sessions.yml  
-  - al_document.yml
----
-modules:
-  - docassemble.ALToolbox.misc
-  - docassemble.ALToolbox.copy_button
-  - .al_general
-  - .al_document
-  - .al_courts
-  - docassemble.GithubFeedbackForm.github_issue
-  
+  - assembly_line_unstyled.yml

--- a/docassemble/AssemblyLine/data/questions/assembly_line.yml
+++ b/docassemble/AssemblyLine/data/questions/assembly_line.yml
@@ -1,7 +1,18 @@
-################
-# This was added on 1/11/2022
-# When enough packages point to this file instead of al_package.yml, we should change the
-# include order so this one is the main file instead of the alias
+# For usage, see https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/framework/magic_variables
 ---
 include:
-  - al_package.yml  
+  - al_settings.yml
+  - al_code.yml
+  - al_saved_sessions.yml  
+  - al_visual.yml
+  - al_document.yml
+  - ql_baseline.yml
+---
+modules:
+  - docassemble.ALToolbox.misc
+  - docassemble.ALToolbox.copy_button
+  - .al_general
+  - .al_document
+  - .al_courts
+  - docassemble.GithubFeedbackForm.github_issue
+  

--- a/docassemble/AssemblyLine/data/questions/assembly_line.yml
+++ b/docassemble/AssemblyLine/data/questions/assembly_line.yml
@@ -1,0 +1,7 @@
+################
+# This was added on 1/11/2022
+# When enough packages point to this file instead of al_package.yml, we should change the
+# include order so this one is the main file instead of the alias
+---
+include:
+  - al_package.yml  

--- a/docassemble/AssemblyLine/data/questions/assembly_line_unstyled.yml
+++ b/docassemble/AssemblyLine/data/questions/assembly_line_unstyled.yml
@@ -1,0 +1,20 @@
+comment: |
+  The purpose of this YAML file is to allow you to make use of all of the Assembly
+  Line standard questions, etc. with one include, but eliminate all code that 
+  changes the visual appearance of your interview.
+---
+include:
+  - ql_baseline.yml
+  - al_settings.yml
+  - al_code.yml
+  - al_saved_sessions.yml  
+  - al_document.yml
+---
+modules:
+  - docassemble.ALToolbox.misc
+  - docassemble.ALToolbox.copy_button
+  - .al_general
+  - .al_document
+  - .al_courts
+  - docassemble.GithubFeedbackForm.github_issue
+  


### PR DESCRIPTION
Fix #38 

Don't think there are any other changes to the file layout that we have come up with in the last 12 months. This is an easy one that does help make the API for using AssemblyLine in your interview a little bit easier to follow.