### PR TITLE
Create a replacement page for "My interviews"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+global-include *.typed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include README.md
-global-include *.typed

--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
@@ -41,7 +41,7 @@ subquestion: |
   You can re-use the answers in this answer set by visiting a new form and selecting
   "Load answer set" from the main menu.
 
-  ${ action_button_html(interview_url(i=f"{user_info().current_package}:data/questions/interview_list.yml", label="List in progress forms", color="link", size="md") } ${ action_button_html(get_config("assembly line",{}).get("new form url", url_of("dispatch")), label="List available forms", icon="list", color="primary", size="md") }
+  ${ action_button_html(interview_url(i=f"{user_info().current_package}:data/questions/interview_list.yml", label="List in progress forms", color="link", size="md")) } ${ action_button_html(get_config("assembly line",{}).get("new form url", url_of("dispatch")), label="List available forms", icon="list", color="primary", size="md") }
 ---
 id: rename answer
 question: |

--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
@@ -41,7 +41,7 @@ subquestion: |
   You can re-use the answers in this answer set by visiting a new form and selecting
   "Load answer set" from the main menu.
 
-  ${ action_button_html(url_of("interviews"),label="List in progress forms", color="link", size="md") } ${ action_button_html(url_of("dispatch"), label="List available forms", icon="list", color="primary", size="md") }
+  ${ action_button_html(interview_url(i=f"{user_info().current_package}:data/questions/interview_list.yml", label="List in progress forms", color="link", size="md") } ${ action_button_html(get_config("assembly line",{}).get("new form url", url_of("dispatch")), label="List available forms", icon="list", color="primary", size="md") }
 ---
 id: rename answer
 question: |

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -7,6 +7,7 @@ include:
 ---
 features:
   small screen navigation: dropdown
+  navigation: True
   navigation back button: False
   javascript:
     - al_audio.js
@@ -14,13 +15,13 @@ features:
     - styles.css
     - al_audio.css
   question help button: True
-  question back button: True
+  question back button: False
 ---
 metadata:
   title: |
-    View saved forms
+    In progress forms
   short title: |
-    Saved forms
+    In progress forms
   unique session: True    
 ---
 modules:
@@ -61,32 +62,19 @@ default screen parts:
         <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>
         <span class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
       </span>
-    </span>    
+    </span>
+---
+sections:
+  - section_in_progress_forms: In progress forms
+  - section_answer_sets: Answer sets
+progressive: False
 ---
 mandatory: True
+event: section_in_progress_forms
 id: interview list
 question: |
-  View saved progress <span style="float: right;">${ action_button_html(get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE), label="Start a new form", icon="plus-circle", color="primary", size="md") }</span>
+  In progress forms <span style="float: right;">${ action_button_html(get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE), label="Start a new form", icon="plus-circle", color="primary", size="md") }</span>
 subquestion: |
-  ${ tabbed_templates_html("al-", resume_sessions_template, saved_answer_sets_template, ) }
----
-template: saved_answer_sets_template
-subject: |
-  Your answer sets :clone:
-content: |
-  View, delete, or rename your answer sets below. To copy an answer set into a
-  new form:
-  
-  1. [Start a new 
-  form](${ get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE) })
-  1. Then, use the menu to load your answer set.
-
-  ${ interview_list_html(view_only=True, delete_action="interview_list_delete_session") }
----
-template: resume_sessions_template
-subject: |
-  Your forms :folder-open:
-content: |
   Tap the title of a form to keep working on it or to download your completed
   documents.
 
@@ -96,6 +84,22 @@ content: |
   [< Previous page](${ url_action("update_page_event", page_increment=-1) })
   % endif  
   [Next page >](${ url_action("update_page_event", page_increment=1) })
+section: section_in_progress_forms
+---
+event: section_answer_sets
+id: answer set list
+question: |
+  Answer sets <span style="float: right;">${ action_button_html(get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE), label="Start a new form", icon="plus-circle", color="primary", size="md") }</span>
+subquestion: |
+  View, delete, or rename your answer sets below. To copy an answer set into a
+  new form:
+  
+  1. [Start a new 
+  form](${ get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE) })
+  1. Then, use the menu to load your answer set.
+
+  ${ interview_list_html(view_only=True, delete_action="interview_list_delete_session") }
+section: section_answer_sets
 ---
 code: |
   session_page = 0
@@ -103,3 +107,19 @@ code: |
 event: update_page_event
 code: |
   session_page += action_argument("page_increment")
