### PR TITLE
Added a max size feature to the ExhibitDocument

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -16,7 +16,7 @@ objects:
   - attorneys: ALPeopleList
   - translators: ALPeopleList
   - debt_collectors: ALPeopleList
-  - creditors: ALPeopleList  
+  - creditors: ALPeopleList
   - spouses: ALPeopleList
   - parents: ALPeopleList
   - decedents: ALPeopleList.using(ask_number=True, target_number=1)
@@ -41,8 +41,8 @@ subquestion: |
   % endif
   
   Step 1. Answer questions that will fill in your form for you.  
-  Step 2. Preview the completed form.  
-  % if form_approved_for_email_filing:  
+  Step 2. Preview the completed form.
+  % if form_approved_for_email_filing:
   Step 3. Email the form to the court using this secure website and save copies
   for yourself for later reference.  
   % elif al_form_type in ['starts_case','existing_case','appeal']:
@@ -1555,6 +1555,9 @@ code: |
 #########################################################
 # ALExhibitDocument questions
 ---
+imports:
+  - humanize
+---
 generic object: ALExhibitDocument
 code: |
   x.enabled = x.exhibits.has_exhibits
@@ -1576,22 +1579,28 @@ fields:
     show if: x.has_exhibits
   - First document title: x[0].title
     maxlength: 60 # longer might break TOC
-    show if: x.has_exhibits    
+    show if: x.has_exhibits
   - Upload the first document: x[0].pages
-    show if: x.has_exhibits    
+    show if: x.has_exhibits
     datatype: files
     maximum image size: 1024
-    image upload type: jpeg        
+    image upload type: jpeg
     accept: |
       "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
 validation code: |
   if x.has_exhibits:
-    if sum(exhibit.size_in_bytes() for exhibit in x[0].pages) > (15 * 1024 * 1024):
+    full_size = sum(a_page.size_in_bytes() for a_page in x[0].pages)
+    log(f"Noted full size: {full_size}")
+    if full_size > (15 * 1024 * 1024):
       validation_error("Upload a file smaller than 15 MB.")
+    if hasattr(x, 'maximum_size'):
+      log(f"Noted maximum_size: {x.maximum_size}")
+      if full_size > x.maximum_size:
+        validation_error(f"Upload a file smaller than {humanize.naturalsize(x.maximum_size)}")
     try:
       pdf_concatenate(x[0].pages)
     except:
-      validation_error("Unable to convert this file. Please upload a new one.", field="x[0].pages")
+      validation_error("Unable to convert this file. Please upload a new one.")
     x[0].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
 generic object: ALExhibitList
@@ -1603,23 +1612,30 @@ id: exhibit i
 question: |
   Upload the ${ ordinal(i) } document
 subquestion: |
-  You will have a chance to upload additional pages for this document later.  
+  You will have a chance to upload additional pages for this document later.
 fields:
   - Document title: x[i].title
     maxlength: 60 # longer might break TOC
-  - Upload the first exhibit: x[i].pages
+  - Upload the exhibit: x[i].pages
     datatype: files
     maximum image size: 1024
-    image upload type: jpeg        
+    image upload type: jpeg
     accept: |
       "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
 validation code: |
-  if sum(exhibit.size_in_bytes() for exhibit in x[i].pages) > (15 * 1024 * 1024):
+  this_doc_size = sum(a_page.size_in_bytes() for a_page in x[i].pages)
+  log(f"this doc: {this_doc_size}")
+  if this_doc_size > (15 * 1024 * 1024):
     validation_error("Upload a file smaller than 15 MB.")
+  if hasattr(x, 'maximum_size'):
+    full_size = x.size_in_bytes()
+    if full_size > x.maximum_size:
+      suggested_size = x.maximum_size - (full_size - this_doc_size)
+      validation_error(f"All exhibits combined must be smaller than {humanize.naturalsize(x.maximum_size)}. Upload a file smaller than {humanize.naturalsize(suggested_size)}.")
   try:
     pdf_concatenate(x[i].pages)
   except:
-    validation_error("Unable to convert this file. Please upload a new one.", field="x[i].pages")
+    validation_error("Unable to convert this file. Please upload a new one.")
   x[i].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
 generic object: ALExhibitList
@@ -1627,7 +1643,12 @@ id: exhibit i has additional pages
 question: |
   Does "**${ x[i] }**" have any additional pages?
 subquestion: |
-  You have uploaded ${ x[i].pages.num_pages() } pages so far.  
+  You have uploaded ${ x[i].pages.num_pages() } pages so far.
+
+  % if hasattr(x, 'maximum_size'):
+  The total size of all exhibits must be less than ${ humanize.naturalsize(x.maximum_size) }.
+  You can upload ${ humanize.naturalsize(x.maximum_size - x.size_in_bytes() - sum(ap.size_in_bytes() for ap in x[i].pages.complete_elements()))} more.
+  % endif
 
   ${ collapse_template(x[i].in_progress_template )}
   
