### PR TITLE
Offer the user's address as a default for second, third, etc.

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -461,6 +461,34 @@ fields:
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
 ---
+id: user i's address
+question: |
+  What is ${ users[i] }'s address?
+fields:
+  - Same as your address: users[i].address
+    datatype: object_radio
+    choices:
+      - users[0].address
+    object labeler: |
+      lambda y: y.on_one_line()      
+    none of the above: |
+      Somewhere else
+    disable others: True      
+  - ${ users[i].address.address_label}: users[i].address.address
+    address autocomplete: True
+  - ${ users[i].address.unit_label}: users[i].address.unit
+    required: False
+  - ${ users[i].address.city_label}: users[i].address.city
+  - ${ users[i].address.state_label}: users[i].address.state
+    code: |
+      states_list(country_code=AL_DEFAULT_COUNTRY)
+    default: ${ AL_DEFAULT_STATE }
+  - ${ users[i].address.zip_label}: users[i].address.zip
+    required: False
+#  - ${ users[i].address.country_label}: users[i].address.country
+#    code: countries_list()
+#    default: ${ AL_DEFAULT_COUNTRY }
+---
 generic object: ALIndividual
 id: any mailing address
 question: |


### PR DESCRIPTION
Provides a default question which will list the first user's address as an option for each subsequent user

fix #502 