### PR TITLE
Speak text fixes

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -43,7 +43,7 @@ code: |
   # Set some variables that we need in all the interviews
   multi_user = True
   allow_cron = True
-  speak_text = config('voicerss').get('enable', False)
+  speak_text = get_config('voicerss').get('enable', False)
   set_live_help_status(availability='available', mode='help',partner_roles=['housing','family law'])
 ---
 code: |

--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -43,7 +43,7 @@ code: |
   # Set some variables that we need in all the interviews
   multi_user = True
   allow_cron = True
-  speak_text = True
+  speak_text = config('voicerss').get('enable', False)
   set_live_help_status(availability='available', mode='help',partner_roles=['housing','family law'])
 ---
 code: |

--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -43,7 +43,7 @@ code: |
   # Set some variables that we need in all the interviews
   multi_user = True
   allow_cron = True
-  speak_text = get_config('voicerss').get('enable', False)
+  speak_text = get_config('voicerss', {}).get('enable', False)
   set_live_help_status(availability='available', mode='help',partner_roles=['housing','family law'])
 ---
 code: |

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -10,7 +10,7 @@ $(document).on('daPageLoad', function() {
       al_js.replace_with_audio_minimal_controls( audio_node, 'page_reader_substitute_' + id_count );
       id_count++;
     }
-  } catch ( error ) { console.log( 'AL audio intantiation error:', error ) }
+  } catch ( error ) { console.log( 'AL audio instantiation error:', error ) }
 });
 
 // We are not providing a way to rewind or scan through the audio.


### PR DESCRIPTION
Quick fix I realized testing on a local docassemble server: we still turn on `speak_text`, even if voiceRSS isn't setup on the server. Given that the [DA docs on speak_text](https://docassemble.org/docs/special.html#speak_text) say that speak text just won't work without voicerss being turned on.

I've tested locally, and the speak text doesn't turn on unless you enable it in `voicerss['enable']` in the config, so it doesn't turn on broken speak text on my local server, but still works correctly on the Dev server.