### PR TITLE
Allow someone to add multiple pages to the *second*+ exhibit document in ALExhibit model questions

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1527,8 +1527,7 @@ validation code: |
     pdf_concatenate(x[i].pages)
   except:
     validation_error("Unable to convert this file. Please upload a new one.", field="x[i].pages")
-  if defined('x[i].pages'):    
-    x[i].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
+  x[i].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
 generic object: ALExhibitList
 id: exhibit i has additional pages


### PR DESCRIPTION
Fixes bug in the existing ALExhibit questions where you are currently only prompted to add additional pages for the first exhibit.