### PR TITLE
Increase contrast of docassemble's term coloring

### DIFF
--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -113,7 +113,10 @@ input[type=number] {
   min-width: 8em;
 }
 
-/* Make the footer links slightly darker for better contrast */
+/* Make the footer links and da terms slightly darker for better contrast */
 footer a {
   color: #0264F7
+}
+.daterm {
+  color: #3b842c
 }


### PR DESCRIPTION
Was originally #408e30, which has a contrast of only 4.09 on a white background.
Darkens the color to #3b842c, for a contrast of 4.64, well above the WCAG minimum of 4.5.