### PR TITLE
Rename "docket number" to case number

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -10,6 +10,7 @@ objects:
   - other_parties: ALPeopleList
   - witnesses: ALPeopleList.using(ask_number=True)
   - docket_numbers: DAList
+  - case_numbers: DAList
   - caregivers: ALPeopleList
   - guardians_ad_litem: ALPeopleList
   - attorneys: ALPeopleList
@@ -27,8 +28,6 @@ objects:
   - courts: DAList.using(auto_gather=False, target_number=1, gathered=True)
   - trial_court_address: Address
   - appeals_court_address: Address
-  
-  
 ---
 id: basic questions intro screen
 decoration: form-lineal
@@ -604,6 +603,36 @@ subquestion: |
 list collect: True
 fields:
   - Case number: docket_numbers[i]
+    required: False
+---
+id: case number
+question: |
+  What is the case number used to track this case in court?
+fields:
+  - I don't know the case number: dont_know_case_number
+    datatype: yesno    
+  - Case number: case_number
+    hide if: dont_know_case_number
+validation code: |
+  # This should be safe too
+  if dont_know_case_number:
+    case_number = ''    
+---
+question: |
+  Do you have a case number used to track this case in court?
+fields:
+  - I have a case number: case_numbers.there_are_any
+    datatype: yesnoradio
+---
+id: case numbers
+question: |
+  Case number
+subquestion: |
+  If there are multiple case numbers on this form, you can tap "${word("Add another")}"
+  to add more than one.
+list collect: True
+fields:
+  - Case number: case_numbers[i]
     required: False
 ---
 id: who will be on this form

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -578,32 +578,32 @@ content: |
 ---
 id: docket number
 question: |
-  What is the docket number for your case?
+  What is the case number used to track this case in court?
 fields:
-  - I don't know the docket number: dont_know_docket_number
+  - I don't know the case number: dont_know_docket_number
     datatype: yesno    
-  - no label: docket_number
+  - Case number: docket_number
     hide if: dont_know_docket_number
 validation code: |
-  # This should be safe to 
+  # This should be safe too
   if dont_know_docket_number:
-    docket_number = ''      
+    docket_number = ''    
 ---
 question: |
-  Do you have a docket number for this case?
+  Do you have a case number used to track this case in court?
 fields:
-  - no label: docket_numbers.there_are_any
+  - I have a case number: docket_numbers.there_are_any
     datatype: yesnoradio
 ---
 id: docket numbers
 question: |
-  What is the docket number for this case?
+  Case number
 subquestion: |
-  If there are multiple docket numbers on this form, you can tap "${word("Add another")}"
+  If there are multiple case numbers on this form, you can tap "${word("Add another")}"
   to add more than one.
 list collect: True
 fields:
-  - no label: docket_numbers[i]
+  - Case number: docket_numbers[i]
     required: False
 ---
 id: who will be on this form


### PR DESCRIPTION
Fix #564. Docket number, as far as we can tell with the dozen or so states we've interacted with, is a pretty Massachusetts-specific term. The more general term is "case number". This changes the phrasing of "Docket number" to be "case number" so that people in other states can get better interviews out of the box.

See https://github.com/SuffolkLITLab/docassemble-ALMassachusetts/issues/7 which will move the docket number phrasing to ALMassachusetts, where it is the less confusing term