### PR TITLE
Allow setting of logo titles more flexibly. Discussion needed.

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -14,8 +14,19 @@ code: |
 code: |
   AL_DEFAULT_STATE = "MA"
 ---
+# Allow flexible customization of header logo titles
 code: |
-  interview_short_title = "AL Question Test"
+  AL_LOGO_TITLE_ROW_1 = "Title Row 1"
+---
+code: |
+  AL_LOGO_TITLE_ROW_2 = "Title Row 2"
+---
+# Allow flexible customization of header logo short titles
+code: |
+  AL_LOGO_SHORT_TITLE_ROW_1 = "Short Row 1"
+---
+code: |
+  AL_LOGO_SHORT_TITLE_ROW_2 = "Short Row 2"
 ---
 metadata:
   title: |

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -17,18 +17,18 @@ default screen parts:
         <img src="${ al_logo.url_for() }"/>
       </div>
       <div class="al-title">
-        <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>
-        <div class="title-row-2">${all_variables(special='metadata').get('title','').rstrip()}</div>
+        <div class="title-row-1">${ AL_LOGO_TITLE_ROW_1 }</div>
+        <div class="title-row-2">${ AL_LOGO_TITLE_ROW_2 }</div>
       </div>
-    </div> 
+    </div>
   short logo: |
     <div class="title-container">
       <div class="al-logo">
         <img src="${ al_logo.url_for() }"/>
       </div>
       <div class="al-title">
-        <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>
-        <div class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</div>
+        <div class="title-row-1">${ AL_LOGO_SHORT_TITLE_ROW_1 }</div>
+        <div class="title-row-2">${ AL_LOGO_SHORT_TITLE_ROW_2 }</div>
       </div>
     </div>   
   continue button label: |
@@ -79,6 +79,20 @@ code: |
     "label": "Start over"
     },
   ]
+---
+# Allow flexible customization of header logo titles
+code: |
+  AL_LOGO_TITLE_ROW_1 = AL_ORGANIZATION_TITLE
+---
+code: |
+  AL_LOGO_TITLE_ROW_2 = all_variables(special='metadata').get('title','').rstrip()
+---
+# Allow flexible customization of header logo short titles
+code: |
+  AL_LOGO_SHORT_TITLE_ROW_1 = AL_ORGANIZATION_TITLE
+---
+code: |
+  AL_LOGO_SHORT_TITLE_ROW_2 = all_variables(special='metadata').get('short title','').rstrip()
 ---
 event: al_start_over
 code: |


### PR DESCRIPTION
If we want to adopt these changes, this could take care of one of our user's recently expressed needs. i.e. For the text next to the logo in the header bar, allow them to switch which item appears in which row. Currently it's locked into org name above title or short title. This PR creates variables specifically for those positions in the header.

Not sure we want this much flexibility or abstraction, but it was easy to do so I figured I'd offer it. Feel free to close if it doesn't fall within our mission. Or feel free to edit if that's more useful.

I considered making them `template`s, but I don't see a reason for them to update those mid-stream.