+
+---
+id: rename answer
+question: |
+  Rename saved answers
+fields:
+  - New name: al_sessions_snapshot_new_label
+    default: |
+      ${ all_variables(special='titles').get('sub') }
+continue button label: |
+  :save: Save changes
+---
+code: |
+  rename_interview_answers(user_info().filename, user_info().session, new_name = al_sessions_snapshot_new_label)
+  log("New name saved", "success")
+  al_sessions_rename_session = True

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -1,0 +1,105 @@
+---
+# Provide a replacement for the /interviews endpoint in Docassemble
+---
+include: 
+  - docassemble.ALToolbox:display_template.yml
+  - al_settings.yml
+---
+features:
+  small screen navigation: dropdown
+  navigation back button: False
+  javascript:
+    - al_audio.js
+  css:
+    - styles.css
+    - al_audio.css
+  question help button: True
+  question back button: True
+---
+metadata:
+  title: |
+    View saved forms
+  short title: |
+    Saved forms
+  unique session: True    
+---
+modules:
+  - .sessions
+  - docassemble.ALToolbox.misc
+---
+objects:
+  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Assembly Line Logo")
+---
+code: |
+  al_logo.alt_text = "Assembly Line Logo"
+---
+default screen parts:
+  title: |
+    ${ all_variables(special='metadata').get('title', AL_ORGANIZATION_TITLE) }
+  short title: |
+    ${ all_variables(special='metadata').get('short title', AL_ORGANIZATION_TITLE) }
+  title url: |
+    ${ all_variables(special='metadata').get('title url', AL_ORGANIZATION_HOMEPAGE) }
+  exit url: |
+    ${ all_variables(special='metadata').get('exit url', AL_ORGANIZATION_HOMEPAGE) }
+  logo: |
+    <span class="title-container">
+      <span class="al-logo">
+        <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
+      </span>
+      <span class="al-title">
+        <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>
+        <span class="title-row-2">${all_variables(special='metadata').get('title','').rstrip()}</span>
+      </span>
+    </span>
+  short logo: |
+    <span class="title-container">
+      <span class="al-logo">
+        <img src="${ al_logo.url_for() }" alt="${ al_logo.alt_text }"/>
+      </span>
+      <span class="al-title">
+        <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>
+        <span class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
+      </span>
+    </span>    
+---
+mandatory: True
+id: interview list
+question: |
+  View saved progress <span style="float: right;">${ action_button_html(get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE), label="Start a new form", icon="plus-circle", color="primary", size="md") }</span>
+subquestion: |
+  ${ tabbed_templates_html("al-", resume_sessions_template, saved_answer_sets_template, ) }
+---
+template: saved_answer_sets_template
+subject: |
+  Your answer sets :clone:
+content: |
+  View, delete, or rename your answer sets below. To copy an answer set into a
+  new form:
+  
+  1. [Start a new 
+  form](${ get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE) })
+  1. Then, use the menu to load your answer set.
+
+  ${ interview_list_html(view_only=True, delete_action="interview_list_delete_session") }
+---
+template: resume_sessions_template
+subject: |
+  Your forms :folder-open:
+content: |
+  Tap the title of a form to keep working on it or to download your completed
+  documents.
+
+  ${ session_list_html(filename=None, limit=20, offset=session_page) }
+  
+  % if session_page > 0:
+  [< Previous page](${ url_action("update_page_event", page_increment=-1) })
+  % endif  
+  [Next page >](${ url_action("update_page_event", page_increment=1) })
+---
+code: |
+  session_page = 0
+---
+event: update_page_event
+code: |
+  session_page += action_argument("page_increment")

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -197,7 +197,7 @@ code: |
 ---
 code: |
   try:
-      delete_interview_sessions(filename_to_exclude="docassemble.AssemblyLine:data/questions/al_saved_sessions_store.yml")      
+      interview_list(action="delete_all", query=(~DA.Or(DA.Sessions.filename == f"{user_info().current_package}:al_saved_sessions_store.yml", DA.Sessions.filename == "docassemble.AssemblyLine:data/questions/al_saved_sessions_store.yml")))
       log("Deleted answers", "success")
   except Exception as ex:
       log("Problem deleting answers", "danger")

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -32,6 +32,13 @@ modules:
 objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Assembly Line Logo")
 ---
