### PR TITLE
More convenient place to customize `auto_labeler` in the ALExhibitDocument class

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1448,7 +1448,7 @@ class ALExhibitList(DAList):
             auto_labeler = self.auto_labeler
 
         for index, exhibit in enumerate(self.elements):
-            exhibit.label = self.auto_labeler(index)
+            exhibit.label = auto_labeler(index)
 
     def ocr_ready(self) -> bool:
         """
@@ -1513,6 +1513,7 @@ class ALExhibitDocument(ALDocument):
         include_exhibit_cover_pages (bool): flag to control whether cover pages are included with each separate exhibit
         add_page_numbers (bool): Flag that controls whether the as_pdf() method
           also will add Bates-stamp style page numbers and labels on each page.
+        auto_labeler (callable): a Lambda or Python function that will be used to label exhibits.          
 
     Todo:
         * Method of making a safe link in place of the attachment (e.g., filesize limits on email)
@@ -1531,11 +1532,20 @@ class ALExhibitDocument(ALDocument):
     objects:
       - al_user_bundle: ALDocumentBundle.using(elements=[my_instructions, my_main_attachment, exhibit_attachment], filename="user_bundle.pdf", title="All forms to download for your records")
     ```
+    
+    Example of using a custom label function, https://docassemble.org/docs/functions.html#item_label:
+    ```
+    ---
+    objects:
+      - exhibit_attachment: ALExhibitDocument.using(title="Exhibits", filename="exhibits" , auto_labeler=item_label)
+    ```    
     """
 
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.initializeAttribute("exhibits", ALExhibitList)
+        if hasattr(self, "auto_labeler"):
+            self.exhibits.auto_labeler = self.auto_labeler
         if not hasattr(self, "include_table_of_contents"):
             self.include_table_of_contents = True
         if not hasattr(self, "include_exhibit_cover_pages"):


### PR DESCRIPTION
A little esoteric, but when you use the ALExhibitDocument class, it defaults to giving each exhibit a cover page like `A`, `B`, etc. The `auto_labeler` attribute lets you override this function to use a different function that takes a list index and returns a suitable sequential label, like [item_label](https://docassemble.org/docs/functions.html#item_label).

This PR just makes it easier to specify the `auto_labeler` attribute when you create an ALExhibitDocument object. Specifically, you can now do it in the `objects` block.

Fix #394

Also spotted a bug in the _update_labels() method.