@@ -1653,16 +1674,24 @@ fields:
   - Upload a PDF, Word, or image file: x[i].pages[j]
     datatype: file
     maximum image size: 1024
-    image upload type: jpeg        
+    image upload type: jpeg
     accept: |
       "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
 validation code: |
-  if x[i].pages[j].size_in_bytes() > (15 * 1024 * 1024):
+  page_size = x[i].pages[j].size_in_bytes()
+  if page_size > (15 * 1024 * 1024):
     validation_error("Upload a file smaller than 15 MB.")
+  if hasattr(x, 'maximum_size'):
+    # this_doc_size already includes `page_size`
+    this_doc_size = sum(a_page.size_in_bytes() for a_page in x[i].pages.complete_elements())
+    full_size = x.size_in_bytes() + this_doc_size
+    if full_size > x.maximum_size:
+      suggested_size = x.maximum_size - (full_size - page_size)
+      validation_error(f"All exhibits combined must be smaller than {humanize.naturalsize(x.maximum_size)}. Upload a file smaller than {humanize.naturalsize(suggested_size)}.")
   try:
     pdf_concatenate(x[i].pages[j])
   except:
-    validation_error("Unable to convert this file. Please upload a new one.", field="x[i].pages[j]")
+    validation_error("Unable to convert this file. Please upload a new one.")
 
   x[i].pages[j] = unpack_dafilelist(x[i].pages[j])
 ---
@@ -1672,6 +1701,11 @@ question: |
   You have ${ x.number_gathered() } document(s) so far. Do you have another document
   you want to upload?
 subquestion: |
+  % if hasattr(x, 'maximum_size'):
+  The total size of all exhibits must be less than ${ humanize.naturalsize(x.maximum_size) }.
+  You can upload ${ humanize.naturalsize(x.maximum_size - x.size_in_bytes())} more.
+  % endif
+
   ${ collapse_template(x.in_progress_exhibits) }
 field: x.there_is_another
 buttons:

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1590,11 +1590,9 @@ fields:
 validation code: |
   if x.has_exhibits:
     full_size = sum(a_page.size_in_bytes() for a_page in x[0].pages)
-    log(f"Noted full size: {full_size}")
     if full_size > (15 * 1024 * 1024):
       validation_error("Upload a file smaller than 15 MB.")
     if hasattr(x, 'maximum_size'):
-      log(f"Noted maximum_size: {x.maximum_size}")
       if full_size > x.maximum_size:
         validation_error(f"Upload a file smaller than {humanize.naturalsize(x.maximum_size)}")
     try:
@@ -1624,7 +1622,6 @@ fields:
       "image/png, image/jpeg, .doc,.docx,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/pdf,.pdf"   
 validation code: |
   this_doc_size = sum(a_page.size_in_bytes() for a_page in x[i].pages)
-  log(f"this doc: {this_doc_size}")
   if this_doc_size > (15 * 1024 * 1024):
     validation_error("Upload a file smaller than 15 MB.")
   if hasattr(x, 'maximum_size'):

--- a/docassemble/AssemblyLine/data/questions/test_alexhibit_maxsize.yml
+++ b/docassemble/AssemblyLine/data/questions/test_alexhibit_maxsize.yml
@@ -1,0 +1,23 @@
+---
+include:
+  - al_package.yml
+---
+mandatory: True
+code: |
+  gather_main
+---
+objects:
+  - exhibits_bundle_defaults_1: ALDocumentBundle.using(elements=[exhibit_doc_defaults_1], filename="exhibits_bundle_defaults", title="Exhibits with defaults")
+---
+objects:
+  - exhibit_doc_defaults_1: ALExhibitDocument.using(title="Exhibits doc defaults", filename="exhibits_doc_defaults", maximum_size=1*1024*1024 )
+---
+id: gather_main
+event: gather_main
+question: Default ALDocumentBundle thumbnail method args
+subquestion: |
+  exhibits_bundle_defaults_1.as_pdf()
+  
+  ${ exhibits_bundle_defaults_1.as_pdf() }
+  
+  ${ exhibits_bundle_defaults_1.as_pdf().size_in_bytes() }


### PR DESCRIPTION
Also give suggested remaining upload size in human readable file sizes in errors and in between upload screens.

Test is in new file called `test_alexhibit_maxsize.yml`, as it's not easily tested in a unit test.

Made this because e-filing into Tyler will require size limits on the overall size of the submission, not just each individually uploaded file like we have now. Unfortunately, the existing approach of "send the documents as a downloadable link instead of sending in the email" won't work, as Tyler's system has a max limit, and I think we want to tread carefully about using external documents not in the filing, as it'll force the courts to act differently with our filings.

Also found a bug (that [I reported in the docassemble slack](https://docassemble.slack.com/archives/C7791ATUJ/p1667409800971949)) where `validation_error(...)` on show if'd file uploads don't work / show up at all. So I removed the validation errors that were currently doing that.