### PR TITLE
Add questions for `previous_addresses` and `other_addresses`

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -14,12 +14,13 @@ from docassemble.base.util import (
     validation_error,
     DAWeb,
     get_config,
+    get_country, 
+    country_name,
     as_datetime,
     DADateTime,
     subdivision_type,
     this_thread,
 )
-from docassemble.base.functions import DANav
 import re
 
 __all__ = [
@@ -178,7 +179,7 @@ class ALAddress(Address):
             elif hasattr(self, "postal_code") and self.postal_code:
                 i18n_address["postal_code"] = str(self.postal_code)
             i18n_address["country_code"] = self._get_country()
-            return i18naddress.format_address(i18n_address).replace("\n", line_breaker)
+            return i18n_address.format_address(i18n_address).replace("\n", line_breaker)
         output = ""
         if self.city_only is False:
             if (
@@ -663,7 +664,7 @@ class ALIndividual(Individual):
         )
 
 
-def section_links(nav: DANav) -> List[str]:
+def section_links(nav) -> List[str]:
     """Returns a list of clickable navigation links without animation."""
     sections = nav.get_sections()
     section_link = []

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -773,6 +773,80 @@ fields:
   - code: |
       x.address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
 ---
+generic object: ALIndividual
+id: x has other addresses
+question: |
+  Does ${ x } live at more than one address?
+fields:  
+  - ${ x } lives at more than one address: x.other_addresses.there_are_any
+    datatype: yesnoradio
+---
+generic object: ALIndividual
+sets:
+  - x.other_addresses[i].address
+  - x.other_addresses[i].city
+id: other address where x lives
+question: |
+  Tell us about the ${ordinal(i)} other address where ${ x } lives
+subquestion: |
+  You already told us about ${x.address.on_one_line()}
+  % if len(x.other_addresses.complete_elements()):
+  as well as ${x.other_addresses.complete_elements()}
+  % endif
+fields:
+  - code: |
+      x.other_addresses[i].address_fields(default_state=AL_DEFAULT_STATE)
+---
+generic object: ALIndividual
+id: x has another other address
+question: |
+  Does ${ x } have any other address where they currently live to tell us about?
+subquestion: |
+  You already told us about ${ x.address.on_one_line() }
+  % if len(x.other_addresses.complete_elements()):
+  as well as ${x.other_addresses.complete_elements()}
+  % endif
+fields:
+  - Does ${ x } have another address?: x.other_addresses.there_is_another  
+    datatype: yesnoradio
+---
+generic object: ALIndividual
+id: x has previous addresses
+question: |
+  Does ${ x } have any previous addresses?
+fields:  
+  - ${ x } has a previous address to list: x.previous_addresses.there_are_any
+    datatype: yesnoradio
+---
+generic object: ALIndividual
+sets:
+  - x.previous_addresses[i].address
+  - x.previous_addresses[i].city
+id: other previous address where x lives
+question: |
+  Tell us about the ${ordinal(i)} address where ${ x } used to live
+subquestion: |
+  You already told us about ${x.address.on_one_line()}
+  % if len(x.previous_addresses.complete_elements()):
+  as well as ${x.previous_addresses.complete_elements()}
+  % endif
+fields:
+  - code: |
+      x.previous_addresses[i].address_fields(default_state=AL_DEFAULT_STATE)
+---
+generic object: ALIndividual
+id: has another previous address
+question: |
+  Does ${ x } have any other address where they used to live to tell us about?
+subquestion: |
+  You already told us about ${ x.address.on_one_line() }
+  % if len(x.previous_addresses.complete_elements()):
+  as well as ${x.previous_addresses.complete_elements()}
+  % endif
+fields:
+  - Does ${ x } have another address where they used to live?: x.previous_addresses.there_is_another  
+    datatype: yesnoradio
+---
 id: persons contact information
 generic object: ALIndividual
 question: |

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -847,6 +847,75 @@ fields:
   - Does ${ x } have another address where they used to live?: x.previous_addresses.there_is_another  
     datatype: yesnoradio
 ---
+id: user has other addresses
+question: |
+  Do you live at more than one address?
+fields:  
+  - I live at more than one address: users[0].other_addresses.there_are_any
+    datatype: yesnoradio
+---
+sets:
+  - users[0].other_addresses[i].address
+  - users[0].other_addresses[i].city
+id: other address where user lives
+question: |
+  Tell us about the ${ordinal(i)} other address where you live
+subquestion: |
+  You already told us about ${users[0].address.on_one_line()}
+  % if len(users[0].other_addresses.complete_elements()):
+  as well as ${users[0].other_addresses.complete_elements()}
+  % endif
+fields:
+  - code: |
+      users[0].other_addresses[i].address_fields(default_state=AL_DEFAULT_STATE)
+---
+id: user has another other address
+question: |
+  Do you have any other address where you currently live to tell us about?
+subquestion: |
+  You already told us about ${ users[0].address.on_one_line() }
+  % if len(users[0].other_addresses.complete_elements()):
+  as well as ${users[0].other_addresses.complete_elements()}
+  % endif
+fields:
+  - Do you have another address?: users[0].other_addresses.there_is_another  
+    datatype: yesnoradio
+---
+id: user has previous addresses
+question: |
+  Do you have any addresses where you used to live?
+fields:  
+  - I have a previous address to list: users[0].previous_addresses.there_are_any
+    datatype: yesnoradio
+---
+sets:
+  - users[0].previous_addresses[i].address
+  - users[0].previous_addresses[i].city
+id: other previous address where user lives
+question: |
+  Tell us about the ${ordinal(i)} address where you used to live
+subquestion: |
+  You already told us about ${users[0].address.on_one_line()}
+  % if len(users[0].previous_addresses.complete_elements()):
+  as well as ${users[0].previous_addresses.complete_elements()}
+  % endif
+fields:
+  - code: |
+      users[0].previous_addresses[i].address_fields(default_state=AL_DEFAULT_STATE)
+---
+generic object: ALIndividual
+id: has another previous address
+question: |
+  Do you have any other address where you used to live to tell us about?
+subquestion: |
+  You already told us about ${ users[0].address.on_one_line() }
+  % if len(users[0].previous_addresses.complete_elements()):
+  as well as ${users[0].previous_addresses.complete_elements()}
+  % endif
+fields:
+  - Do you have another address where you used to live?: users[0].previous_addresses.there_is_another  
+    datatype: yesnoradio
+---
 id: persons contact information
 generic object: ALIndividual
 question: |


### PR DESCRIPTION
ALIndividuals have a `previous_addresses` and `other_addresses` attribute but there was no reasonable question to provide a definition. This adds one so it's a little better than the generic object question for an ALAddress.

These questions are copied in from the 209A.

Test interview:

```yaml
---
include:
  - assembly_line.yml
---
objects:
  - mailman: ALIndividual
---
mandatory: True
question: |
subquestion: |
  Your current address is ${ users[0].address.on_one_line() }
  
  Your mailing address is ${ users[0].mailing_address }
  
  Your other addresses are ${ users[0].other_addresses }

  Your previous addresses are ${ users[0].previous_addresses }
  
  Addresses for your Mailman:
  
  Mailman current address is ${ mailman.address.on_one_line() }
  
  Mailman mailing address is ${ mailman.mailing_address }
  
  Mailman other addresses are ${ mailman.other_addresses }

  Mailman previous addresses are ${ mailman.previous_addresses }  
```