### PR TITLE
Distribute type information as a python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+global-include *.typed


### PR DESCRIPTION
Following the instructions in https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages.

> packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory. 

The standard docassemble package data should take care of finding the file.