### PR TITLE
Update `plaintiffs`, `defendants` etc. when user changes answer to `user_ask_role`

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -133,6 +133,8 @@ content: |
   If you are responding to a case or court papers someone else filed, you
   are the "Defendant" or the "Respondent."
 ---
+depends on:
+  - user_started_case
 code: |
   if user_started_case:
     plaintiffs = users
@@ -145,6 +147,8 @@ code: |
     plaintiffs = other_parties
     petitioners = other_parties
 ---
+depends on:
+  - user_ask_role
 code: |
   # If the interview author didn't specify and it's a "court" or "other" case, we just ask
   user_started_case = user_ask_role == 'plaintiff'


### PR DESCRIPTION
Fix #200 

This will let someone modify their answer to whether or not they started the case.