### PR TITLE
Exhibit improvements

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1352,7 +1352,7 @@ class ALDocumentBundle(DAList):
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
     Atributes:
-        elements (list): List of individual DAFiles representing uploaded images or documents.
+        pages (list): List of individual DAFiles representing uploaded images or documents.
         cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block
           Will typically say something like "Exhibit 1"
         label (str): A label, like "A" or "1" for this exhibit in the cover page and table of contents
@@ -1366,12 +1366,36 @@ class ALExhibit(DAObject):
         if not hasattr(self, "starting_page"):
             self.start_page = 1
 
-    def add_numbers(self, starting_page=None) -> None:
+    def _start_ocr(self):
         """
-        Todo:
-            Not implemented yet.
+        Starts the OCR (optical character resolution) process on the uploaded documents.
+
+        Makes a background action for each page in the document.
         """
-        pass
+        if len(self.pages):
+            # We cannot OCR in place. It is too fragile.
+            for page in self.pages:
+                page.ocr_version = DAFile(page.attr_name("ocr_version"))
+                # psm=1 is the default which uses automatic text orientation and location detection.
+                # Appears to be the most accurate method.
+                page.ocr_status = page.ocr_version.make_ocr_pdf_in_background(
+                    page, psm=1
+                )
+
+    def ocr_ready(self) -> bool:
+        """
+        Returns:
+            True iff OCR process has finished on all pages. OCR is non-blocking, and assembly will work
+            even if OCR is not complete. Check this status if you want to wait to deliver a document until
+            OCR is complete.
+
+            Will return true (but log a warning) if OCR was never started on the documents.
+            That situation is likely a developer error, as you shouldn't wait for OCR if it never started
+        """
+        for page in self.pages:
+            if hasattr(page, "ocr_status") and not page.ocr_status.ready():
+                return False
+        return True
 
     def ocr_pages(self):
         """
@@ -1393,25 +1417,38 @@ class ALExhibit(DAObject):
 
     def as_pdf(
         self,
-        prefix="",
+        *,
+        refresh: bool = False,
+        prefix: str ="",
         pdfa: bool = False,
         add_page_numbers: bool = True,
         add_cover_page: bool = True,
         filename: str = None,
     ) -> DAFile:
-        if hasattr(self._cache, "_file"):
-            return self._cache._file
+        safe_key = "_file"
+        if pdfa:
+          safe_key = safe_key + "_pdfa"
+        if add_page_numbers:
+          safe_key = safe_key + "_page_nums"
+
+        if hasattr(self._cache, safe_key):
+            return getattr(self._cache, safe_key)
         if not filename:
             filename = "exhibits.pdf"
         if add_cover_page:
-            self._cache._file = pdf_concatenate(
+            concatenated_pages = pdf_concatenate(
                 self.cover_page, self.ocr_pages(), filename=filename, pdfa=pdfa
             )
         else:
-            self._cache._file = pdf_concatenate(
+            concatenated_pages = pdf_concatenate(
                 self.ocr_pages(), filename=filename, pdfa=pdfa
             )
-        return self._cache._file
+
+        if add_page_numbers:
+            concatenated_pages.bates_number(prefix=prefix, start=self.start_page)
+
+        setattr(self._cache, safe_key, concatenated_pages)
+        return getattr(self._cache, safe_key)
 
     def num_pages(self) -> int:
         return self.pages.num_pages()
@@ -1445,11 +1482,16 @@ class ALExhibitList(DAList):
             self.auto_labeler = alpha
         if not hasattr(self, "auto_ocr"):
             self.auto_ocr = True
+        if not hasattr(self, "include_table_of_contents"):
+            self.include_table_of_contents = True
+        if not hasattr(self, "include_exhibit_cover_pages"):
+            self.include_cover_pages =  True
         self.object_type = ALExhibit
         self.complete_attribute = "complete"
 
     def as_pdf(
-        self, filename="file.pdf", pdfa: bool = False, add_cover_pages: bool = True
+        self, filename="file.pdf", pdfa: bool = False, add_cover_pages: bool = True,
+        add_page_numbers: bool = True
     ) -> DAFile:
         """
         Return a single PDF containing all exhibits.