+# Clear some Playground invalid variable reference errors
+objects:
+  - ex: DAEmpty
+  - interview_metadata: DAEmpty
+  - other_parties: DAEmpty
+  - users: DAEmpty
+---
 code: |
   al_logo.alt_text = "Assembly Line Logo"
 ---
@@ -134,11 +141,6 @@ code: |
 event: update_page_event
 code: |
   session_page += action_argument("page_increment")
----
-code: |
-  # Get the existing form's subtitle
-  session_vars = get_session_variables(filename, session_id)
-  existing_subtitle = session_vars.get("_internal",{}).get("subtitle", session_vars.get("_internal",{}).get("title", "Untitled interview"))
 ---
 id: copy to answer set
 question: |

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -107,15 +107,40 @@ code: |
 event: update_page_event
 code: |
   session_page += action_argument("page_increment")
+---
+code: |
+  # Get the existing form's subtitle
+  session_vars = get_session_variables(filename, session_id)
+  existing_subtitle = session_vars.get("_internal",{}).get("subtitle", session_vars.get("_internal",{}).get("title", "Untitled interview"))
+---
+id: copy to answer set
+question: |
+  Copy as answer set
+subquestion: |
+  Before saving your answer set, give the answers a name.
 
+  Pick a name that will help you choose the right answers to use on a new form.
+fields:
+  - Name: al_sessions_copy_as_answer_set_label
+    default: ${ existing_subtitle }
+continue button label: |
+  :save: Save copy
+---
+code: |
+  save_interview_answers(
+      source_filename=existing_filename,
+      source_session=existing_session_id,
+      metadata={
+        "title": al_sessions_copy_as_answer_set_label
+        }
+      )
+  copy_as_answer_set = True
 ---
 id: rename answer
 question: |
   Rename saved answers
 fields:
   - New name: al_sessions_snapshot_new_label
-    default: |
-      ${ all_variables(special='titles').get('sub') }
 continue button label: |
   :save: Save changes
 ---

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -197,6 +197,7 @@ code: |
   try:
       delete_interview_sessions(filename_to_exclude="docassemble.AssemblyLine:data/questions/al_saved_sessions_store.yml")      
       log("Deleted answers", "success")
-  except:
+  except Exception as ex:
       log("Problem deleting answers", "danger")
+      log(f"Problem deleting answers for a user: {ex}")
   interview_list_delete_all = True

--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -115,8 +115,10 @@ input[type=number] {
 
 /* Make the footer links and da terms slightly darker for better contrast */
 footer a {
-  color: #0264F7
+  color: #0264F7;
 }
 .daterm {
-  color: #3b842c
+  color: #3b842c;
+  text-decoration: dashed;
+  text-decoration-line: underline;
 }

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -664,7 +664,7 @@ def session_list_html(
         <td class="al-progress-box">{ radial_progress(answer) }
         </td>
         <td>
-          <a href="{ url_ask_rename }"><i class="fa-solid fa-i-cursor" aria-hidden="true" title="{ rename_label }"></i><span class="sr-only">{ rename_label }</span></a>
+          <a href="{ url_ask_rename }"><i class="fa-solid fa-tag" aria-hidden="true" title="{ rename_label }"></i><span class="sr-only">{ rename_label }</span></a>
         """
         if get_config("assembly line", {}).get("enable answer sets"):
             table += f"""

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,3 +15,6 @@ ignore_missing_imports = True
 
 [mypy-pycountry]
 ignore_missing_imports = True
+
+[mypy-backports.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.4.2', 'docassemble.GithubFeedbackForm>=0.1.3'],
+      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
This adds `interview_list.yml`, a replacement interview for the "My interviews" page. An admin can configure Docassemble to use this interview instead of the internal "My interviews" page.

Importantly, this replacement page:

1. Implements some usability suggestions from both Bentley and Theory and Principle
2. Lets the user navigate between Answer Sets and ordinary sessions
3. Is faster than the built-in interviews page because it does not load all interview data into memory to display the list of interviews.

It respects the relevant configuration options, such as `interview page heading`, `interview page title` and `interview page pre`. More extensive customization can be made by `including` this interview into another interview.

Fix #237
Fix #520 
Fix #526 
Fix #493

The `interview_list` will display some unencrypted metadata that we don't store along with interviews yet. For example: `progress` is reserved for future use. `title` can be set manually by the user, but in the future we should set this automatically as the interview advances.

By design, `session_list_html()` itself is very opinionated, with the main customization simply being using the system-wide words.yml file to replace some of the strings.