### PR TITLE
Add a default gender of a business

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1670,3 +1670,8 @@ generic object: ALDocumentBundle
 code: |
   x.there_is_another = False
 ---
+generic object: ALIndividual
+code: |
+  # Set a default gender of a business to aid in methods like pronoun_possessive
+  if x.person_type == "business":
+    x.gender = "other"


### PR DESCRIPTION
Fix #423 

This will fix methods like `pronoun_possessive` if the person selected "business" on the screen that asks "Is this a business, or a person?"

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
code: |
  other_parties.gather()
---
mandatory: True
question: |
  ${ other_parties[0].pronoun_possessive("apple") }
```