### PR TITLE
Append '_preview' by default to PDF filename generated with the "preview" key

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.md
-global-include *.typed

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -730,9 +730,9 @@ class ALDocument(DADict):
         Returns the assembled document as a single DOCX file, if possible. Otherwise returns a PDF.
         """
         if append_matching_suffix and key == self.suffix_to_append:
-            filename = f"{basename(self.filename)}_{key}"
+            filename = f"{base_name(self.filename)}_{key}"
         else:
-            filename = f"{basename(self.filename)}"
+            filename = f"{base_name(self.filename)}"
         if self.need_addendum():
             try:
                 the_file = docx_concatenate(self.as_list(key=key, refresh=refresh, filename=filename+".docx"))

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -737,7 +737,8 @@ class ALDocument(DADict):
         if self.need_addendum():
             try:
                 the_file = docx_concatenate(
-                    self.as_list(key=key, refresh=refresh, filename=filename + ".docx")
+                    self.as_list(key=key, refresh=refresh),
+                    filename=filename + ".docx",
                 )
                 the_file.title = self.title
                 return the_file
@@ -1802,7 +1803,12 @@ class ALExhibitDocument(ALDocument):
                     pdfa=pdfa,
                 )
 
-    def as_docx(self, key: str = "bool", refresh: bool = True) -> DAFile:
+    def as_docx(
+        self,
+        key: str = "bool",
+        refresh: bool = True,
+        append_matching_suffix: bool = True,
+    ) -> DAFile:
         return self.as_pdf()
 
 
@@ -1852,7 +1858,12 @@ class ALTableDocument(ALDocument):
         )
         return self.file
 
-    def as_docx(self, key: str = "final", refresh: bool = True, **kwargs) -> DAFile:
+    def as_docx(
+        self,
+        key: str = "bool",
+        refresh: bool = True,
+        append_matching_suffix: bool = True,
+    ) -> DAFile:
         return self.as_pdf()
 
 
@@ -1888,7 +1899,12 @@ class ALUntransformedDocument(ALDocument):
         """
         return self[key]
 
-    def as_docx(self, key: str = "final", refresh: bool = True, **kwargs) -> DAFile:
+    def as_docx(
+        self,
+        key: str = "bool",
+        refresh: bool = True,
+        append_matching_suffix: bool = True,
+    ) -> DAFile:
         return self[key]
 
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -884,14 +884,10 @@ class ALStaticDocument(DAStaticFile):
         append_matching_suffix: bool = True,
         refresh: bool = False,
     ) -> Union[DAStaticFile, DAFile]:
-        if append_matching_suffix and key == self.suffix_to_append:
-            append_suffix: str = f"_{key}"
-        else:
-            append_suffix = ""
         if not filename:
             filename = self.filename
         return pdf_concatenate(
-            self, pdfa=pdfa, filename=f"{base_name(filename)}{append_suffix}.pdf"
+            self, pdfa=pdfa, filename=f"{base_name(filename)}.pdf"
         )
 
     def as_docx(


### PR DESCRIPTION
For purposes of testing, this defaults to giving a unique suffix to the "preview" version of a PDF as requested by @plocket for ALKiln

Incidentally, this also gives a way for the author to rename an ALStaticDocument PDF (#222)

Fix #506, fix #222