### PR TITLE
Making our theme accessible

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,6 +1,6 @@
 ---
 objects:
-  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
+  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Assembly Line Logo")
 ---
 default screen parts:
   title: |

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,6 +1,6 @@
 ---
 objects:
-  - al_logo: DAStaticFile.using(filename="ma_logo.png")
+  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
 ---
 default screen parts:
   title: |

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -14,7 +14,7 @@ default screen parts:
   logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="${ al_logo.url_for() }"/>
+        <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
       </div>
       <div class="al-title">
         <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>
@@ -24,7 +24,7 @@ default screen parts:
   short logo: |
     <div class="title-container">
       <div class="al-logo">
-        <img src="${ al_logo.url_for() }"/>
+        <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
       </div>
       <div class="al-title">
         <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -98,7 +98,7 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
 
 // The DOM structure for every AL audio element with custom controls
 var audio_contents_html = '\
-  <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="play" value="play">\
+  <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="Listen" value="play">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Play&nbsp;</span>\
     <i class="fas fa-play"></i>\
   </button>\

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -99,15 +99,15 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
 // The DOM structure for every AL audio element with custom controls
 var audio_contents_html = '\
   <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="play" value="play">\
-    <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
+    <i class="fas fa-volume-up"></i><span>&nbsp;Play&nbsp;</span>\
     <i class="fas fa-play"></i>\
   </button>\
   <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="restart" value="restart">\
-    <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
+    <i class="fas fa-volume-up"></i><span>&nbsp;Restart&nbsp;</span>\
     <i class="fas fa-undo"></i>\
   </button>\
   <button class="media-action pause btn btn-sm btn-outline-secondary" aria-label="pause" value="pause">\
-    <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
+    <i class="fas fa-volume-up"></i><span>&nbsp;Pause&nbsp;</span>\
     <i class="fas fa-pause"></i>\
   </button>\
   <button class="media-action stop btn btn-sm btn-outline-secondary" aria-label="stop" value="stop">\

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -99,7 +99,7 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
 // The DOM structure for every AL audio element with custom controls
 var audio_contents_html = '\
   <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="Listen" value="play">\
-    <i class="fas fa-volume-up"></i><span>&nbsp;Play&nbsp;</span>\
+    <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
     <i class="fas fa-play"></i>\
   </button>\
   <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="restart" value="restart">\

--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -112,3 +112,8 @@ input[type=number] {
 .btn[type='submit'] {
   min-width: 8em;
 }
+
+/* Make the footer links slightly darker for better contrast */
+footer a {
+  color: #0264F7
+}


### PR DESCRIPTION
Changes made:
* added a simple alt text to our logo image. There's a lot of differing information out there about what alt text to use (I found [this flow chart](https://www.w3.org/WAI/tutorials/images/decision-tree/) when developing), but I think going by the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#icons_or_logos), and [this good blog post](https://davidmacd.com/blog/what-is-pure-decoration-alt-text-in-wcag.html) by a WCAG member, is a good idea. Those say to use some simple alt text (just the project's name) on images and logos that aren't purely decorative
* Make the audio buttons have the same names as aria labels. 
From https://www.w3.org/WAI/WCAG21/Techniques/failures/F96:

    > "When speech input users interact with a web page, they usually speak
    a command followed by the reference to some visible label (like the
    text in a button or a link, or the text labelling some input). If the
    visible label does not match the accessible name of the control, speech
    users may be unable to directly activate that control."


    The options to fix this are to:
    * remove "Listen" (bad for non-assistive tech users IMO), 
    * make all of the aria-labels "Listen" (bad for assistive tech users),
    * or just make the visible text match the aria-labels.

* Since our footer is a slightly darker white, the default blue link text doesn't quite have enough contrast (was at 4.2 something, and needed to be 4.5), so I changed the link color in the footer just slightly.
