### PR TITLE
First check if the bundle's enabled attribute is on

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1444,19 +1444,25 @@ class ALDocumentBundle(DAList):
                 attachments=self.as_pdf_list(key=key),
                 **kwargs,
             )
+    
+    def _is_self_enabled(self, refresh=True) -> bool:
+        """The same as ALDocument.is_enabled"""
+        if hasattr(self, "always_enabled") and self.always_enabled:
+            return True
+        if hasattr(self.cache, "enabled"):
+            return self.cache.enabled
+        if refresh:
+            self.cache.enabled = self.enabled
+            if hasattr(self, "enabled"):
+                del self.enabled
+            return self.cache.enabled
+        else:
+            return self.enabled
+      
 
     def is_enabled(self, refresh=True) -> bool:
         """Returns true if the bundle itself is enabled, and it has at least one enabled child document"""
-        self_enabled = (hasattr(self, "always_enabled") and self.always_enabled) or \
-            (hasattr(self.cache, "enabled") and self.cache.enabled)
-        if not self_enabled:
-            if refresh:
-                self.cache.enabled = self.enabled
-                self_enabled = self_enabled or self.cache.enabled
-                if hasattr(self, "enabled"):
-                    del self.enabled
-            else:
-                self_enabled = self_enabled or self.enabled
+        self_enabled = self._is_self_enabled(refresh=refresh)
         return self_enabled and self.has_enabled_documents(refresh=refresh)
 
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1445,8 +1445,19 @@ class ALDocumentBundle(DAList):
                 **kwargs,
             )
 
-    def is_enabled(self, refresh=True):
-        return self.has_enabled_documents(refresh=refresh)
+    def is_enabled(self, refresh=True) -> bool:
+        """Returns true if the bundle itself is enabled, and it has at least one enabled child document"""
+        self_enabled = (hasattr(self, "always_enabled") and self.always_enabled) or \
+            (hasattr(self.cache, "enabled") and self.cache.enabled)
+        if not self_enabled:
+            if refresh:
+                self.cache.enabled = self.enabled
+                self_enabled = self_enabled or self.cache.enabled
+                if hasattr(self, "enabled"):
+                    del self.enabled
+            else:
+                self_enabled = self_enabled or self.enabled
+        return self_enabled and self.has_enabled_documents(refresh=refresh)
 
 
 class ALExhibit(DAObject):


### PR DESCRIPTION
Fixes #538

An example playground to play around with, simply upload a `my_pdf.pdf` file to that project:

```yaml
---
include:
  - docassemble.AssemblyLine:assembly_line.yml
---
objects:
  - attachment: ALStaticDocument.using(title="Attachment", filename="my_pdf.pdf", has_addendum=False)
  - instructions: ALStaticDocument.using(title="Instructions", filename="my_pdf.pdf", has_addendum=False)
  - additional: ALStaticDocument.using(title="Additional", filename="my_pdf.pdf", has_addendum=False)
---
code: |
  attachment.enabled = True
  instructions.enabled = True
  additional.enabled = True
---
objects:
  - al_user_bundle: ALDocumentBundle.using(elements=[instructions, bundle], filename="appearance.pdf", title="Download all forms")
---
objects:
  - bundle: ALDocumentBundle.using(elements=[attachment, additional], filename="appearance.pdf", title="Bundle", enabled=False)
---
mandatory: True
question: Test first screen
subquestion: otherwise DA might 504 during development
continue button field: fake_field
---
mandatory: True
question: Hi
subquestion: |
  ${ al_user_bundle.download_list_html() }
```