### PR TITLE
Add ALDocumentUpload class to allow adding a simple uploaded file to an ALDocumentBundle

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -43,6 +43,7 @@ __all__ = [
     "ALTableDocument",
     "ALUntransformedDocument",
     "unpack_dafilelist",
+    "ALDocumentUpload",
 ]
 
 DEBUG_MODE = get_config("debug")
@@ -1351,9 +1352,8 @@ class ALDocumentBundleDict(DADict):
         """
         Return a list of PDF-ified documents, suitable to make an attachment to send_mail.
         """
-        return self[bundle].as_pdf_list(key="final")
-
-
+        return self[bundle].as_pdf_list(key="final")  
+      
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
     Atributes:
@@ -1679,9 +1679,22 @@ class ALUntransformedDocument(ALDocument):
         return self[key]
 
     def as_docx(self, key: str = "final", refresh: bool = True, **kwargs) -> DAFile:
-        return self.as_pdf(key, refresh, **kwargs)
+        return self[key]
 
-
+      
+class ALDocumentUpload(ALUntransformedDocument):
+    """
+    Simplified class to handle uploaded documents, without any of the complexity of the 
+    ALExhibitDocument class.
+    """
+    def __getitem__(self, key):
+        # This overrides the .get() method so that the 'final' and 'private' key always exist and
+        # point to the same file.
+        # There's no need to have final/preview versions of an uploaded document
+        if isinstance(self.file, DAFileList):
+            self.file = unpack_dafilelist(self.file)
+        return self.file
+      
 def unpack_dafilelist(the_file: DAFileList) -> DAFile:
     """Creates a plain DAFile out of the first item in a DAFileList
     Args:
@@ -1697,3 +1710,6 @@ def unpack_dafilelist(the_file: DAFileList) -> DAFile:
         return inner_file
     else:
         return the_file
+
+      
+      

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1670,3 +1670,20 @@ generic object: ALDocumentBundle
 code: |
   x.there_is_another = False
 ---
+################################### ALDocumentUpload questions #############################
+---
+generic object: ALDocumentUpload
+id: Upload a document for a bundle that will not be transformed
+question: |
+  ${ x.title.capitalize() }
+fields:
+  - I do not have a ${ x.title }: x.has_no_file
+    datatype: yesno
+  - Upload the ${ x.title } below: x.file
+    datatype: file
+    label above field: True
+    hide if: x.has_no_file
+---
+generic object: ALDocumentUpload
+code: |
+  x.enabled = not x.has_no_file

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -28,13 +28,14 @@ code: |
 ---
 objects:
   # No addenda, all start enabled
-  - multi_bundle_1: ALDocumentBundle.using(elements=[pdf_1, docx_1], title="Multiple docs 1", filename="multi_bundle_1" )
+  - multi_bundle_1: ALDocumentBundle.using(elements=[pdf_1, docx_1, notice_to_quit], title="Multiple docs 1", filename="multi_bundle_1" )
   - single_pdf_bundle_1: ALDocumentBundle.using(elements=[pdf_1], title="One pdf", filename="single_pdf_1" )
   - single_docx_bundle_1: ALDocumentBundle.using(elements=[docx_1], title="One docx", filename="single_docx_1" )
 ---
 objects:
   - pdf_1: ALDocument.using( title="PDF 1", filename="pdf_doc_1", enabled=True, has_addendum=False )
   - docx_1: ALDocument.using( title="Docx 1", filename="docx_doc_1", enabled=True, has_addendum=False )
+  - notice_to_quit: ALDocumentUpload.using(title="Notice to Quit", filename="notice_to_quit")
 ---
 attachment: 
   variable name: pdf_1[i]


### PR DESCRIPTION
Fix #427 

Limitations:
- The ALDocumentUpload can only contain one DAFile