### PR TITLE
Switch back to the clickable link being form title, not subtitle

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
@@ -7,7 +7,7 @@ code: |
 initial: True
 code: |
   ########### Save title and progress to session list ##################
-  if get_config("assembly line",{}).get("update answer set metadata"):
+  if get_config("assembly line",{}).get("update session metadata"):
     # To limit impact on DB, save progress every 3 steps or when progress is 100 +- 1
     if get_progress() > 99 or int(_internal.get('steps',1)) % 3 == 1:
       al_temp_metadata = get_interview_metadata(

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -111,14 +111,18 @@ subquestion: |
   documents.
   % endif
 
-  ${ session_list_html(filename=None, limit=20, offset=session_page) }
-  
+  ${ session_list_html(filename=None, limit=20, offset=session_page*20) }
+
+  <nav aria-label="Page navigation">
+    <ul class="pagination justify-content-center">
   % if session_page > 0:
-  [< Previous page](${ url_action("update_page_event", page_increment=-1) })
+      <li class="page-item"><a class="page-link" href="${ url_action("update_page_event", page_increment=-1) }">Previous</a></li>
   % endif
-  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, offset=session_page)) > 20:
-  [Next page >](${ url_action("update_page_event", page_increment=1) })
+  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, limit=20, offset=session_page*20)) >= 20:
+      <li class="page-item"><a class="page-link" href="${ url_action("update_page_event", page_increment=1) }">Next</a></li>
   % endif
+    </ul>
+  </nav>  
   % else:
   You do not have any current forms in progress
   % endif

--- a/docassemble/AssemblyLine/data/static/interview_list.css
+++ b/docassemble/AssemblyLine/data/static/interview_list.css
@@ -21,6 +21,10 @@
       flex-flow: row wrap;
 }*/
 
+.al-session-form-title {
+  font-weight: bolder;
+}
+
 .radialProgressBar {
   border-radius: 50%;
   width: 2.5rem;

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -670,24 +670,25 @@ def session_list_html(
         table += """<tr class="al-saved-answer-table-row">"""
         table += f"""
         <td>
-        <a href="{ interview_url(i=answer.get("filename"), session=answer.get("key")) }">{ nice_interview_subtitle(answer, exclude_identical=False) or nice_interview_title(answer) }</a>
+        <a class="al-session-form-title" href="{ interview_url(i=answer.get("filename"), session=answer.get("key")) }">{ nice_interview_title(answer) }</a>
         {"<br/>" if nice_interview_subtitle(answer) else ""}
-        <span class="al-session-title">{ nice_interview_title(answer) if nice_interview_subtitle(answer) else "" }</span>
+        <span class="al-session-form-subtitle">{ nice_interview_subtitle(answer) if nice_interview_subtitle(answer) else "" }</span>
         </td>
         """
         table += f"""
-        <td>{ local_date(answer.get("modtime")) } <br/>
-            { format_time(local_date(answer.get("modtime")).time(), format="h:mm a") }
+        <td>
+            <span class="al-session-date-modified">{ local_date(answer.get("modtime")) }</span> <br/>
+            <span class="al-session-time-modified">{ format_time(local_date(answer.get("modtime")).time(), format="h:mm a") }</span>
         </td>
         <td class="al-progress-box">{ radial_progress(answer) }
         </td>
         <td>
-          <a href="{ url_ask_rename }"><i class="fa-solid fa-tag" aria-hidden="true" title="{ rename_label }"></i><span class="sr-only">{ rename_label }</span></a>
+          <a class="al-sessions-action-rename" href="{ url_ask_rename }"><i class="fa-solid fa-tag" aria-hidden="true" title="{ rename_label }"></i><span class="sr-only">{ rename_label }</span></a>
         """
         if get_config("assembly line", {}).get("enable answer sets"):
             table += f"""
           &nbsp;
-          <a href="{ url_ask_copy }"><i class="fa-regular fa-clone" aria-hidden="true" title="{clone_label}"></i><span class="sr-only">{ clone_label }</span></a>
+          <a class="al-sessions-actions-clone" href="{ url_ask_copy }"><i class="fa-regular fa-clone" aria-hidden="true" title="{clone_label}"></i><span class="sr-only">{ clone_label }</span></a>
           """
         table += f"""
           &nbsp;


### PR DESCRIPTION
- Make the clickable link the form title again, not the subtitle
- Add some new CSS classes to allow more customization of layout
- Default the form title to being bold

If tests pass, I'll go ahead and merge as this is a minor revision to the last PR and doesn't need a full review. This feature is currently only being evaluated by ILAO although hopefully we'll deploy it live soon.