### PR TITLE
Make al_logo alt_text attr backwards compatible

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -2,6 +2,9 @@
 objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Assembly Line Logo")
 ---
+code: |
+  al_logo.alt_text = "Assembly Line Logo"
+---
 default screen parts:
   title: |
     ${ all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE) }


### PR DESCRIPTION
Added an alt_text attribute to an objects block, but forgot that DA
doesn't re-run those for existing sessions, so will just complain instead.

Love when normal program invariants just go out the window /s

Should fix #466, can't directly check until commited though, can you check @nonprofittechy?