### PR TITLE
Add `full_names` method to ALPeopleList class

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -330,6 +330,14 @@ class ALPeopleList(DAList):
             return comma_and_list(self[:limit]) + truncate_string
         else:
             return comma_and_list(self)
+  
+    def full_names(self, comma_string=', ', and_string=word("and")):
+        """
+        Return a formatted list of names in the PeopleList, without shortening middle name to an initial.
+        Optional parameters `comma_string` and `and_string` will be passed to `comma_and_list` and allow
+        you to change the list separator and the word before the final list item, respectively.
+        """
+        return comma_and_list([person.name.full(middle="full") for person in self], comma_string=comma_string, and_string=and_string)
 
 
 class ALIndividual(Individual):


### PR DESCRIPTION
Fix #388 

Per request from @mnewsted, this method allows you to print the names in an ALPeopleList without shortening middle names to an initial.

Short test YAML:

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
question: |
  ${ children.full_names(and_string="or", comma_string="; ") }
```