### PR TITLE
Don't turn on address autocomplete if not enabled

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -110,7 +110,9 @@ class ALAddress(Address):
             [
                 {
                     "label": str(self.address_label),
-                    "address autocomplete": bool((get_config("google") or {}).get("google maps api key")),
+                    "address autocomplete": bool(
+                        (get_config("google") or {}).get("google maps api key")
+                    ),
                     "field": self.attr_name("address"),
                 },
                 {

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -110,7 +110,7 @@ class ALAddress(Address):
             [
                 {
                     "label": str(self.address_label),
-                    "address autocomplete": True,
+                    "address autocomplete": bool((get_config("google") or {}).get("google maps api key")),
                     "field": self.attr_name("address"),
                 },
                 {


### PR DESCRIPTION
Checks if the google maps API is present on the server, and if it isn't, does not use address autocomplete in `ALAddress.address_fields()`.

Not necessary for our servers, but helpful when running on local servers, and for users who might not wath Google autocomplete enabled.