### PR TITLE
Add additional safety to as_editable_list() method of ALDocumentBundle

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,21 @@
+name: Run python only unit tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test-assemblyline:
+    runs-on: ubuntu-latest
+    name: Run python only unit tests
+    env:
+      ISUNITTEST: true
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
+      - name: Check
+        uses: actions/checkout@v2
+      - run: pip install virtualenv
+      - run: virtualenv -p python3.8 venv
+      - run: venv/bin/pip install -r docassemble/ALWeaver/requirements.txt
+      - run: venv/bin/pip install --editable .
+      - run: venv/bin/python3 -m unittest discover

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/checkout@v2
       - run: pip install virtualenv
       - run: virtualenv -p python3.8 venv
-      - run: venv/bin/pip install -r docassemble/ALWeaver/requirements.txt
+      - run: venv/bin/pip install -r docassemble/AssemblyLine/requirements.txt
       - run: venv/bin/pip install --editable .
       - run: venv/bin/python3 -m unittest discover

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1031,17 +1031,33 @@ class ALDocumentBundle(DAList):
             for doc in self.enabled_documents(refresh=refresh)
         ]
 
+    def as_docx_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
+        """
+        Returns the nested bundles as a list of DOCX files. If the file isn't able
+        to be represented as a DOCX, the original file or a PDF will be returned instead.
+        """
+        return [
+            doc.as_docx(key=key, refresh=refresh)
+            for doc in self.enabled_documents(refresh=refresh)
+        ]        
+        
     def as_editable_list(
         self, key: str = "final", refresh: bool = True
     ) -> List[DAFile]:
         """
-        Return a flat list of the editable versions of the docs in this bundle.
-        Not yet tested with editable PDFs.
+        Return a flat list of the DOCX versions of the docs in this bundle, if they exist.
         """
         docs = self.as_flat_list(key=key, refresh=refresh)
         editable = []
         for doc in docs:
-            editable.append(doc.docx if hasattr(doc, "docx") else doc.pdf)
+            if hasattr(doc, 'docx'):
+              editable.append(doc.docx)
+            elif hasattr(doc, 'rtf'):
+              editable.append(doc.rtf)
+            else:
+              # The whole DAFile should still be appendable
+              # for custom filetypes like PNG, etc.
+              editable.append(doc)
         return editable
 
     def download_list_html(

--- a/docassemble/AssemblyLine/requirements.txt
+++ b/docassemble/AssemblyLine/requirements.txt
@@ -1,0 +1,2 @@
+docassemble.base>=1.3
+docassemble.webapp

--- a/docassemble/AssemblyLine/test_al_document.py
+++ b/docassemble/AssemblyLine/test_al_document.py
@@ -1,0 +1,17 @@
+import unittest
+from docassemble.base.util import DAFile
+from .al_document import ALDocument, ALDocumentBundle
+
+class test_dont_assume_pdf(unittest.TestCase):
+  def test_upload_pdf(self):
+    doc1 = ALDocument("doc1", title="PDF 1", filename="pdf_doc_1", enabled=True, has_addendum=False)
+    doc1["final"] = DAFile("test_aldocument_pdf_1.pdf")
+    doc2 = ALDocument("doc2", title="DOCX 2", filename="docx_doc_1", enabled=True, has_addendum=False)
+    doc2["final"] = DAFile("test_aldocument_docx_1.docx")
+    al_doc_bundle = ALDocumentBundle("al_doc_bundle", elements=[doc1, doc2], title="Multiple docs", filename="multi_bundle_1", enabled=True)
+    new_list = al_doc_bundle.as_editable_list()
+    self.assertEqual(len(new_list), 2)
+    pass
+
+if __name__ == '__main__':
+  unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.3.6', 'docassemble.GithubFeedbackForm>=0.1.3'],
+      install_requires=['docassemble.ALToolbox>=0.4.0', 'docassemble.GithubFeedbackForm>=0.1.3'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
Fix #426

Don't assume that if a document isn't a DOCX there is a PDF version of it--instead, check and return the closest thing to an "editable" document that we can for the given file.

Also added a semantically equivalent as_docx_list() method that mirrors as_pdf_list and will call the generally safe as_docx() method for each file in the bundle instead of directly referencing the .docx or .pdf attribute. Adding this as a separate method in case someone was relying on the behavior of as_editable_list.