### PR TITLE
Do not show `send_button_html()` if there are no enabled documents in a bundle

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_question_test.yml
+++ b/docassemble/AssemblyLine/data/questions/al_question_test.yml
@@ -225,3 +225,5 @@ subquestion: |
   **Single file**
   
   ${ al_single_doc_bundle.download_list_html() }
+
+  ${ al_single_doc_bundle.send_button_html() }


### PR DESCRIPTION
Made a small refactor to logic in enabled_documents() and added an `is_enabled()` method that tracks the logic that was in `enabled_documents()`. This allows us to use a generator expression, so that we can return `True` as soon as we figure out at least one document is enabled.

Fix #503