### PR TITLE
DA 1.4.0 compatibility

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -42,9 +42,9 @@ from .al_document import (
 import json
 import os
 try:
-  import zoneinfo
+  import zoneinfo # type: ignore
 except ImportError:
-  import backports.zoneinfo as zoneinfo
+  import backports.zoneinfo as zoneinfo # type: ignore
 
 __all__ = [
     "is_file_like",

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -41,7 +41,10 @@ from .al_document import (
 )
 import json
 import os
-import backports.zoneinfo as zoneinfo
+try:
+  import zoneinfo
+except ImportError:
+  import backports.zoneinfo as zoneinfo
 
 __all__ = [
     "is_file_like",

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -41,10 +41,11 @@ from .al_document import (
 )
 import json
 import os
+
 try:
-  import zoneinfo # type: ignore
+    import zoneinfo  # type: ignore
 except ImportError:
-  import backports.zoneinfo as zoneinfo # type: ignore
+    import backports.zoneinfo as zoneinfo  # type: ignore
 
 __all__ = [
     "is_file_like",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3'],
+      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3', 'backports; python_version<"3.9"'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3', 'backports; python_version<"3.9"'],
+      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3', 'backports.zoneinfo; python_version<"3.9"'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
Now we're on python 3.10, there's a `zoneinfo` directly in python, and the `backports.zoneinfo` module doesn't exist.

Adds a try-except for the import, and additionally install the `backports.zoneinfo` package when AL is installed (without which, it will error on a fresh DA instance).