### PR TITLE
Address improvements

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -74,6 +74,7 @@ class ALAddress(Address):
         country_code: str = None,
         default_state: str = None,
         show_country: bool = False,
+        show_county: bool = False,
         show_if: Union[str, Dict[str, str]] = None,
         allow_no_address: bool = False,
     ):
@@ -101,25 +102,27 @@ class ALAddress(Address):
                     "help": str(self.has_no_address_explanation_help),
                     "show if": self.attr_name("has_no_address"),
                     "required": False,
-                }
-                ]
+                },
+            ]
         else:
             fields = []
-        fields.extend([
-            {
-                "label": str(self.address_label),
-                "address autocomplete": True,
-                "field": self.attr_name("address"),
-                "hide if": self.attr_name("has_no_address"),
-            },
-            {
-                "label": str(self.unit_label),
-                "field": self.attr_name("unit"),
-                "required": False,
-                "hide if": self.attr_name("has_no_address"),
-            },
-            {"label": str(self.city_label), "field": self.attr_name("city")},
-        ])
+        fields.extend(
+            [
+                {
+                    "label": str(self.address_label),
+                    "address autocomplete": True,
+                    "field": self.attr_name("address"),
+                    "hide if": self.attr_name("has_no_address"),
+                },
+                {
+                    "label": str(self.unit_label),
+                    "field": self.attr_name("unit"),
+                    "required": False,
+                    "hide if": self.attr_name("has_no_address"),
+                },
+                {"label": str(self.city_label), "field": self.attr_name("city")},
+            ]
+        )
         if country_code:
             fields.append(
                 {
@@ -156,11 +159,18 @@ class ALAddress(Address):
                     "hide if": self.attr_name("has_no_address"),
                 }
             )
-
+        if show_county:
+            fields.append(
+                {
+                    "label": str(self.county_label),
+                    "field": self.attr_name("county"),
+                    "required": False,
+                }
+            )
         if show_country:
             fields.append(
                 {
-                    "label": self.country_label,
+                    "label": str(self.country_label),
                     "field": self.attr_name("country"),
                     "required": False,
                     "code": "countries_list()",
@@ -202,10 +212,14 @@ class ALAddress(Address):
             line_breaker = '</w:t><w:br/><w:t xml:space="preserve">'
         else:
             line_breaker = " [NEWLINE] "
-        
-        if hasattr(self, "has_no_address") and self.has_no_address and hasattr(self, "has_no_address_explanation"):
+
+        if (
+            hasattr(self, "has_no_address")
+            and self.has_no_address
+            and hasattr(self, "has_no_address_explanation")
+        ):
             return (
-                self.has_no_address_explanation 
+                self.has_no_address_explanation
                 + line_breaker
                 + self.city
                 + line_breaker
@@ -275,7 +289,11 @@ class ALAddress(Address):
     def line_one(self, language=None, bare=False):
         """Returns the first line of the address, including the unit
         number if there is one."""
-        if hasattr(self, "has_no_address") and self.has_no_address and hasattr(self, "has_no_address_explanation"):
+        if (
+            hasattr(self, "has_no_address")
+            and self.has_no_address
+            and hasattr(self, "has_no_address_explanation")
+        ):
             return self.has_no_address_explanation
         if self.city_only:
             return ""
@@ -301,7 +319,11 @@ class ALAddress(Address):
         bare=False,
     ):
         """Returns a one-line address.  Primarily used internally for geocoding."""
-        if hasattr(self, "has_no_address") and self.has_no_address and hasattr(self, "has_no_address_explanation"):
+        if (
+            hasattr(self, "has_no_address")
+            and self.has_no_address
+            and hasattr(self, "has_no_address_explanation")
+        ):
             return f"{self.has_no_address_explanation}, {self.city} {self.state}"
         output = ""
         if self.city_only is False:
@@ -658,6 +680,7 @@ class ALIndividual(Individual):
         country_code: str = "US",
         default_state: str = None,
         show_country: bool = False,
+        show_county: bool = False,
         show_if: Union[str, Dict[str, str]] = None,
         allow_no_address: bool = False,
     ) -> List[Dict[str, str]]:
@@ -670,6 +693,7 @@ class ALIndividual(Individual):
             country_code=country_code,
             default_state=default_state,
             show_country=show_country,
+            show_county=show_county,
             show_if=show_if,
             allow_no_address=allow_no_address,
         )

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -382,28 +382,6 @@ class ALAddress(Address):
             return self.norm_long
         return self
 
-    def normalized_city(self) -> str:
-        """
-        Return the "normalized" city name as known by Google. Typically this is
-        the proper city name to use for mail delivery. It will standardize
-        lookups based on city if the user entered a neighborhood name like
-        "Dorchester" rather than the official city name, "Boston".
-        """
-        try:
-            self.geocode()
-        except:
-            pass
-        if (
-            hasattr(self, "norm_long")
-            and hasattr(self.norm_long, "city")
-            and self.norm_long.city
-        ):
-            return self.norm_long.city
-        else:
-            if hasattr(self, "city") and self.city:
-                return self.city
-        return ""
-
 
 class ALAddressList(DAList):
     """Store a list of Address objects"""

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -364,6 +364,12 @@ template: x.country_label
 content: |
   Country
 ---
+generic object: ALAddress
+template: x.county_label
+content: |
+  County
+# Note: Louisiana uses Parish while Alaska uses Borough. Handle by overriding this template
+---
 id: your name
 sets:
     - users[0].name.first

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1783,3 +1783,22 @@ question: |
 fields:
   - code: |
       x.language_fields(choices=al_language_user_choices)
+---
+generic object: ALIndividual
+template: x.address.has_no_address_label
+content: |
+  ${ x } does not have an address
+---
+template: users[0].address.has_no_address_label
+content: |
+  I do not have an address
+---
+generic object: ALAddress
+template: x.has_no_address_explanation_label
+content: |
+  Anything else you want to add about your living situation?
+---
+generic object: ALAddress
+template: x.has_no_address_explanation_help
+content: |
+  Example: "I normally sleep at 5th and Main."


### PR DESCRIPTION
A small collection of new, optional ALAddress enhancements:

Fix #213 - Provide a helper method to get the "normalized" address as known by Google, even if user provides a neighborhood instead of city name
Fix #127  - Provide an optional way for unhoused people to describe as much of their address as possible. Adjusted address.block(), line_one() etc. so they can handle addresses provided with this feature
Fix #535 - Add a parameter to show/hide the county field in address_fields() method

Small test YAML:

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
question: |
  Address
fields:
  - code: |
      users[0].address_fields(allow_no_address=True)
---
mandatory: True
question: |
subquestion: |
  
  ${ users[0].address.on_one_line() }
  
  ${ users[0].address.line_one() }
  
  ${ users[0].address.line_two() }
  
  ${ users[0].normalized_address().block() }
```