### PR TITLE
Check if the `suffix_to_append` attribute exists

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -673,6 +673,8 @@ class ALDocument(DADict):
 
         safe_key = space_to_underscore(key)
 
+        if not hasattr(self, 'suffix_to_append'):
+            self.suffix_to_append = "preview"
         if append_matching_suffix and key == self.suffix_to_append:
             append_suffix: str = f"_{safe_key}"
         else:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -673,7 +673,7 @@ class ALDocument(DADict):
 
         safe_key = space_to_underscore(key)
 
-        if not hasattr(self, 'suffix_to_append'):
+        if not hasattr(self, "suffix_to_append"):
             self.suffix_to_append = "preview"
         if append_matching_suffix and key == self.suffix_to_append:
             append_suffix: str = f"_{safe_key}"


### PR DESCRIPTION
On older objects, the attribute might not exist, so make sure it's updated to the standard default. I think this was the only place where we weren't setting this value at the beginning of functions.

This error has shown up on the production server in both the Name change interview and the 209a on 9/14 and 9/15.