### PR TITLE
Close #563 Add send email table row and change styling to align buttons

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -103,14 +103,14 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     html = (
         f'\n\t<div class="row al_doc_table_row">'
         f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
-        # At some widths, `col-6` barely has room to avoid 
+        # At some widths, `col-6` barely has room to avoid
         # wrapping lines for these buttons
         f'\n\t\t<div class="col col-6 al_buttons">'
     )
     for button in button_htmls:
         html += button
-    html += '</div>'
-    html += '\n\t</div>'
+    html += "</div>"
+    html += "\n\t</div>"
 
     return html
 
@@ -1188,7 +1188,7 @@ class ALDocumentBundle(DAList):
         zip_label: str = None,
         zip_icon: str = "file-archive",
         append_matching_suffix: bool = True,
-        include_email: bool = False
+        include_email: bool = False,
     ) -> str:
         """
         Returns string of a table to display a list
@@ -1294,8 +1294,8 @@ class ALDocumentBundle(DAList):
             html += table_row(zip.title, zip_button)
 
         if include_email:
-          html += self.send_email_table_row( key=key )
-            
+            html += self.send_email_table_row(key=key)
+
         html += "\n</div>"
 
         # Discuss: Do we want a table with the ability to have a merged pdf row?
@@ -1355,7 +1355,7 @@ class ALDocumentBundle(DAList):
 
         return html
 
-    def send_email_table_row( self, key: str = "final" ) -> str:
+    def send_email_table_row(self, key: str = "final") -> str:
         """
         Generate HTML doc table row for an input box and button that allows
         someone to send the bundle to the specified email address.
@@ -1386,10 +1386,10 @@ class ALDocumentBundle(DAList):
           <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
-        
+
         # "Send" button for the 2nd column of the table row
         send_button = f'{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}'
-        
+
         # Whole row put together
         html = f"""
         <div class="row al_doc_table_row al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
@@ -1397,7 +1397,7 @@ class ALDocumentBundle(DAList):
           <div class="col col-3 al_email_send_col al_buttons">{ send_button }</div>
         </div>
         """
-        
+
         return html
 
     def send_button_html(

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -101,7 +101,7 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     return the row of an AL document-styled table in HTML format.
     """
     html = (
-        f'\n\t<div class="row al_doc_table_row">''
+        f'\n\t<div class="row al_doc_table_row">'
         f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
         # At some widths, `col-6` barely has room to avoid 
         # wrapping lines for these buttons
@@ -1382,7 +1382,7 @@ class ALDocumentBundle(DAList):
         # Label "email" and input field for the 1st column of the table row
         input_html = f"""
         <span class="al_email_input_container {name} form-group da-field-container da-field-container-datatype-email">
-          <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+          <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
           <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
@@ -1450,7 +1450,7 @@ class ALDocumentBundle(DAList):
   <div class="al_email_container">
   
     <span class="al_email_address {name} container form-group row da-field-container da-field-container-datatype-email">
-      <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+      <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
       <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
     </span>
     

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -109,23 +109,27 @@ subquestion: |
   
   Note: We're deprecating `download_html()` and removing it, so it will not be tested in here.
 
-  multi_bundle_1.download_list_html()
+  multi_bundle_1.download_list_html() with send button for alignment comparison
   
   ${ multi_bundle_1.download_list_html() }
   
-  ---
+  ${ multi_bundle_1.send_button_html() }
+  
+  multi_bundle_1.download_list_html( include_email=True )
+  
+  ${ multi_bundle_1.download_list_html( include_email=True ) }
 
   single_pdf_bundle_1.download_list_html()
   
   ${ single_pdf_bundle_1.download_list_html() }
   
-  ---
+  single_pdf_bundle_1.download_list_html( include_email=True )
+  
+  ${ single_pdf_bundle_1.download_list_html( include_email=True ) }
 
   single_docx_bundle_1.download_list_html()
   
   ${ single_docx_bundle_1.download_list_html() }
-  
-  ---
 ---
 # Keeping this in here until method is completely removed just in case other decisions are made
 #id: download_html_defaults
@@ -146,19 +150,13 @@ subquestion: |
 
   ${ multi_bundle_1.send_button_html() }
   
-  ---
-  
   single_pdf_bundle_1.send_button_html()
 
   ${ single_pdf_bundle_1.send_button_html() }
   
-  ---
-  
   single_docx_bundle_1.send_button_html()
 
   ${ single_docx_bundle_1.send_button_html() }
-  
-  ---
 ---
 id: as_foo_custom
 continue button field: as_foo_custom

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -1,7 +1,6 @@
 /* WARNING TO AL DEVELOPERS: Only use CSS _classes_ in our CSS unless you know for a fact that an ID is static. Most IDs are generated dynamically, so using them in the CSS will only work with our test files. */
 
 /* ========= Isolated email send button ========= */
-/* Email button (there's another section for this at the bottom?) */
 /* Feedback from UI designers has been that email input field and
    send button should be on the same line. */
 
@@ -37,7 +36,7 @@
 }
 
 .al_send_section_alone .al_email_address,
