### PR TITLE
Decrease the size of images in tables

### DIFF
--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -107,6 +107,11 @@ blockquote p {
   border-width: 1px;
   border-color: gray;
 }
+
+td img.daicon {
+  width: 100%;
+}
+
 /* Reduce integer and number input box size */
 input[type=number] {
   width: 10rem;


### PR DESCRIPTION
Commonly in review tables, if we show the signature it will be too big for it's column. This extra CSS makes it small enough to fit in the column, which looks less buggy.

## Before:

![Screenshot from 2022-10-31 16-59-38](https://user-images.githubusercontent.com/6252212/199109916-926f5e91-03e8-4427-aac9-bbdb2e72bfdf.png)

## After:

![Screenshot from 2022-10-31 16-59-52](https://user-images.githubusercontent.com/6252212/199109930-7f0c9a70-e0ba-4e22-a286-64d7193d0107.png)

Will consider pushing this upstream if I can reproduce outside of our interviews, but not prioritizing that.