### PR TITLE
Close #563 Add send email table row and change styling to align buttons

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Suffolk Legal Innovation and Technology Lab
+Copyright (c) 2023 Suffolk Legal Innovation and Technology Lab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1432,7 +1432,7 @@ class ALDocumentBundle(DAList):
         the bundle to the specified email address.
 
         Optionally, display a checkbox that allows someone to decide whether or not to
-        include an editable (Word) copy of the file, if it is available.
+        include an editable (Word) copy of the file, if and only if it is available.
         """
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1280,7 +1280,7 @@ class ALDocumentBundle(DAList):
                 icon=download_icon,
                 color="primary",
                 size="md",
-                classname="al_download",
+                classname="al_download al_button",
             )
             if view and doc.as_pdf().url_for().endswith(".pdf"):
                 doc_view_button = action_button_html(
@@ -1293,7 +1293,7 @@ class ALDocumentBundle(DAList):
                     icon=view_icon,
                     color="secondary",
                     size="md",
-                    classname="al_view",
+                    classname="al_view al_button",
                 )
                 buttons = [doc_view_button, doc_download_button]
             else:
@@ -1313,7 +1313,7 @@ class ALDocumentBundle(DAList):
                 icon=zip_icon,
                 color="primary",
                 size="md",
-                classname="al_zip",
+                classname="al_zip al_button",
             )
             html += table_row(zip.title, zip_button)
 
@@ -1407,12 +1407,12 @@ class ALDocumentBundle(DAList):
         input_html = f"""
         <span class="al_email_input_container {name} form-group da-field-container da-field-container-datatype-email">
           <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
-          <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+          <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field al_button" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
         
         # "Send" button for the 2nd column of the table row
-        send_button = f'{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}'
+        send_button = f'{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button al_button", id_tag=al_send_button_id)}'
         
         # Whole row put together
         html = f"""
@@ -1455,8 +1455,8 @@ class ALDocumentBundle(DAList):
 
         # Container of whole email section with header
         return_str = f"""
-  <div class="al_send_bundle al_send_section_alone {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
-    <h2 class="h4 al_doc_email_header">{self._cached_get_email_copy}</h5> 
+  <fieldset class="al_send_bundle al_send_section_alone {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
+    <legend class="h4 al_doc_email_header">{self._cached_get_email_copy}</legend> 
     """
         # "Editable" checkbox
         if show_editable_checkbox:
@@ -1482,7 +1482,7 @@ class ALDocumentBundle(DAList):
 
   </div>
   """
