### PR TITLE
Add property getter for phone_numbers

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -397,6 +397,11 @@ class ALIndividual(Individual):
         else:
             return ""
 
+    @property
+    def all_phone_numbers(self) -> str:
+        """A property getter for phone_numbers(). Useful for when you can't use functions, like in 'showifdef'"""
+        return self.phone_numbers()
+
     def contact_methods(self) -> str:
         """Method to return a formatted string with all provided contact methods of the individual:
             * Phone number(s)


### PR DESCRIPTION
Allows for use to get the full list of phone numbers in things like `showifdef`, which
doesn't like functions.
Used the `all_phone_numbers` so it doesn't cause any breaking changes to `phone_numbers`.

Currently causing some issues in prod, since the Interpreternotice includes a `showifdef("users[0].phone_numbers()")` in the DOCX template, and there's no simple way to fix that error without something like this.