### PR TITLE
Make our Visual HTML valid

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -15,25 +15,25 @@ default screen parts:
   exit url: |
     ${ all_variables(special='metadata').get('exit url', AL_ORGANIZATION_HOMEPAGE) }
   logo: |
-    <div class="title-container">
-      <div class="al-logo">
+    <span class="title-container">
+      <span class="al-logo">
         <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
-      </div>
-      <div class="al-title">
-        <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>
-        <div class="title-row-2">${all_variables(special='metadata').get('title','').rstrip()}</div>
-      </div>
-    </div> 
+      </span>
+      <span class="al-title">
+        <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>
+        <span class="title-row-2">${all_variables(special='metadata').get('title','').rstrip()}</span>
+      </span>
+    </span>
   short logo: |
-    <div class="title-container">
-      <div class="al-logo">
+    <span class="title-container">
+      <span class="al-logo">
         <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
-      </div>
-      <div class="al-title">
-        <div class="title-row-1">${ AL_ORGANIZATION_TITLE }</div>
-        <div class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</div>
-      </div>
-    </div>   
+      </span>
+      <span class="al-title">
+        <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>
+        <span class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
+      </span>
+    </span>
   continue button label: |
     Next
   back button label: |


### PR DESCRIPTION
DA puts the logo item inside a span, and only spans be a part of other spans, not divs.

Valid HTML is [success criteria in WCAG](https://www.w3.org/TR/WCAG21/#parsing), so we should change, even though it displays fine as is.

Was caught using https://validator.w3.org/nu/?doc=https%3A%2F%2Fapps-dev.suffolklitlab.org%2Frun%2FEFSPIntegration%2Fany_filing_interview, which I am currently integrating into Kiln as well to catch future errors like this.