-        return_str += "</div>"  # .al_send_bundle container
+        return_str += "</fieldset>"  # .al_send_section_alone container
         return return_str
 
     def send_email(

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -107,10 +107,10 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     """
     html = (
         f'\n\t<div class="row al_doc_table_row">'
-        f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
+        f'\n\t\t<div class="col col-12 col-sm-6 al_doc_title">{title}</div>'
         # At some widths, `col-6` barely has room to avoid
         # wrapping lines for these buttons
-        f'\n\t\t<div class="col col-6 al_buttons">'
+        f'\n\t\t<div class="col col-12 col-sm-6 al_buttons">'
     )
     for button in button_htmls:
         html += button
@@ -1417,8 +1417,8 @@ class ALDocumentBundle(DAList):
         # Whole row put together
         html = f"""
         <div class="row al_doc_table_row al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
-          <div class="col col-9 al_email_input_col">{ input_html }</div>
-          <div class="col col-3 al_email_send_col al_buttons">{ send_button }</div>
+          <div class="col col-12 col-sm-9 al_email_input_col">{ input_html }</div>
+          <div class="col col-12 col-sm-3 al_email_send_col al_buttons">{ send_button }</div>
         </div>
         """
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -108,14 +108,14 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     html = (
         f'\n\t<div class="row al_doc_table_row">'
         f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
-        # At some widths, `col-6` barely has room to avoid 
+        # At some widths, `col-6` barely has room to avoid
         # wrapping lines for these buttons
         f'\n\t\t<div class="col col-6 al_buttons">'
     )
     for button in button_htmls:
         html += button
-    html += '</div>'
-    html += '\n\t</div>'
+    html += "</div>"
+    html += "\n\t</div>"
 
     return html
 
@@ -1212,7 +1212,7 @@ class ALDocumentBundle(DAList):
         zip_label: Optional[str] = None,
         zip_icon: str = "file-archive",
         append_matching_suffix: bool = True,
-        include_email: bool = False
+        include_email: bool = False,
     ) -> str:
         """
         Returns string of a table to display a list
@@ -1318,8 +1318,8 @@ class ALDocumentBundle(DAList):
             html += table_row(zip.title, zip_button)
 
         if include_email:
-          html += self.send_email_table_row( key=key )
-            
+            html += self.send_email_table_row(key=key)
+
         html += "\n</div>"
 
         # Discuss: Do we want a table with the ability to have a merged pdf row?
@@ -1379,7 +1379,7 @@ class ALDocumentBundle(DAList):
 
         return html
 
-    def send_email_table_row( self, key: str = "final" ) -> str:
+    def send_email_table_row(self, key: str = "final") -> str:
         """
         Generate HTML doc table row for an input box and button that allows
         someone to send the bundle to the specified email address.
@@ -1410,10 +1410,10 @@ class ALDocumentBundle(DAList):
           <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field al_button" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
-        
+
         # "Send" button for the 2nd column of the table row
         send_button = f'{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button al_button", id_tag=al_send_button_id)}'
-        
+
         # Whole row put together
         html = f"""
         <div class="row al_doc_table_row al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
@@ -1421,7 +1421,7 @@ class ALDocumentBundle(DAList):
           <div class="col col-3 al_email_send_col al_buttons">{ send_button }</div>
         </div>
         """
-        
+
         return html
 
     def send_button_html(

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -106,7 +106,7 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     return the row of an AL document-styled table in HTML format.
     """
     html = (
-        f'\n\t<div class="row al_doc_table_row">''
+        f'\n\t<div class="row al_doc_table_row">'
         f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
         # At some widths, `col-6` barely has room to avoid 
         # wrapping lines for these buttons
@@ -1406,7 +1406,7 @@ class ALDocumentBundle(DAList):
         # Label "email" and input field for the 1st column of the table row
         input_html = f"""
         <span class="al_email_input_container {name} form-group da-field-container da-field-container-datatype-email">
-          <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+          <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
           <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
@@ -1474,7 +1474,7 @@ class ALDocumentBundle(DAList):
   <div class="al_email_container">
   
     <span class="al_email_address {name} container form-group row da-field-container da-field-container-datatype-email">
-      <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+      <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
       <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
     </span>
     

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -100,23 +100,22 @@ def html_safe_str(the_string: str) -> str:
     return re.sub(r"[^A-Za-z0-9]+", "_", the_string)
 
 
-# def table_row( title, view_file:DAFile, download_file:DAFile=None, view_icon:str="eye", download_icon:str="download") -> str:
 def table_row(title: str, button_htmls: List[str] = []) -> str:
     """
     Uses the provided title and list of button html strings to
     return the row of an AL document-styled table in HTML format.
     """
     html = (
-        f"\n\t<tr>"
-        # '\n\t\t<td><i class="fas fa-file"></i>&nbsp;&nbsp;</td>'
-        # TODO: Need to replace with proper CSS
-        f'\n\t\t<td class="al_doc_title"><strong>{title}</strong></td>'
-        f'\n\t\t<td class="al_buttons">'
+        f'\n\t<div class="row al_doc_table_row">''
+        f'\n\t\t<div class="col col-6 al_doc_title">{title}</div>'
+        # At some widths, `col-6` barely has room to avoid 
+        # wrapping lines for these buttons
+        f'\n\t\t<div class="col col-6 al_buttons">'
     )
     for button in button_htmls:
         html += button
-    html += "</td>"
-    html += "\n\t</tr>"
+    html += '</div>'
+    html += '\n\t</div>'
 
     return html
 
@@ -1213,6 +1212,7 @@ class ALDocumentBundle(DAList):
         zip_label: Optional[str] = None,
         zip_icon: str = "file-archive",
         append_matching_suffix: bool = True,
+        include_email: bool = False
     ) -> str:
         """
         Returns string of a table to display a list
@@ -1238,7 +1238,7 @@ class ALDocumentBundle(DAList):
                     append_matching_suffix=append_matching_suffix,
                 )  # Generate cached file for this session
 
-        html = f'<table class="al_table" id="{ html_safe_str(self.instanceName) }">'
+        html = f'<div class="container al_table al_doc_table" id="{ html_safe_str(self.instanceName) }">'
 
         for doc in enabled_docs:
             filename_root = os.path.splitext(str(doc.filename))[0]
@@ -1317,7 +1317,10 @@ class ALDocumentBundle(DAList):
             )
             html += table_row(zip.title, zip_button)
 
