### PR TITLE
Hotfix - Fix the package name in sessions.py

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -161,7 +161,19 @@ al_sessions_variables_to_remove_from_new_interview = [
     "user_ask_role",
 ]
 
-al_session_store_default_filename = f"{user_info().package}:al_saved_sessions_store.yml"
+
+def _package_name(package_name: str = None):
+    """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
+    docassemble.ALWeaver.advertise_capabilities"""
+    if not package_name:
+        package_name = __name__
+    try:
+        return ".".join(package_name.split(".")[:-1])
+    except:
+        return package_name
+
+
+al_session_store_default_filename = f"{_package_name()}:al_saved_sessions_store.yml"
 
 
 def is_file_like(obj):


### PR DESCRIPTION
The existing sessions.py reference (using user_info()) does not work when you reference it from a different package on the server. This corrects it to use the same package local trick that is used in the Weaver's configuration setting tool.