-.al_send_section_alone .al_doc_email_label {
+.al_send_section_alone .al_email_address label {
   max-width: 70%;
   padding-left: 0;
 }
@@ -47,12 +46,26 @@
 }
 
 .al_send_section_alone .al_doc_email_header {
+  margin: 1em 0;
+}
+
+.al_send_section_alone .al_doc_email_header {
     margin-bottom: 0.2em;
+}
+
+/* al_email_container mobile version */
+@media only screen and (max-width: 700px) {
+  .al_email_container {
+    display: block; 
+  }
+  .al_email_container > span > input {
+    margin: 0 0 10px; 
+  }
 }
 
 /* ========= Table rows ========= */
 .al_doc_table {
-    margin-bottom: 2em;
+    margin-bottom: 2rem;
 }
 
 .al_doc_table_row .al_doc_title,
@@ -81,7 +94,7 @@
     justify-content: space-between;
 }
 
-.al_doc_table_row .al_doc_email_label {
+.al_doc_table_row .al_email_input_container label {
     width: unset;
     padding-right: 1em;
 }
@@ -91,107 +104,7 @@
     flex-grow: 1;
 }
 
-/*
-.al_table_css_sibling + div thead {
-  display: none;
-}
-
-.al_table_css_sibling + div td {
-  padding: .3em;
-  vertical-align: text-top;
-}
-td.text-left:first-child {
-  width: 1em;
-  padding-left: .5em;
-}
-.al_table_css_sibling + div td.text-left + td.text-right {
-  width: 5em;
-}
-.al_table_css_sibling + div td.text-right {
-  width: 7em;
-}
-
-.al_table_css_sibling + div a {
-  margin: 0em;
-}
-*/
-
-/* TODO: Should it be this broad? This looks like it's for all pages */
+/* TODO: Should it be in here and this broad? This looks like it's for all pages */
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;
 }
-
-/* Should not be an id */
-#al_doc_email_header {
-  margin: 1rem 0;
-}
-
-.al_doc_email_header {
-  margin: 1rem 0;
-}
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_user_bundle {
-  margin: 0.5rem 0;
-}
-*/
-
-/* Avoid icons being on their own lines */
-/*
-.al_table .al_buttons .btn {
-  position: relative;
-  margin: 0;
-  margin-bottom: 0.1rem;
-  white-space: nowrap;
-}
-*/
-
-/* On wide screens, let titles wrap, but let buttons stay horizontal */
-/* On small screens, wrap buttons and let titles have the room they need */
-/*
-@media only screen and (min-width: 450px) {
-  .al_table .al_buttons {
-    white-space: nowrap;
-  }
-}
-*/
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_user_bundle td div {
-  min-width: 320px;
-}
-*/
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_send_bundle_al_user_bundle .form-check-container {
-  margin: 0.5rem 0 5px 0;
-}
-*/
-
-/* al_email_container mobile version */
-@media only screen and (max-width: 700px) {
-  .al_email_container {
-    display: block; 
-  }
-  .al_email_container > span > input {
-    margin: 0 0 10px; 
-  }
-}
-
-/* The following 3 rules split title/button columns on the download screen by a 30%/70% ratio. This is to give the buttons enough room to stay horizontal even with long titles. */
-/*
-table {
-  width: 100%;
-  table-layout: fixed;
-}
-.al_doc_title {
-  width: 30%; 
-}
-.al_buttons {
-  width: 70%;
-  padding-left: 2em;  
-}
-*/

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -1,27 +1,97 @@
 /* WARNING TO AL DEVELOPERS: Only use CSS _classes_ in our CSS unless you know for a fact that an ID is static. Most IDs are generated dynamically, so using them in the CSS will only work with our test files. */
 
-/* Email button (there's another section for this at the bottom) */
+/* ========= Isolated email send button ========= */
+/* Email button (there's another section for this at the bottom?) */
 /* Feedback from UI designers has been that email input field and
    send button should be on the same line. */
