### PR TITLE
Improve usability of signature question

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -126,7 +126,10 @@ code: |
     # 3. Used the QR code
     saw_signature_choice
     # Branch 1: PC
-    if signature_choice =='this device':
+    if signature_choice == "sign_after_printing":
+      for signature in signature_fields:
+        define(signature, DAEmpty())
+    elif signature_choice in ['this device', 'this_device']:
       for signature in signature_fields:
         value(signature)    
     # Check for Branch 2 or 3

--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -108,7 +108,7 @@ attachment:
 # Signature code  
 ---
 code: |
-  started_on_phone = device() and device().is_mobile
+  started_on_phone = device() and (device().is_mobile or device().is_touch_capable)
 ---
 # Triggers some questions to ask for signatures on either desktop or mobile
 # Allows sending via text/email

--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -101,5 +101,6 @@ code: |
 ---
 code: |
   AL_DEFAULT_OVERFLOW_MESSAGE = "..."
-  
-  
+---
+code: |
+  al_form_requires_digital_signature = True

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1243,22 +1243,21 @@ fields:
   - Choose a way to sign: signature_choice
     input type: radio
     choices:
-      - Give me a link so I can sign on my phone with my finger: phone
-        image: mobile-alt
+      - Sign on a phone with my finger: phone
+        help: |
+          We can text or share a link with your phone on the next screen
       - Sign with my computer mouse: this_device
-        image: desktop
     show if:
       code: |
         al_form_requires_digital_signature
   - Choose a way to sign: signature_choice
     input type: radio
     choices:
-      - Give me a link so I can sign on my phone with my finger: phone
-        image: mobile-alt
+      - Sign on a phone with my finger: phone
+        help: |
+          We can text or share a link with your phone on the next screen
       - Sign with my computer mouse: this_device
-        image: desktop
       - Sign after I print: sign_after_printing
-        image: print
     show if:
       code: |
         not al_form_requires_digital_signature

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1236,28 +1236,28 @@ code: |
 id: signature choice
 decoration: file-signature
 question: |
-  How do you want to sign your forms?
+  Your documents are almost ready
 subquestion: |
-  Your forms are almost ready. You need to sign them first.
+  How do you want to sign them?
 fields: 
-  - Choose a way to sign: signature_choice
+  - I will sign: signature_choice
     input type: radio
     choices:
-      - Sign on a phone with my finger: phone
+      - On a phone with my finger: phone
         help: |
           We can text or share a link with your phone on the next screen
-      - Sign with my computer mouse: this_device
+      - On a computer with my mouse: this_device
     show if:
       code: |
         al_form_requires_digital_signature
-  - Choose a way to sign: signature_choice
+  - I will sign: signature_choice
     input type: radio
     choices:
-      - Sign on a phone with my finger: phone
+      - On a phone with my finger: phone
         help: |
           We can text or share a link with your phone on the next screen
-      - Sign with my computer mouse: this_device
-      - Sign after I print: sign_after_printing
+      - On a computer with my mouse: this_device
+      - On the paper with a pen after I print the documents: sign_after_printing
     show if:
       code: |
         not al_form_requires_digital_signature

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1060,7 +1060,7 @@ question: |
 signature: x.signature
 under: |
   ${x}
-progress: 99  
+progress: 99
 ---
 id: signature date
 question: |
@@ -1236,24 +1236,33 @@ code: |
 id: signature choice
 decoration: file-signature
 question: |
-  Sign your forms
+  How do you want to sign your forms?
 subquestion: |
   Your forms are almost ready. You need to sign them first.
-  
-  Use the mouse or touchpad on your computer or
-  sign with your finger on a smartphone.
-field: signature_choice
-buttons:  
-  - Sign on my phone: phone
-    image: mobile-alt
-  - Sign on this computer: this device
-    image: desktop
-continue button field: saw_signature_choice
-script: |
-  <script>
-    $(".da-field-buttons > div > .btn-da-custom").last().after("<br>")
-    $(".da-field-buttons > div > .btn-da-custom").first().before("<br>")
-  </script>
+fields: 
+  - Choose a way to sign: signature_choice
+    input type: radio
+    choices:
+      - Give me a link so I can sign on my phone with my finger: phone
+        image: mobile-alt
+      - Sign with my computer mouse: this_device
+        image: desktop
+    show if:
+      code: |
+        al_form_requires_digital_signature
+  - Choose a way to sign: signature_choice
+    input type: radio
+    choices:
+      - Give me a link so I can sign on my phone with my finger: phone
+        image: mobile-alt
+      - Sign with my computer mouse: this_device
+        image: desktop
+      - Sign after I print: sign_after_printing
+        image: print
+    show if:
+      code: |
+        not al_form_requires_digital_signature
+continue button field: saw_signature_choice        
 ---
 comment: |
   This block is shown when the user texts a link to sign a form


### PR DESCRIPTION
Fix #585

This just makes the changes we discussed on our call today. It's a pretty simple fix but touches most of our interviews so I welcome additional feedback I missed on the call.

![image](https://user-images.githubusercontent.com/7645641/193682593-3ddc420d-81be-4e64-9a3c-077b48761e75.png)

I added a new flag variable, `al_form_requires_digital_signature` which can be used to add a third option that's currently missing: "sign after I print". When this is chosen, the `x.signature` attribute will be defined as `DAEmpty()`