### PR TITLE
Fix the `key` function to return key of first dictionary item instead of value of first dictionary item

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -49,15 +49,21 @@ DEBUG_MODE = get_config("debug")
 
 
 def label(dictionary):
+    """Given a dictionary like: {"some_attribute":"Some label"}, return the `value` of the first dictionary item.
+    Useful for working with the `columns` method of an ALAddendumField.
+    """
     try:
-        return list(dictionary.items())[0][1]
+        return next(iter(dictionary.values()),"")
     except:
         return ""
 
 
 def key(dictionary):
+    """Given a dictionary like: {"some_attribute":"Some label"}, return the `key` of the first dictionary item.
+    Useful for working with the `columns` method of an ALAddendumField.
+    """  
     try:
-        return list(dictionary.items())[0][1]
+        return next(iter(dictionary.keys()),"")
     except:
         return ""
 


### PR DESCRIPTION
Fix #338

This is a subtle mistake that will only appear when:

1. Someone uses the ALAddendum class
2. They use our stock ALAddendum DOCX template, or one based off of it
3. They customize the `headers` attribute and the existing attribute names are not descriptive

In most circumstances, someone likely used a custom addendum file or didn't know to set the `headers` attribute.

I also took the chance to refactor the code so it uses `next(` rather than creating a full list of dictionary items.