### PR TITLE
Show answer sets even if they are on "step 1" (as answer sets don't usually have more than 1 step)

### DIFF
--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -108,7 +108,7 @@ question: |
   % endif
   <span style="float: right;">${ action_button_html(get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE), label="Start a new form", icon="plus-circle", color="primary", size="md") }</span>
 subquestion: |
-  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, exclude_filenames=al_sessions_to_exclude_from_interview_list)) > 0:
+  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True)) > 0:
   % if get_config("interview page pre"):
   ${ get_config("interview page pre") }
   % else:
@@ -116,14 +116,14 @@ subquestion: |
   documents.
   % endif
 
-  ${ session_list_html(filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list) }
+  ${ session_list_html(filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }
 
   <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
   % if session_page > 0:
       <li class="page-item"><a class="page-link" href="${ url_action("update_page_event", page_increment=-1) }">Previous</a></li>
   % endif
-  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, exclude_filenames=al_sessions_to_exclude_from_interview_list, limit=20, offset=session_page*20)) >= 20:
+  % if len(get_saved_interview_list(filename=None, filename_to_exclude=al_session_store_default_filename, exclude_filenames=al_sessions_to_exclude_from_interview_list, limit=20, offset=session_page*20, exclude_newly_started_sessions=True)) >= 20:
       <li class="page-item"><a class="page-link" href="${ url_action("update_page_event", page_increment=1) }">Next</a></li>
   % endif
     </ul>
@@ -171,7 +171,7 @@ subquestion: |
   form](${ get_config("assembly line",{}).get("new form url", AL_ORGANIZATION_HOMEPAGE) })
   1. Then, use the menu to load your answer set.
 
-  ${ interview_list_html(view_only=True, delete_action="interview_list_delete_session") }
+  ${ interview_list_html(view_only=True, delete_action="interview_list_delete_session", exclude_newly_started_sessions=False) }
 section: section_answer_sets
 ---
 code: |

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -264,7 +264,7 @@ def get_saved_interview_list(
     filename_to_exclude: str = "",
     exclude_current_filename: bool = True,
     exclude_filenames: List[str] = None,
-    exclude_newly_started_sessions: bool = True,
+    exclude_newly_started_sessions: bool = False,
 ) -> List[Dict]:
     """Get a list of saved sessions for the specified filename. If the save_interview_answers function was used
     to add metadata, the result list will include columns containing the metadata.
@@ -423,6 +423,7 @@ def interview_list_html(
     filename: str = al_session_store_default_filename,
     user_id: Union[int, str] = None,
     metadata_key_name: str = "metadata",
+    exclude_newly_started_sessions = False,
     # name_label: str = word("Title"),
     date_label: str = word("Date"),
     details_label: str = word("Details"),
@@ -451,6 +452,7 @@ def interview_list_html(
         limit=limit,
         offset=offset,
         exclude_current_filename=False,
+        exclude_newly_started_sessions=exclude_newly_started_sessions,
     )
 
     if not answers:
@@ -596,7 +598,7 @@ def session_list_html(
     filename_to_exclude: str = al_session_store_default_filename,
     exclude_current_filename: bool = True,
     exclude_filenames: List[str] = None,
-    exclude_newly_started_sessions: bool = True,
+    exclude_newly_started_sessions: bool = False,
     name_label: str = word("Title"),
     date_label: str = word("Date modified"),
     details_label: str = word("Progress"),

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -270,6 +270,12 @@ def get_saved_interview_list(
     to add metadata, the result list will include columns containing the metadata.
     If the user is a developer or administrator, setting user_id = None will list all interviews on the server. Otherwise,
     the user is limited to their own sessions.
+
+    Setting `exclude_newly_started_sessions` to True will exclude any results from the list that are still on
+    "step 1". Note that while this may be useful to filter out interviews that were accidentally started
+    and likely do not need to be resumed, it will also have the side effect of excluding all answer sets from the
+    results. Answer sets generally have exactly one "step", which is the step where information was copied from
+    an existing interview to the answer set.
     """
     # We use an `offset` instead of a cursor because it is simpler and clearer
     # while it appears to be performant enough for real-world usage.
@@ -442,6 +448,10 @@ def interview_list_html(
     Designed to return a list of "answer sets" and by default clicking a title will
     trigger an action to load the answers into the current session. This only works as
     designed when inside an AssemblyLine line interview.
+
+    `exclude_newly_started_sessions` should almost always be set to False, because most answer sets
+    are on "page 1" (exactly 1 step was taken to copy the answers and the user isn't able to interact with the answer set
+    itself in a way that adds additional steps)
     """
     # TODO: Currently, using the `word()` function for translation, but templates
     # might be more flexible


### PR DESCRIPTION
Fix #598 