### PR TITLE
Fix session list on small screens

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -536,14 +536,14 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
     If exclude_identical, return empty string when title is the same as the subtitle.
     """
     if answer.get("title"):
-        return pascal_to_zwspace(answer.get("title"))
+        return pascal_to_zwspace(answer["title"])
     elif answer.get("auto_title") and (
         not exclude_identical
         or not (
             answer.get("auto_title", "").lower() == nice_interview_title(answer).lower()
         )
     ):
-        return pascal_to_zwspace(answer.get("auto_title"))
+        return pascal_to_zwspace(answer["auto_title"])
     else:
         return ""
 


### PR DESCRIPTION
Currently on small screens, if the title of the form uses PascalCase, it will bleed into the second column.
This change:
- Inserts an invisible space (zero width space) into PascalCase words so there is a natural break point
- Turns on the bootstrap text-break utility so that further breaks can happen even in the middle of a word instead of breaking the display

Fix #568 