### PR TITLE
Use `user_role` over users == plaintiff

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -166,6 +166,8 @@ code: |
     first_form = {}
   del(first_form_key)
 ---
+depends on:
+  - user_ask_role
 code: |
   # If the author hasn't explicitly defined it in the interview_order block,
   # define user_role to be either "defendant" or "plaintiff",

--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -169,12 +169,14 @@ code: |
 depends on:
   - user_ask_role
 code: |
+  # DEPRECATED as of 2.17.1. Won't be removed, but you shouldn't reference this
+  # variable in your code. Use `user_ask_role` instead.
   # If the author hasn't explicitly defined it in the interview_order block,
   # define user_role to be either "defendant" or "plaintiff",
   # either by checking interview_metadata or asking the user.
   # The only valid values for user_role are "plaintiff" and "defendant".
   
-  # We will check for the "typical_role" key.  
+  # We will check for the "typical_role" key.
   # Some older wizarded code doesn't define `typical_role`, so fall back
   # to "unknown" if the key is not present.
   # first_form is the first entry in interview_metadata

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -148,10 +148,10 @@ code: |
     petitioners = other_parties
 ---
 depends on:
-  - user_role
+  - user_ask_role
 code: |
   # If the interview author didn't specify and it's a "court" or "other" case, we just ask
-  user_started_case = user_role == 'plaintiff'
+  user_started_case = user_ask_role == 'plaintiff'
 ---
 id: what is the user's detailed role in this case?
 comment: |
@@ -181,7 +181,7 @@ fields:
     datatype: radio
     choices:
       - Petitioner: petitioner
-      - Plaintiff: plaintiff      
+      - Plaintiff: plaintiff
       - I don't know: unknown
     show if:
       variable: user_detailed_role_started_case
@@ -804,7 +804,7 @@ fields:
 ---
 id: any other opposing parties
 question: |
-  % if user_role == 'plaintiff':
+  % if user_started_case:
   Is there any other **defendant** or respondent in this
   matter?
   % else:
@@ -821,7 +821,7 @@ sets:
   - other_parties[i].name.suffix
 id: names of opposing parties
 question: |
-  % if user_role == 'plaintiff':
+  % if user_started_case:
   Name of ${ ordinal(i) } **defendant** or respondent in this
   matter
   % else:
@@ -1503,12 +1503,12 @@ buttons:
 id: is the user the plaintiff or defendant?
 comment: |
   This question is asked if the interview can be used by both
-  a Plaintiff and a Defendant. It sets the value of `user_role`,
+  a Plaintiff and a Defendant. It sets the value of `user_role`, `user_started_case`,
   `plaintiffs`, `defendants`, `petitioners` and `respondents`.
   
   If you know your interview is exclusively
-  used by the Plaintiff or Defendant, set `user_role = 'plaintiff'` or 
-  `user_role='defendant'` in your code.
+  used by the Plaintiff or Defendant, set `user_ask_role = 'plaintiff'` or
+  `user_ask_role='defendant'` in your code.
 question: |
   Did you start this case, or are you responding to a case
   that someone else started?

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -804,7 +804,7 @@ fields:
 ---
 id: any other opposing parties
 question: |
-  % if users==plaintiffs:
+  % if user_role == 'plaintiff':
   Is there any other **defendant** or respondent in this
   matter?
   % else:
@@ -821,7 +821,7 @@ sets:
   - other_parties[i].name.suffix
 id: names of opposing parties
 question: |
-  % if users==plaintiffs:
+  % if user_role == 'plaintiff':
   Name of ${ ordinal(i) } **defendant** or respondent in this
   matter
   % else:

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -148,10 +148,10 @@ code: |
     petitioners = other_parties
 ---
 depends on:
-  - user_ask_role
+  - user_role
 code: |
   # If the interview author didn't specify and it's a "court" or "other" case, we just ask
-  user_started_case = user_ask_role == 'plaintiff'
+  user_started_case = user_role == 'plaintiff'
 ---
 id: what is the user's detailed role in this case?
 comment: |


### PR DESCRIPTION
When you are directly comparing the users to the plaintiffs, DA will try to gather both of the objects. This is fine if `users` is `plaintiffs`, but if the users are the defendants instead, it will trigger a infinite loop screen, since `other_parties` has been set to `plaintiffs`, and it's trying to gather `plaintiffs` before being able to fill `other_parties`.

Additionally, uses `user_role` instead of `user_ask_role`, which will always ask for the user's role in the case, even if it's a form that always done from one side, or we can detect what side of the case the user is on (as with e-filing).

Would like to do some additional testing with this on the dev server, but that might take a bit, since I don't know which interviews to test with. I'll make sure the ALAffidavit and the interpreter notice work correctly.

A minimal reproduction, with 57ee87e496109ba8f2c7c7175991cea38eb86100: Saying that you are a defendant will result in an error screen.

```yaml
include:
  - docassemble.AssemblyLine:assembly_line.yml
---
mandatory: True
code: |
  users.gather()
  other_parties.gather()
```

Results in the <summary>Following error:
<details>
<pre>
There appears to be an infinite loop. Variables in stack are x.first.
...
Needed definition of other_parties[0].name.first at 0.33673s
Tried to ask question at 0.33724s

(from ql_baseline.yml)

sets:
  - other_parties[i].name.first
  - other_parties[i].name.last
  - other_parties[i].name.middle
  - other_parties[i].name.suffix
id: names of opposing parties
question: |
  % if users==plaintiffs:
  Name of ${ ordinal(i) } **defendant** or respondent in this
  matter
  % else:
  Name of ${ ordinal(i) } **plaintiff** or petitioner in this matter
  % endif
fields:
  - code: |
      other_parties[i].name_fields(person_or_business='unsure')
</pre>
(repeated)
</details>
</summary>

Doesn't happen with this PR.