### PR TITLE
Fix no address

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -112,17 +112,19 @@ class ALAddress(Address):
                     "label": str(self.address_label),
                     "address autocomplete": True,
                     "field": self.attr_name("address"),
-                    "hide if": self.attr_name("has_no_address"),
                 },
                 {
                     "label": str(self.unit_label),
                     "field": self.attr_name("unit"),
                     "required": False,
-                    "hide if": self.attr_name("has_no_address"),
                 },
-                {"label": str(self.city_label), "field": self.attr_name("city")},
             ]
         )
+        if allow_no_address:
+            fields[-1]["hide if"] = self.attr_name("has_no_address")
+            fields[-2]["hide if"] = self.attr_name("has_no_address")
+
+        fields.append({"label": str(self.city_label), "field": self.attr_name("city")})
         if country_code:
             fields.append(
                 {
@@ -146,7 +148,6 @@ class ALAddress(Address):
                     "label": str(self.zip_label),
                     "field": self.attr_name("zip"),
                     "required": False,
-                    "hide if": self.attr_name("has_no_address"),
                 }
             )
         else:
@@ -156,9 +157,11 @@ class ALAddress(Address):
                     "label": str(self.postal_code_label),
                     "field": self.attr_name("zip"),
                     "required": False,
-                    "hide if": self.attr_name("has_no_address"),
                 }
             )
+        if allow_no_address:
+            fields[-1]["hide if"] = self.attr_name("has_no_address")
+
         if show_county:
             fields.append(
                 {

--- a/docassemble/AssemblyLine/data/questions/test_alcourts.yml
+++ b/docassemble/AssemblyLine/data/questions/test_alcourts.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - al_package.yml
+  - assembly_line.yml
 ---
 metadata:
   title: |

--- a/docassemble/AssemblyLine/data/questions/test_question_library.yml
+++ b/docassemble/AssemblyLine/data/questions/test_question_library.yml
@@ -1,0 +1,42 @@
+---
+include:
+  - assembly_line.yml
+---
+metadata:
+  title: |
+    Test Question Library
+---
+mandatory: True
+code: |
+  which_to_test
+  if which_to_test == 'name':
+    users[0].name.first
+  else:
+    users[0].name.first = 'John'
+    users[0].name.last = 'Brown'
+
+  if which_to_test == 'address':
+    users[0].address.address
+  if which_to_test == 'address_no_address':
+    users[0].address.has_no_address
+  if which_to_test == 'contact':
+    users[0].phone_number
+  all_done
+---
+event: all_done
+question: All done!
+---
+question: Which question do you want to test?
+field: which_to_test
+choices:
+  - Address: address
+  - Address (with the option to not have one): address_no_address
+  - Contact Information: contact
+---
+sets: users[0].address.has_no_address
+question: |
+  What is your address?
+fields: 
+  - code: |
+      users[0].address_fields(allow_no_address=True, country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
+ 

--- a/docassemble/AssemblyLine/data/sources/test_question_library.feature
+++ b/docassemble/AssemblyLine/data/sources/test_question_library.feature
@@ -1,0 +1,43 @@
+@alql
+Feature: AL question library
+
+@alql @ql1
+Scenario: Can enter all parts of address
+  Given the max seconds for each step is 50
+  And I start the interview at "test_question_library"
+  Then I set the variable "which_to_test" to "address"
+  And I tap to continue
+  Then I should see the phrase "Street address"
+  And I should see the phrase "Apartment"
+  And I set the variable "users[0].address.address" to "123 Fake Street"
+  And I set the variable "users[0].address.unit" to "Apt 5"
+  And I set the variable "users[0].address.city" to "Boston"
+  And I set the variable "users[0].address.state" to "MA"
+  And I set the variable "users[0].address.zip" to "12345"
+  And I tap to continue
+  Then I should see the phrase "All done!"
+
+@alql @ql2
+Scenario: Can say no address available
+  Given the max seconds for each step is 50
+  And I start the interview at "test_question_library"
+  Then I set the variable "which_to_test" to "address_no_address"
+  And I tap to continue
+  And I set the variable "users[0].address.has_no_address" to "True"
+  And I set the variable "users[0].address.has_no_address_explanation" to "I sometimes sleep at 5th and Yorkshire"
+  And I set the variable "users[0].address.city" to "Boston"
+  And I set the variable "users[0].address.state" to "MA"
+  And I tap to continue
+  Then I should see the phrase "All done!"
+
+@alq1 @ql3
+Scenario: Can enter all parts of contact info
+  Given the max seconds for each step is 50
+  And I start the interview at "test_question_library"
+  Then I set the variable "which_to_test" to "contact"
+  And I tap to continue
+  And I tap to continue
+  Then I should see the phrase "You need to provide at least one contact method"
+  And I set the variable "users[0].mobile_number" to "123-456-7890"
+  And I tap to continue
+  Then I should see the phrase "All done!"


### PR DESCRIPTION
`hide if` will hide the field if the variable isn't present.

Also adds a simple ALKiln test to look for things like this again, just in the question library versions of address, no address, and contact info. ALKiln test passes locally.