-        html += "\n</table>"
+        if include_email:
+          html += self.send_email_table_row( key=key )
+            
+        html += "\n</div>"
 
         # Discuss: Do we want a table with the ability to have a merged pdf row?
         return html
@@ -1369,22 +1372,17 @@ class ALDocumentBundle(DAList):
             buttons = [doc_download_button]
 
         html = (
-            f'<table class="al_table merged_docs" id="{html_safe_str(self.instanceName)}">'
+            f'<div class="container al_table merged_docs" id="{html_safe_str(self.instanceName)}">'
             f"{table_row(self.title, buttons)}"
-            f"\n</table>"
+            f"\n</div>"
         )
 
         return html
 
-    def send_button_html(
-        self, key: str = "final", show_editable_checkbox: bool = True
-    ) -> str:
+    def send_email_table_row( self, key: str = "final" ) -> str:
         """
-        Generate HTML for an input box and button that allows someone to send
-        the bundle to the specified email address.
-
-        Optionally, display a checkbox that allows someone to decide whether or not to
-        include an editable (Word) copy of the file, iff it is available.
+        Generate HTML doc table row for an input box and button that allows
+        someone to send the bundle to the specified email address.
         """
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents
@@ -1405,10 +1403,62 @@ class ALDocumentBundle(DAList):
             f"'{al_wants_editable_input_id}','{al_email_input_id}')"
         )
 
+        # Label "email" and input field for the 1st column of the table row
+        input_html = f"""
+        <span class="al_email_input_container {name} form-group da-field-container da-field-container-datatype-email">
+          <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+          <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+        </span>
+        """
+        
+        # "Send" button for the 2nd column of the table row
+        send_button = f'{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}'
+        
+        # Whole row put together
+        html = f"""
+        <div class="row al_doc_table_row al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
+          <div class="col col-9 al_email_input_col">{ input_html }</div>
+          <div class="col col-3 al_email_send_col al_buttons">{ send_button }</div>
+        </div>
+        """
+        
+        return html
+
+    def send_button_html(
+        self, key: str = "final", show_editable_checkbox: bool = True
+    ) -> str:
+        """
+        Generate HTML for an input box and button that allows someone to send
+        the bundle to the specified email address.
+
+        Optionally, display a checkbox that allows someone to decide whether or not to
+        include an editable (Word) copy of the file, if it is available.
+        """
+        if not self.has_enabled_documents():
+            return ""  # Don't let people email an empty set of documents
+        if not hasattr(self, "_cached_get_email_copy"):
+            self._cached_get_email_copy = str(self.get_email_copy)
+        if not hasattr(self, "_cached_include_editable_documents"):
+            self._cached_include_editable_documents = str(
+                self.include_editable_documents
+            )
+        name = html_safe_str(self.instanceName)
+        al_wants_editable_input_id = "_ignore_al_wants_editable_" + name
+        al_email_input_id = "_ignore_al_doc_email_" + name
+        al_send_button_id = "al_send_email_button_" + name
+
+        javascript_string = (
+            f"javascript:aldocument_send_action("
+            f"'{self.attr_name('send_email_action_event')}',"
+            f"'{al_wants_editable_input_id}','{al_email_input_id}')"
+        )
+
+        # Container of whole email section with header
         return_str = f"""
-  <div class="al_send_bundle {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
-    <h5 id="al_doc_email_header">{self._cached_get_email_copy}</h5> 
+  <div class="al_send_bundle al_send_section_alone {name}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
+    <h2 class="h4 al_doc_email_header">{self._cached_get_email_copy}</h5> 
     """
+        # "Editable" checkbox
         if show_editable_checkbox:
             return_str += f"""
     <div class="form-check-container">
@@ -1419,16 +1469,20 @@ class ALDocumentBundle(DAList):
       </div>
     </div>
   """
