### PR TITLE
Mypy changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,14 @@ downloads_*
 *_report_*
 _al_test_project_name.json
 .history
+
+# Python related
 __pycache__/
 docassemble.AssemblyLine.egg-info/*
+**/*.pyi
+.mypy_cache/**
+**/.mypy_cache/**
+dist/**
+
+# IDE related
+.vscode/**

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -11,6 +11,7 @@ import re
 #import usaddress
 #from uszipcode import SearchEngine
 #from collections.abc import Iterable
+from typing import Any, Dict, List, Optional
 
 class ALCourt(Court):
     """Object representing a court in Massachusetts.
@@ -26,10 +27,10 @@ class ALCourt(Court):
         if 'location' not in kwargs:
             self.initializeAttribute('location', LatitudeLongitude)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.name)
       
-    def _map_info(self)->str:
+    def _map_info(self)->List[Dict[str, Any]]:
         the_info = str(self.name)
         the_info += "  [NEWLINE]  " + self.address.block()
         result = {'latitude': self.location.latitude, 'longitude': self.location.longitude, 'info': the_info}
@@ -136,7 +137,7 @@ class ALCourtLoader(DAObject):
   def all_courts(self)->list:
     return self.filter_courts(None)
   
-  def filter_courts(self, court_types: list, column='department')->list:
+  def filter_courts(self, court_types: Optional[List], column='department')->list:
     """
     Return a subset of courts, only the name column and index. 
     

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -1,16 +1,11 @@
-#####################################
-# Package for a very simple / MVP list of courts that is mostly signature compatible w/ MACourts for now
+"""
+Package for a very simple / MVP list of courts that is mostly signature compatible w/ MACourts for now
+"""
 
-from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, DAStaticFile, markdown_to_html, prevent_dependency_satisfaction, DAObject, DAList, DADict, log, space_to_underscore
+from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, DAObject, log, space_to_underscore
 from docassemble.base.legal import Court
 import pandas as pd
 import os
-import re
-#import io, json, sys, requests, bs4, re, os
-# from docassemble.webapp.playground import PlaygroundSection
-#import usaddress
-#from uszipcode import SearchEngine
-#from collections.abc import Iterable
 from typing import Any, Dict, List, Optional
 
 class ALCourt(Court):
@@ -52,7 +47,7 @@ class ALCourt(Court):
         else:
           return str(self.name) + ' (' + self.address.city + ')'
       else:
-        return str( self.name )
+        return str(self.name)
     
     def short_label_and_address(self)->str:
       """

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -713,7 +713,7 @@ class ALStaticDocument(DAStaticFile):
     return self
   
   def as_list(self, key:str='final', refresh:bool=True) -> List[DAStaticFile]:
-    return [self[key]]
+    return [self]
   
   def as_pdf(self, key:str='final', refresh:bool=True) -> DAStaticFile:
     return pdf_concatenate(self)

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Union
-from docassemble.base.util import Address, Individual, DAList, date_difference, name_suffix, states_list, comma_and_list, word, comma_list, url_action, get_config, phone_number_is_valid, validation_error, DAWeb, get_config, as_datetime, DADateTime, subdivision_type
+from docassemble.base.util import Address, Individual, DAList, date_difference, name_suffix, comma_and_list, word, comma_list, url_action, get_config, phone_number_is_valid, validation_error, DAWeb, get_config, as_datetime, DADateTime, subdivision_type
 from docassemble.base.functions import DANav
 import re
 

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -170,7 +170,7 @@ class ALIndividual(Individual):
     # TODO: move to 209A package
     """If the Individual has a child_letters attribute, add the new letters to the existing list"""
     if hasattr(self, 'child_letters'):
-      self.child_letters = filter_letters([new_letters, self.child_letters])
+      self.child_letters:str = filter_letters([new_letters, self.child_letters])
     else:
       self.child_letters = filter_letters(new_letters)
 


### PR DESCRIPTION
I've been slowing adding more python type annotations to AL, and checking them using mypy. It's caught a few poorly-defined behaviors, particularly in the python modules. It's hard to say if mypy would be useful for the interview YAMLs, but it's flexible enough to be useful for module files now.

Some of the examples of issues found by mypy:
* missing returns. Makes use add `Optional[ReturnVal]` where necessary
* making you have the same named arguments on subclass methods: otherwise, the defaults can't be expected to be the same (debatable if it applies to us, but good practice probably)
* different return types. The only one that I didn't correct was the fact that `ALExhibitDocument.al_list` says it returns a `List[DAFile]`, but it really returns a `List[ALExhibitDocument]`, and I'm not sure if that's intended behavior or the typing is wrong (if it is, the method should be renamed: it's overriding ALDocument.as_list, which is supposed to return a list of DAFiles).


## The mypy process

If you're developing locally, you should have a pip venv already. Install mypy in it `pip install mypy` and install the pandas stubs `pip install pandas-stubs`.  In a different directory, generate stubs for docassemble (`stubgen docassemble_base/docassemble/base/util.py`, and the other modules as needed). Move those stubs to the `base` directory under `docassemble` in AssemblyLine (be sure to add an empty init file (`touch __init__.pyi`)). Then simply run `mypy al_general.py`, etc. The docassmble packages still have some errors, you can ignore those for now.