@@ -1460,20 +1502,10 @@ class ALExhibitList(DAList):
             A DAfile containing the rendered exhibit list as a single file.
         """
         return pdf_concatenate(
-            [exhibit.as_pdf(add_cover_page=add_cover_pages) for exhibit in self],
+            [exhibit.as_pdf(add_cover_page=add_cover_pages, add_page_numbers=add_page_numbers) for exhibit in self],
             filename=filename,
             pdfa=pdfa,
         )
-
-    def add_numbers(self, prefix: str = "", starting_number: int = 1) -> None:
-        """
-        Add running page numbers. (TODO: not yet implemented)
-        Args:
-            prefix (str): The prefix before each page number. E.g., Ex-
-            starting_number (int): The number that the first page will be assigned. Defaults
-                                   to 1.
-        """
-        pass
 
     def _update_labels(self, auto_labeler: Callable = None) -> None:
         """
@@ -1496,31 +1528,24 @@ class ALExhibitList(DAList):
         """
         ready = True
         for exhibit in self.elements:
-            for page in exhibit.pages:
-                if hasattr(page, "ocr_status"):
-                    ready &= page.ocr_status.ready()
+            ready &= exhibit.ocr_ready()
         return ready
 
-    def _update_page_numbers(self) -> None:
+    def _update_page_numbers(self, starting_number: Optional[int] = None) -> None:
         """
         Update the `start_page` attribute of all exhibits so it reflects current position in the list + number of pages of each document.
         """
-        current_index = 1
+        toc_pages = 1 if self.include_table_of_contents else 0
+        cover_pages = 1 if self.include_cover_pages else 0
+        current_index = starting_number if starting_number else 1
+        current_index += toc_pages
         for exhibit in self.elements:
             exhibit.start_page = current_index
-            current_index += exhibit.num_pages()
+            current_index = current_index + exhibit.num_pages() + toc_pages
 
-    def _ocr_docs(self):
+    def _start_ocr(self):
         for exhibit in self.elements:
-            if len(exhibit.pages):
-                # We cannot OCR in place. It is too fragile.
-                for page in exhibit.pages:
-                    page.ocr_version = DAFile(page.attr_name("ocr_version"))
-                    # psm=1 is the default which uses automatic text orientation and location detection.
-                    # Appears to be the most accurate method.
-                    page.ocr_status = page.make_ocr_pdf_in_background(
-                        page.ocr_version, psm=1
-                    )
+            exhibit._start_ocr()
 
     def hook_after_gather(self):
         """
@@ -1530,11 +1555,8 @@ class ALExhibitList(DAList):
             self._update_page_numbers()
             if self.auto_label:
                 self._update_labels()
-
-        # TODO: implement below. Was buggy when OCRing a lot of files and OCRing in place.
-        # Switched to creating a new DAFile, but that introduced different bugs. -- third refresh breaks it. file never gets a number so not "ok"
-        # if self.auto_ocr:
-        #  self._ocr_docs()
+            if self.auto_ocr:
+              self._start_ocr()
 
 
 class ALExhibitDocument(ALDocument):
@@ -1583,10 +1605,16 @@ class ALExhibitDocument(ALDocument):
         self.initializeAttribute("exhibits", ALExhibitList)
         if hasattr(self, "auto_labeler"):
             self.exhibits.auto_labeler = self.auto_labeler
+        if hasattr(self, "auto_ocr"):
+            self.exhibits.auto_ocr = self.auto_ocr
         if not hasattr(self, "include_table_of_contents"):
             self.include_table_of_contents = True
+            self.exhibits.include_table_of_contents = True
         if not hasattr(self, "include_exhibit_cover_pages"):
             self.include_exhibit_cover_pages = True