+        # Email input and send button
         return_str += f"""
   <div class="al_email_container">
-    <span class="al_email_address {name} form-group row da-field-container da-field-container-datatype-email">
-      <label for="{al_email_input_id}" class="al_doc_email col-form-label da-form-label datext-right">Email</label>
-      <input value="{user_info().email if user_logged_in() else ''}" alt="Input box" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
-    </span>{action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}
+  
+    <span class="al_email_address {name} container form-group row da-field-container da-field-container-datatype-email">
+      <label for="{al_email_input_id}" class="al_doc_email_label col-form-label da-form-label datext-right">Email</label>
+      <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+    </span>
+    
+    {action_button_html(javascript_string, label="Send", icon="envelope", color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}
 
   </div>
   """
-        return_str += "</div>"  # al_send_bundle
+        return_str += "</div>"  # .al_send_bundle container
         return return_str
 
     def send_email(

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -109,23 +109,27 @@ subquestion: |
   
   Note: We're deprecating `download_html()` and removing it, so it will not be tested in here.
 
-  multi_bundle_1.download_list_html()
+  multi_bundle_1.download_list_html() with send button for alignment comparison
   
   ${ multi_bundle_1.download_list_html() }
   
-  ---
+  ${ multi_bundle_1.send_button_html() }
+  
+  multi_bundle_1.download_list_html( include_email=True )
+  
+  ${ multi_bundle_1.download_list_html( include_email=True ) }
 
   single_pdf_bundle_1.download_list_html()
   
   ${ single_pdf_bundle_1.download_list_html() }
   
-  ---
+  single_pdf_bundle_1.download_list_html( include_email=True )
+  
+  ${ single_pdf_bundle_1.download_list_html( include_email=True ) }
 
   single_docx_bundle_1.download_list_html()
   
   ${ single_docx_bundle_1.download_list_html() }
-  
-  ---
 ---
 # Keeping this in here until method is completely removed just in case other decisions are made
 #id: download_html_defaults
@@ -146,19 +150,13 @@ subquestion: |
 
   ${ multi_bundle_1.send_button_html() }
   
-  ---
-  
   single_pdf_bundle_1.send_button_html()
 
   ${ single_pdf_bundle_1.send_button_html() }
   
-  ---
-  
   single_docx_bundle_1.send_button_html()
 
   ${ single_docx_bundle_1.send_button_html() }
-  
-  ---
 ---
 id: as_foo_custom
 continue button field: as_foo_custom

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -1,7 +1,6 @@
 /* WARNING TO AL DEVELOPERS: Only use CSS _classes_ in our CSS unless you know for a fact that an ID is static. Most IDs are generated dynamically, so using them in the CSS will only work with our test files. */
 
 /* ========= Isolated email send button ========= */
-/* Email button (there's another section for this at the bottom?) */
 /* Feedback from UI designers has been that email input field and
    send button should be on the same line. */
 
@@ -37,7 +36,7 @@
 }
 
 .al_send_section_alone .al_email_address,
-.al_send_section_alone .al_doc_email_label {
+.al_send_section_alone .al_email_address label {
   max-width: 70%;
   padding-left: 0;
 }
@@ -47,12 +46,26 @@
 }
 
 .al_send_section_alone .al_doc_email_header {
+  margin: 1em 0;
+}
+
+.al_send_section_alone .al_doc_email_header {
     margin-bottom: 0.2em;
+}
+
+/* al_email_container mobile version */
+@media only screen and (max-width: 700px) {
+  .al_email_container {
+    display: block; 
+  }
+  .al_email_container > span > input {
+    margin: 0 0 10px; 
+  }
 }
 
 /* ========= Table rows ========= */
 .al_doc_table {
-    margin-bottom: 2em;
+    margin-bottom: 2rem;
 }
 
 .al_doc_table_row .al_doc_title,
@@ -81,7 +94,7 @@
     justify-content: space-between;
 }
 
-.al_doc_table_row .al_doc_email_label {
+.al_doc_table_row .al_email_input_container label {
     width: unset;
     padding-right: 1em;
 }
@@ -91,107 +104,7 @@
     flex-grow: 1;
 }
 
