### PR TITLE
Pull in the default value of `github_user` from the config instead of assuming "suffolklitlab"

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -125,7 +125,7 @@ code: |
   # Username or organization name for Github repositories
   # Used to direct feedback to the right place and to check for
   # the last commit date.
-  github_user = "suffolklitlab" 
+  github_user = get_config("github issues",{}).get("default repository owner","").strip() or "suffolklitlab"
 ---
 code: |
   feedback_form = "docassemble.AssemblyLine:feedback.yml"


### PR DESCRIPTION
Fix #517

Note that in many cases, a server-wide value for this setting doesn't make as much sense as a branding-package specific value, but we do ask people for this value in the installation script and it's used by the bare GithubFeedbackForm already.