### PR TITLE
Mypy action

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,5 +17,7 @@ jobs:
       - run: pip install virtualenv
       - run: virtualenv -p python3.8 venv
       - run: venv/bin/pip install -r docassemble/AssemblyLine/requirements.txt
+      - run: venv/bin/pip install mypy 
       - run: venv/bin/pip install --editable .
+      - run: venv/bin/python3 -m mypy .
       - run: venv/bin/python3 -m unittest discover

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,9 +15,8 @@ jobs:
       - name: Check
         uses: actions/checkout@v2
       - run: pip install virtualenv
-      - run: virtualenv -p python3.8 venv
-      - run: venv/bin/pip install -r docassemble/AssemblyLine/requirements.txt
-      - run: venv/bin/pip install mypy 
-      - run: venv/bin/pip install --editable .
-      - run: venv/bin/python3 -m mypy .
-      - run: venv/bin/python3 -m unittest discover
+      - run: virtualenv -p python3.8 .venv
+      - run: .venv/bin/pip install -r docassemble/AssemblyLine/requirements.txt
+      - run: .venv/bin/pip install --editable .
+      - run: .venv/bin/python3 -m mypy .
+      - run: .venv/bin/python3 -m unittest discover

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ docassemble.AssemblyLine.egg-info/*
 .mypy_cache/**
 **/.mypy_cache/**
 dist/**
+.venv/**
 
 # IDE related
 .vscode/**

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -856,6 +856,7 @@ def is_phone_or_email(text: str) -> bool:
         return True
     else:
         validation_error("Enter a valid phone number or email address")
+        assert False, "unreachable"
 
 
 def github_modified_date(

--- a/docassemble/AssemblyLine/requirements.txt
+++ b/docassemble/AssemblyLine/requirements.txt
@@ -1,2 +1,4 @@
 docassemble.base>=1.3
 docassemble.webapp
+mypy
+pandas-stubs

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+# global options
+
+[mypy]
+exclude = setup.py
+
+# per-module options:
+
+[mypy-docassemble.base.*]
+ignore_missing_imports = True
+
+[mypy-pycountry]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # global options
 
 [mypy]
-exclude = setup.py
+exclude = ['venv', 'setup.py']
 
 # per-module options:
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,6 @@
 [mypy]
 exclude = (?x)(
     ^setup.py$
-    | ^venv$
   )
 
 # per-module options:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,10 @@
 # global options
 
 [mypy]
-exclude = ['venv', 'setup.py']
+exclude = (?x)(
+    ^setup.py$
+    | ^venv$
+  )
 
 # per-module options:
 


### PR DESCRIPTION
Actually starts running mypy on each commit though the existing unittest action. Necessary to make sure that our types are correct.

Started off in the [suggested state](https://breadcrumbscollector.tech/mypy-how-to-use-it-in-my-project/) of just ignoring errors that occur from third party libraries. Eventually we might want to add stubs for other libraries like the country stuff, or we can make it so that those libraries have types themselves (:eyes: docassemble :eyes:). Probably worth it at some point to look through everything and make sure there are types where there should be.