-/*
-.al_table_css_sibling + div thead {
-  display: none;
-}
-
-.al_table_css_sibling + div td {
-  padding: .3em;
-  vertical-align: text-top;
-}
-td.text-left:first-child {
-  width: 1em;
-  padding-left: .5em;
-}
-.al_table_css_sibling + div td.text-left + td.text-right {
-  width: 5em;
-}
-.al_table_css_sibling + div td.text-right {
-  width: 7em;
-}
-
-.al_table_css_sibling + div a {
-  margin: 0em;
-}
-*/
-
-/* TODO: Should it be this broad? This looks like it's for all pages */
+/* TODO: Should it be in here and this broad? This looks like it's for all pages */
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;
 }
-
-/* Should not be an id */
-#al_doc_email_header {
-  margin: 1rem 0;
-}
-
-.al_doc_email_header {
-  margin: 1rem 0;
-}
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_user_bundle {
-  margin: 0.5rem 0;
-}
-*/
-
-/* Avoid icons being on their own lines */
-/*
-.al_table .al_buttons .btn {
-  position: relative;
-  margin: 0;
-  margin-bottom: 0.1rem;
-  white-space: nowrap;
-}
-*/
-
-/* On wide screens, let titles wrap, but let buttons stay horizontal */
-/* On small screens, wrap buttons and let titles have the room they need */
-/*
-@media only screen and (min-width: 450px) {
-  .al_table .al_buttons {
-    white-space: nowrap;
-  }
-}
-*/
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_user_bundle td div {
-  min-width: 320px;
-}
-*/
-
-/* Won't work for users. Doesn't account for dynamic ids. */
-/*
-#al_send_bundle_al_user_bundle .form-check-container {
-  margin: 0.5rem 0 5px 0;
-}
-*/
-
-/* al_email_container mobile version */
-@media only screen and (max-width: 700px) {
-  .al_email_container {
-    display: block; 
-  }
-  .al_email_container > span > input {
-    margin: 0 0 10px; 
-  }
-}
-
-/* The following 3 rules split title/button columns on the download screen by a 30%/70% ratio. This is to give the buttons enough room to stay horizontal even with long titles. */
-/*
-table {
-  width: 100%;
-  table-layout: fixed;
-}
-.al_doc_title {
-  width: 30%; 
-}
-.al_buttons {
-  width: 70%;
-  padding-left: 2em;  
-}
-*/

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -125,9 +125,8 @@
     flex-grow: 1;
 }
 
-@media (max-width: 500px) {
+@media (max-width: 575px) {
   .al_doc_table .col {
-      width: 100%;
       padding-right: 0;
       padding-left: 0;
   }
@@ -139,7 +138,6 @@
       padding-top: 0.25em;
   }
 }
-
 /* TODO: Should it be in here and this broad? This looks like it's for all pages */
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -116,9 +116,28 @@
     padding-right: 1em;
 }
 
+.al_doc_table .al_email_input_container {
+  flex-wrap: wrap;
+}
+
 .al_doc_table_row .al_doc_email_field {
     width: 50%;
     flex-grow: 1;
+}
+
+@media (max-width: 500px) {
+  .al_doc_table .col {
+      width: 100%;
+      padding-right: 0;
+      padding-left: 0;
+  }
+  .al_doc_table .al_doc_title {
+      text-align: left;
+  }
+  .al_doc_table .al_email_input_col {
+      padding-bottom: 0.5em;
+      padding-top: 0.25em;
+  }
 }
 
 /* TODO: Should it be in here and this broad? This looks like it's for all pages */

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -116,8 +116,16 @@
     padding-right: 1em;
 }
 
+/* Puts the invalid email input message under the input field
+*    instead of beside it. */
 .al_doc_table .al_email_input_container {
   flex-wrap: wrap;
+}
+
+/* Prevent 'send' button from stretching vertically on wide
+*    screens when validation message appears. */
+.al_doc_table .al_email_send_col {
+  align-self: flex-start;
 }
 
 .al_doc_table_row .al_doc_email_field {

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -1,6 +1,8 @@
 /* WARNING TO AL DEVELOPERS: Only use CSS _classes_ in our CSS unless you know for a fact that an ID is static. Most IDs are generated dynamically, so using them in the CSS will only work with our test files. */
 
-/* ========= Isolated email send button ========= */
+/*---------------------------------------------------------*/
+/* Isolated email send button
+/*---------------------------------------------------------*/
 /* Feedback from UI designers has been that email input field and
    send button should be on the same line. */
 
@@ -20,8 +22,8 @@
   max-width: 50%
 }
 