-.al_email_address, .al_email_address label, .al_email_address input {
+
+.al_send_section_alone {
+  margin-bottom: 2rem;
+}
+
+.al_send_section_alone .al_email_address,
+.al_send_section_alone .al_email_address label,
+.al_send_section_alone .al_email_address input {
   display: inline;
   width: unset;
   margin: unset;
 }
 
-.al_email_address input {
+.al_send_section_alone .al_email_address input {
   max-width: 50%
 }
 
-.al_send_button {
+.al_send_section_alone .al_send_button {
   display: inline-block;
 }
-.al_send_editable {
+
+.al_send_section_alone .al_send_editable {
   display: block;
   width: 100%;
 }
 
-/* Download buttons */
+.al_send_section_alone .al_email_container {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.al_send_section_alone .al_email_address,
+.al_send_section_alone .al_doc_email_label {
+  max-width: 70%;
+  padding-left: 0;
+}
+
+.al_send_section_alone .al_email_address input {
+  max-width: 80%;
+}
+
+.al_send_section_alone .al_doc_email_header {
+    margin-bottom: 0.2em;
+}
+
+/* ========= Table rows ========= */
+.al_doc_table {
+    margin-bottom: 2em;
+}
+
+.al_doc_table_row .al_doc_title,
+.al_doc_table_row .al_buttons,
+.al_doc_table_row .al_email_send_col {
+    text-align: right;
+}
+
+.al_doc_table_row .al_buttons,
+.al_doc_table_row .al_email_send_col {
+  padding-right: 0;
+}
+
+.al_doc_table_row .al_doc_title,
+.al_doc_table_row .al_doc_email,
+.al_doc_table_row .al_email_input_col {
+  padding-left: 0;
+}
+
+.al_doc_table_row .al_doc_title {
+  font-weight: bold;
+}
+
+.al_doc_table_row .al_email_input_container {
+    display: flex;
+    justify-content: space-between;
+}
+
+.al_doc_table_row .al_doc_email_label {
+    width: unset;
+    padding-right: 1em;
+}
+
+.al_doc_table_row .al_doc_email_field {
+    width: 50%;
+    flex-grow: 1;
+}
+
+/*
 .al_table_css_sibling + div thead {
   display: none;
 }
@@ -44,42 +114,63 @@ td.text-left:first-child {
 .al_table_css_sibling + div a {
   margin: 0em;
 }
+*/
 
+/* TODO: Should it be this broad? This looks like it's for all pages */
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;
 }
 
+/* Should not be an id */
 #al_doc_email_header {
   margin: 1rem 0;
 }
 
+.al_doc_email_header {
+  margin: 1rem 0;
+}
+
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_user_bundle {
   margin: 0.5rem 0;
 }
+*/
 
+/* Avoid icons being on their own lines */
+/*
 .al_table .al_buttons .btn {
   position: relative;
   margin: 0;
   margin-bottom: 0.1rem;
-  /* Avoid icons being on their own lines */
   white-space: nowrap;
 }
+*/
 
 /* On wide screens, let titles wrap, but let buttons stay horizontal */
 /* On small screens, wrap buttons and let titles have the room they need */
+/*
 @media only screen and (min-width: 450px) {
   .al_table .al_buttons {
     white-space: nowrap;
   }
 }
+*/
 
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_user_bundle td div {
   min-width: 320px;
 }
+*/
 
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_send_bundle_al_user_bundle .form-check-container {
   margin: 0.5rem 0 5px 0;
 }
+*/
+
 /* al_email_container mobile version */
 @media only screen and (max-width: 700px) {
   .al_email_container {
@@ -89,7 +180,9 @@ td.text-left:first-child {
     margin: 0 0 10px; 
   }
 }
+
 /* The following 3 rules split title/button columns on the download screen by a 30%/70% ratio. This is to give the buttons enough room to stay horizontal even with long titles. */
+/*
 table {
   width: 100%;
   table-layout: fixed;
@@ -101,3 +194,4 @@ table {
   width: 70%;
   padding-left: 2em;  
 }
+*/

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from distutils.util import convert_path
 
 standard_exclude = ('*.pyc', '*~', '.*', '*.bak', '*.swp*')
 standard_exclude_directories = ('.*', 'CVS', '_darcs', './build', './dist', 'EGG-INFO', '*.egg-info')
+
 def find_package_data(where='.', package='', exclude=standard_exclude, exclude_directories=standard_exclude_directories):
     out = {}
     stack = [(convert_path(where), '', package)]
@@ -53,7 +54,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3', 'backports.zoneinfo; python_version<"3.9"'],
+      install_requires=['docassemble.ALToolbox>=0.6.0', 'docassemble.GithubFeedbackForm>=0.2.0b1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
Closes #563, alignment of document download table buttons vs. document email section parts, plus other alignment and styling issues. [I tried to limit the changes to the email section as people are using that styled as-is right now.] Here are some notes from our deep dive doc as well:

* We’re going to add a new parameter to download_list_html() to include the send email button. But it will be a copy of the feature - we won’t delete the existing send_button_html() method
* We need to fix the send_button_html() method to remove the H4 and replace with H2 class="h4"
* Maybe we want to right align the send button of the separate email section, but we need to check with Matt to see if it will mess up his styles
* We want to remove the big gutter between the buttons and the text

ACCESSIBILITY QUESTION: Giving the separate email section an `h2` tag assumes that it's always the second level header after the title at the top of the page. I can easily see it being under a different `h2` - the name of document they're sending. Basically `h2`, or any level of header, seems like an assumption I'm not sure we can make if we want to align with accessibility. Thoughts?

Screenshots of the tables and send email section with different widths:

### Narrower

<img width="241" alt="narrower_screen" src="https://user-images.githubusercontent.com/52798256/193133237-467f49ca-8bb6-46b5-8a98-c7268ff9c4a1.png">

---

### Wider

<img width="328" alt="wider_screen" src="https://user-images.githubusercontent.com/52798256/193133238-57664f0e-027f-4b14-9df5-8e677ed04708.png">
