### PR TITLE
If address is empty, `on_one_line()` will be empty

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -345,7 +345,8 @@ class ALAddress(Address):
                 the_unit = self.formatted_unit(language=language, bare=bare)
                 if the_unit != "":
                     output += ", " + the_unit
-            output += ", "
+            if output != "":
+                output += ", "
         # if hasattr(self, 'sublocality') and self.sublocality:
         #    output += str(self.sublocality) + ", "
         if hasattr(self, "sublocality_level_1") and self.sublocality_level_1:

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -1,0 +1,12 @@
+import unittest
+from .al_general import ALIndividual, ALAddress
+
+
+class test_aladdress(unittest.TestCase):
+    def test_empty_is_empty(self):
+        addr = ALAddress(address="", city="")
+        self.assertEqual(addr.on_one_line(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ extend-exclude = '(__init__.py|setup.py)'
 
 [tool.mypy]
 # global options
+no_implicit_optional = false
 exclude = '''(?x)(
     ^setup.py$
   )'''


### PR DESCRIPTION
Originally, was ", ", which is def a bug.

Suggested by @mnewsted 