-.al_send_section_alone .al_send_button {
-  display: inline-block;
+.al_send_section_alone .al_send_email_button {
+  flex-grow: 1;
 }
 
 .al_send_section_alone .al_send_editable {
@@ -46,10 +48,6 @@
 }
 
 .al_send_section_alone .al_doc_email_header {
-  margin: 1em 0;
-}
-
-.al_send_section_alone .al_doc_email_header {
     margin-bottom: 0.2em;
 }
 
@@ -63,9 +61,28 @@
   }
 }
 
-/* ========= Table rows ========= */
+/*---------------------------------------------------------*/
+/* Table rows
+/*---------------------------------------------------------*/
 .al_doc_table {
     margin-bottom: 2rem;
+}
+
+.al_doc_table .al_buttons {
+    display: flex;
+    justify-content: space-between;
+}
+
+.al_doc_table .al_buttons > * {
+    flex-grow: 1;
+}
+
+.al_doc_table .al_buttons .al_button {
+    margin-right: 4px;
+}
+
+.al_doc_table .al_buttons .al_button:last-child {
+    margin-right: 0;
 }
 
 .al_doc_table_row .al_doc_title,

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -1,27 +1,97 @@
 /* WARNING TO AL DEVELOPERS: Only use CSS _classes_ in our CSS unless you know for a fact that an ID is static. Most IDs are generated dynamically, so using them in the CSS will only work with our test files. */
 
-/* Email button (there's another section for this at the bottom) */
+/* ========= Isolated email send button ========= */
+/* Email button (there's another section for this at the bottom?) */
 /* Feedback from UI designers has been that email input field and
    send button should be on the same line. */