+            self.exhibits.include_cover_pages =  True
+        if not hasattr(self, "add_page_numbers"):
+            self.add_page_numbers = False
         self.has_addendum = False
 
     def has_overflow(self):
@@ -1607,6 +1635,7 @@ class ALExhibitDocument(ALDocument):
         """
         Args:
             key (str): unused, for signature compatibility with ALDocument
+            refresh (bool): unused, for signature compatibility with ALDocument
         """
         filename = os.path.splitext(self.filename)[0] + ".pdf"
 
@@ -1615,7 +1644,8 @@ class ALExhibitDocument(ALDocument):
                 return pdf_concatenate(
                     self.table_of_contents,
                     self.exhibits.as_pdf(
-                        add_cover_pages=self.include_exhibit_cover_pages
+                        add_cover_pages=self.include_exhibit_cover_pages,
+                        add_page_numbers=self.add_page_numbers
                     ),
                     filename=filename,
                     pdfa=pdfa,
@@ -1623,6 +1653,7 @@ class ALExhibitDocument(ALDocument):
             else:
                 return self.exhibits.as_pdf(
                     add_cover_pages=self.include_exhibit_cover_pages,
+                    add_page_numbers=self.add_page_numbers,
                     filename=filename,
                     pdfa=pdfa,
                 )

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1646,7 +1646,7 @@ class ALExhibitDocument(ALDocument):
 
     def ocr_ready(self) -> bool:
         """
-        See ALExhibitList.ocr_ready
+        Returns `True` iff each individual exhibit has been OCRed, or if the OCR process was not started.
         """
         return self.exhibits.ocr_ready()
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1537,8 +1537,7 @@ class ALExhibitList(DAList):
 
     def ocr_ready(self) -> bool:
         """
-        Combines the results of all the ALExhibit.ocr_ready calls.
-        See ALExhibi.ocr_ready for more details.
+        Returns `True` iff all individual exhibit pages have been OCRed, or if the OCR process hasn't started.
         """
         ready = True
         for exhibit in self.elements:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1421,7 +1421,7 @@ class ALExhibit(DAObject):
         self,
         *,
         refresh: bool = False,
-        bates_prefix: str ="",
+        bates_prefix: str = "",
         pdfa: bool = False,
         add_page_numbers: bool = True,
         add_cover_page: bool = True,
@@ -1429,9 +1429,9 @@ class ALExhibit(DAObject):
     ) -> DAFile:
         safe_key = "_file"
         if pdfa:
-          safe_key = safe_key + "_pdfa"
+            safe_key = safe_key + "_pdfa"
         if add_page_numbers:
-          safe_key = safe_key + "_page_nums"
+            safe_key = safe_key + "_page_nums"
 
         if hasattr(self._cache, safe_key):
             return getattr(self._cache, safe_key)
