### PR TITLE
ALDocumentBundles need `is_enabled` too

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1445,6 +1445,9 @@ class ALDocumentBundle(DAList):
                 **kwargs,
             )
 
+    def is_enabled(self, refresh=True):
+        return self.has_enabled_documents(refresh=refresh)
+
 
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.


### PR DESCRIPTION
Fixes an error caused by an error when trying to use nested ALDocumentBundles.