-.al_email_address, .al_email_address label, .al_email_address input {
+
+.al_send_section_alone {
+  margin-bottom: 2rem;
+}
+
+.al_send_section_alone .al_email_address,
+.al_send_section_alone .al_email_address label,
+.al_send_section_alone .al_email_address input {
   display: inline;
   width: unset;
   margin: unset;
 }
 
-.al_email_address input {
+.al_send_section_alone .al_email_address input {
   max-width: 50%
 }
 
-.al_send_button {
+.al_send_section_alone .al_send_button {
   display: inline-block;
 }
-.al_send_editable {
+
+.al_send_section_alone .al_send_editable {
   display: block;
   width: 100%;
 }
 
-/* Download buttons */
+.al_send_section_alone .al_email_container {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.al_send_section_alone .al_email_address,
+.al_send_section_alone .al_doc_email_label {
+  max-width: 70%;
+  padding-left: 0;
+}
+
+.al_send_section_alone .al_email_address input {
+  max-width: 80%;
+}
+
+.al_send_section_alone .al_doc_email_header {
+    margin-bottom: 0.2em;
+}
+
+/* ========= Table rows ========= */
+.al_doc_table {
+    margin-bottom: 2em;
+}
+
+.al_doc_table_row .al_doc_title,
+.al_doc_table_row .al_buttons,
+.al_doc_table_row .al_email_send_col {
+    text-align: right;
+}
+
+.al_doc_table_row .al_buttons,
+.al_doc_table_row .al_email_send_col {
+  padding-right: 0;
+}
+
+.al_doc_table_row .al_doc_title,
+.al_doc_table_row .al_doc_email,
+.al_doc_table_row .al_email_input_col {
+  padding-left: 0;
+}
+
+.al_doc_table_row .al_doc_title {
+  font-weight: bold;
+}
+
+.al_doc_table_row .al_email_input_container {
+    display: flex;
+    justify-content: space-between;
+}
+
+.al_doc_table_row .al_doc_email_label {
+    width: unset;
+    padding-right: 1em;
+}
+
+.al_doc_table_row .al_doc_email_field {
+    width: 50%;
+    flex-grow: 1;
+}
+
+/*
 .al_table_css_sibling + div thead {
   display: none;
 }
@@ -44,42 +114,63 @@ td.text-left:first-child {
 .al_table_css_sibling + div a {
   margin: 0em;
 }
+*/
 
+/* TODO: Should it be this broad? This looks like it's for all pages */
 .da-subquestion .daquestionbackbutton {
   background-color: #eee;
 }
 
+/* Should not be an id */
 #al_doc_email_header {
   margin: 1rem 0;
 }
 
+.al_doc_email_header {
+  margin: 1rem 0;
+}
+
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_user_bundle {
   margin: 0.5rem 0;
 }
+*/
 
+/* Avoid icons being on their own lines */
+/*
 .al_table .al_buttons .btn {
   position: relative;
   margin: 0;
   margin-bottom: 0.1rem;
-  /* Avoid icons being on their own lines */
   white-space: nowrap;
 }
+*/
 
 /* On wide screens, let titles wrap, but let buttons stay horizontal */
 /* On small screens, wrap buttons and let titles have the room they need */
+/*
 @media only screen and (min-width: 450px) {
   .al_table .al_buttons {
     white-space: nowrap;
   }
 }
+*/
 
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_user_bundle td div {
   min-width: 320px;
 }
+*/
 
+/* Won't work for users. Doesn't account for dynamic ids. */
+/*
 #al_send_bundle_al_user_bundle .form-check-container {
   margin: 0.5rem 0 5px 0;
 }
+*/
+
 /* al_email_container mobile version */
 @media only screen and (max-width: 700px) {
   .al_email_container {
@@ -89,7 +180,9 @@ td.text-left:first-child {
     margin: 0 0 10px; 
   }
 }
+
 /* The following 3 rules split title/button columns on the download screen by a 30%/70% ratio. This is to give the buttons enough room to stay horizontal even with long titles. */
+/*
 table {
   width: 100%;
   table-layout: fixed;
@@ -101,3 +194,4 @@ table {
   width: 70%;
   padding-left: 2em;  
 }
+*/

--- a/docassemble/AssemblyLine/data/static/aldocument.css
+++ b/docassemble/AssemblyLine/data/static/aldocument.css
@@ -116,16 +116,8 @@
     padding-right: 1em;
 }
 
-/* Puts the invalid email input message under the input field
-*    instead of beside it. */
 .al_doc_table .al_email_input_container {
   flex-wrap: wrap;
-}
-
-/* Prevent 'send' button from stretching vertically on wide
-*    screens when validation message appears. */
-.al_doc_table .al_email_send_col {
-  align-self: flex-start;
 }
 
 .al_doc_table_row .al_doc_email_field {

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from distutils.util import convert_path
 
 standard_exclude = ('*.pyc', '*~', '.*', '*.bak', '*.swp*')
 standard_exclude_directories = ('.*', 'CVS', '_darcs', './build', './dist', 'EGG-INFO', '*.egg-info')
+
 def find_package_data(where='.', package='', exclude=standard_exclude, exclude_directories=standard_exclude_directories):
     out = {}
     stack = [(convert_path(where), '', package)]
@@ -53,7 +54,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.4.3', 'docassemble.GithubFeedbackForm>=0.1.3', 'backports.zoneinfo; python_version<"3.9"'],
+      install_requires=['docassemble.ALToolbox>=0.6.0', 'docassemble.GithubFeedbackForm>=0.2.0b1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.6.0', 'docassemble.GithubFeedbackForm>=0.2.0'],
+      install_requires=['docassemble.ALToolbox>=0.6.2', 'docassemble.GithubFeedbackForm>=0.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='docassemble.AssemblyLine',
       url='https://courtformsonline.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['docassemble.ALToolbox>=0.6.0', 'docassemble.GithubFeedbackForm>=0.2.0b1'],
+      install_requires=['docassemble.ALToolbox>=0.6.0', 'docassemble.GithubFeedbackForm>=0.2.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
Closes #563, Closes #562, alignment of document download table buttons vs. document email section parts, plus other alignment and styling issues. I tried to limit the changes to the email section as people are using that styled as-is right now. Here are some notes from our deep dive doc as well:

* Add a new parameter to download_list_html() to include a send email button row. But it will be a copy of the feature - we won’t delete the existing send_button_html() method.
* Fix the send_button_html() method html strings to remove the H5, though keep the styling
* Right align the send button of the separate email section,
* Remove the big gutter between the buttons and the text

Remade this PR because the pfs/black changes on the old branch caused a conflict with my updates.

Also closes #177 I believe.