@@ -1494,9 +1494,11 @@ class ALExhibitList(DAList):
         self.complete_attribute = "complete"
 
     def as_pdf(
-        self, filename="file.pdf", pdfa: bool = False,
+        self,
+        filename="file.pdf",
+        pdfa: bool = False,
         add_page_numbers: bool = False,
-        toc_pages: int = 0
+        toc_pages: int = 0,
     ) -> DAFile:
         """
         Return a single PDF containing all exhibits.
@@ -1509,11 +1511,14 @@ class ALExhibitList(DAList):
         if self.include_table_of_contents and toc_pages != 1:
             self._update_page_numbers(toc_guess_pages=toc_pages)
         return pdf_concatenate(
-            [exhibit.as_pdf(
-              add_cover_page=self.include_exhibit_cover_pages, 
-              add_page_numbers=add_page_numbers,
-              bates_prefix=self.bates_prefix
-              ) for exhibit in self],
+            [
+                exhibit.as_pdf(
+                    add_cover_page=self.include_exhibit_cover_pages,
+                    add_page_numbers=add_page_numbers,
+                    bates_prefix=self.bates_prefix,
+                )
+                for exhibit in self
+            ],
             filename=filename,
             pdfa=pdfa,
         )
@@ -1540,7 +1545,9 @@ class ALExhibitList(DAList):
             ready &= exhibit.ocr_ready()
         return ready
 
-    def _update_page_numbers(self, starting_number: Optional[int] = None, toc_guess_pages: int = 1) -> None:
+    def _update_page_numbers(
+        self, starting_number: Optional[int] = None, toc_guess_pages: int = 1
+    ) -> None:
         """
         Update the `start_page` attribute of all exhibits so it reflects current position in the list + number of pages of each document.
         """
@@ -1565,7 +1572,7 @@ class ALExhibitList(DAList):
             if self.auto_label:
                 self._update_labels()
             if self.auto_ocr:
-              self._start_ocr()
+                self._start_ocr()
 
 
 class ALExhibitDocument(ALDocument):
@@ -1666,8 +1673,7 @@ class ALExhibitDocument(ALDocument):
                 return pdf_concatenate(
                     self.table_of_contents,
                     self.exhibits.as_pdf(
-                        add_page_numbers=self.add_page_numbers,
-                        toc_pages=toc_pages
+                        add_page_numbers=self.add_page_numbers, toc_pages=toc_pages
                     ),
                     filename=filename,
                     pdfa=pdfa,

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1421,12 +1421,20 @@ class ALExhibit(DAObject):
         self,
         *,
         refresh: bool = False,
-        bates_prefix: str = "",
+        prefix: str = "",
         pdfa: bool = False,
         add_page_numbers: bool = True,
         add_cover_page: bool = True,
         filename: str = None,
     ) -> DAFile:
+        """
+        Params:
+            prefix (str): the prefix for the bates numbering that is applied if
+              add_page_numbers is true
+            add_page_numbers (bool): adds bates numbering to the exhibit if true,
+              starting at the number self.start_page
+            add_cover_page (bool): adds a cover to this exhibit if true
+        """
         safe_key = "_file"
         if pdfa:
             safe_key = safe_key + "_pdfa"
@@ -1447,7 +1455,7 @@ class ALExhibit(DAObject):
             )
 
         if add_page_numbers:
-            concatenated_pages.bates_number(prefix=bates_prefix, start=self.start_page)
+            concatenated_pages.bates_number(prefix=prefix, start=self.start_page)
 
         setattr(self._cache, safe_key, concatenated_pages)
         return getattr(self._cache, safe_key)
@@ -1515,7 +1523,7 @@ class ALExhibitList(DAList):
                 exhibit.as_pdf(
                     add_cover_page=self.include_exhibit_cover_pages,
                     add_page_numbers=add_page_numbers,
-                    bates_prefix=self.bates_prefix,
+                    prefix=self.bates_prefix,
                 )
                 for exhibit in self
             ],


### PR DESCRIPTION
Needed to finish up the ALExhibitDocument, adding bates numbering and OCR. I want to test a bit more on the dev and test servers, but running on a local docassemble, things were fairly stable. The default for `auto_ocr` and `add_page_numbers` is false, so this won't change any existing behavior or make anything unstable yet.

Here's the test interview I used:
```yaml
include:
  - al_package.yml
---
mandatory: True
code: |
  exhibits.exhibits.gather()
  
  if not exhibits.exhibits.ocr_ready():
    waiting_screen
  else:
    final_screen
---
event: waiting_screen
question: Waiting
reload: True
---
event: final_screen
question: |
  Here is your document.
subquestion: |
  ${ single_pdf_bundle_1.as_pdf(pdfa=True) }
---
objects:
  # No addenda, all start enabled
  - single_pdf_bundle_1: ALDocumentBundle.using(elements=[exhibits], pdfa=True, title="One pdf", filename="single_pdf_1" )
---
objects:
  - exhibits: ALExhibitDocument.using( title="PDF 1", filename="pdf_doc_1", enabled=True, auto_ocr=True, add_page_numbers=True)
```