### PR TITLE
No more implicit optionals in function signatures

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -795,7 +795,7 @@ class ALDocument(DADict):
     def safe_value(
         self,
         field_name: str,
-        overflow_message: str = None,
+        overflow_message: Optional[str] = None,
         preserve_newlines: bool = False,
         input_width: int = 80,
     ):
@@ -814,7 +814,7 @@ class ALDocument(DADict):
     def overflow_value(
         self,
         field_name: str,
-        overflow_message: str = None,
+        overflow_message: Optional[str] = None,
         preserve_newlines: bool = False,
         input_width: int = 80,
     ):
@@ -1188,7 +1188,7 @@ class ALDocumentBundle(DAList):
         view_icon: str = "eye",
         download_label: str = "Download",
         download_icon: str = "download",
-        zip_label: str = None,
+        zip_label: Optional[str] = None,
         zip_icon: str = "file-archive",
         append_matching_suffix: bool = True,
     ) -> str:
@@ -1546,7 +1546,7 @@ class ALExhibit(DAObject):
         pdfa: bool = False,
         add_page_numbers: bool = True,
         add_cover_page: bool = True,
-        filename: str = None,
+        filename: Optional[str] = None,
         append_matching_suffix: bool = True,
     ) -> DAFile:
         """
@@ -1668,7 +1668,7 @@ class ALExhibitList(DAList):
             full_size += sum((a_page.size_in_bytes() for a_page in exhibit.pages))
         return full_size
 
-    def _update_labels(self, auto_labeler: Callable = None) -> None:
+    def _update_labels(self, auto_labeler: Optional[Callable] = None) -> None:
         """
         Private method to refresh labels on all exhibits.
         Args:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional
 from docassemble.base.util import (
     Address,
     Individual,
@@ -72,11 +72,11 @@ class ALAddress(Address):
 
     def address_fields(
         self,
-        country_code: str = None,
-        default_state: str = None,
+        country_code: Optional[str] = None,
+        default_state: Optional[str] = None,
         show_country: bool = False,
         show_county: bool = False,
-        show_if: Union[str, Dict[str, str]] = None,
+        show_if: Union[str, Dict[str, str], None] = None,
         allow_no_address: bool = False,
     ):
         """
@@ -568,7 +568,7 @@ class ALIndividual(Individual):
         self,
         person_or_business: str = "person",
         show_suffix: bool = True,
-        show_if: Union[str, Dict[str, str]] = None,
+        show_if: Union[str, Dict[str, str], None] = None,
     ) -> List[Dict[str, str]]:
         """
         Return suitable field prompts for a name. If `person_or_business` is None, adds the
@@ -681,10 +681,10 @@ class ALIndividual(Individual):
     def address_fields(
         self,
         country_code: str = "US",
-        default_state: str = None,
+        default_state: Optional[str] = None,
         show_country: bool = False,
         show_county: bool = False,
-        show_if: Union[str, Dict[str, str]] = None,
+        show_if: Union[str, Dict[str, str], None] = None,
         allow_no_address: bool = False,
     ) -> List[Dict[str, str]]:
         """
@@ -702,7 +702,7 @@ class ALIndividual(Individual):
         )
 
     def gender_fields(
-        self, show_help=False, show_if: Union[str, Dict[str, str]] = None
+        self, show_help=False, show_if: Union[str, Dict[str, str], None] = None
     ):
         """
         Return a standard gender input with "self described" option.
@@ -738,9 +738,9 @@ class ALIndividual(Individual):
 
     def language_fields(
         self,
-        choices: List[Dict[str, str]] = None,
+        choices: Optional[List[Dict[str, str]]] = None,
         style: str = "radio",
-        show_if: Union[str, Dict[str, str]] = None,
+        show_if: Union[str, Dict[str, str], None] = None,
     ):
         """Return a standard language picker with an "other" input. Language should be specified as ISO 639-2 or -3 codes so it is compatible with the language_name() function."""
         if not choices:
@@ -952,7 +952,9 @@ def filter_letters(letter_strings: Union[List[str], str]) -> str:
 # Note: removed "combined_locations" because it is too tightly coupled to MACourts.py right now
 
 
-def fa_icon(icon: str, color: str = "primary", color_css: str = None, size: str = "sm"):
+def fa_icon(
+    icon: str, color: str = "primary", color_css: Optional[str] = None, size: str = "sm"
+):
     """
     Return HTML for a font-awesome icon of the specified size and color. You can reference
     a CSS variable (such as Bootstrap theme color) or a true CSS color reference, such as 'blue' or

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -189,7 +189,7 @@ al_sessions_variables_to_remove_from_new_interview = [
 system_interviews: List[Dict[str, Any]] = interview_menu()
 
 
-def _package_name(package_name: str = None):
+def _package_name(package_name: Optional[str] = None):
     """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
     docassemble.ALWeaver.advertise_capabilities"""
     if not package_name:
@@ -257,13 +257,13 @@ def get_interview_metadata(
 
 def get_saved_interview_list(
     filename: Optional[str] = al_session_store_default_filename,
-    user_id: Union[int, str] = None,
+    user_id: Union[int, str, None] = None,
     metadata_key_name: str = "metadata",
     limit: int = 50,
     offset: int = 0,
     filename_to_exclude: str = "",
     exclude_current_filename: bool = True,
-    exclude_filenames: List[str] = None,
+    exclude_filenames: Optional[List[str]] = None,
     exclude_newly_started_sessions: bool = False,
 ) -> List[Dict]:
     """Get a list of saved sessions for the specified filename. If the save_interview_answers function was used
@@ -375,7 +375,7 @@ def get_saved_interview_list(
 
 
 def delete_interview_sessions(
-    user_id: int = None,
+    user_id: Optional[int] = None,
     filename_to_exclude: str = al_session_store_default_filename,
     exclude_current_filename: bool = True,
 ) -> None:
@@ -427,7 +427,7 @@ def delete_interview_sessions(
 
 def interview_list_html(
     filename: str = al_session_store_default_filename,
-    user_id: Union[int, str] = None,
+    user_id: Union[int, str, None] = None,
     metadata_key_name: str = "metadata",
     exclude_newly_started_sessions=False,
     # name_label: str = word("Title"),
@@ -603,11 +603,11 @@ def local_date(utcstring: Optional[str]) -> DADateTime:
 
 def session_list_html(
     filename: Optional[str] = None,
-    user_id: Union[int, str] = None,
+    user_id: Union[int, str, None] = None,
     metadata_key_name: str = "metadata",
     filename_to_exclude: str = al_session_store_default_filename,
     exclude_current_filename: bool = True,
-    exclude_filenames: List[str] = None,
+    exclude_filenames: Optional[List[str]] = None,
     exclude_newly_started_sessions: bool = False,
     name_label: str = word("Title"),
     date_label: str = word("Date modified"),
@@ -807,8 +807,8 @@ def rename_current_session(
 
 def save_interview_answers(
     filename: str = al_session_store_default_filename,
-    variables_to_filter: Union[Set[str], List[str]] = None,
-    metadata: Dict = None,
+    variables_to_filter: Union[Set[str], List[str], None] = None,
+    metadata: Optional[Dict] = None,
     metadata_key_name: str = "metadata",
     original_interview_filename=None,
     source_filename=None,
@@ -875,7 +875,7 @@ def save_interview_answers(
 def get_filtered_session_variables(
     filename: Optional[str] = None,
     session_id: Optional[int] = None,
-    variables_to_filter: Optional[Union[Set[str], List[str]]] = None,
+    variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> Dict[str, Any]:
     """
     Get a filtered subset of the variables from the specified interview filename and session.
@@ -902,7 +902,7 @@ def get_filtered_session_variables(
 def get_filtered_session_variables_string(
     filename: Optional[str] = None,
     session_id: Optional[int] = None,
-    variables_to_filter: Optional[Union[Set[str], List[str]]] = None,
+    variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> str:
     """
     Get a JSON string representing the filtered contents of the specified filename and session_id. If no filename and session_id
@@ -918,8 +918,8 @@ def load_interview_answers(
     old_interview_filename: str,
     old_session_id: int,
     new_session: bool = False,
-    new_interview_filename: str = None,
-    variables_to_filter: List[str] = None,
+    new_interview_filename: Optional[str] = None,
+    variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
     Load answers from the specified session. If the parameter new_session = True, create a new session of
@@ -949,8 +949,8 @@ def load_interview_answers(
 def load_interview_json(
     json_string: str,
     new_session: bool = False,
-    new_interview_filename: str = None,
-    variables_to_filter: List[str] = None,
+    new_interview_filename: Optional[str] = None,
+    variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
     Provided a JSON string, load the specified variables into a Docassemble session. JSON with annotated class names
@@ -979,7 +979,7 @@ def load_interview_json(
 def export_interview_variables(
     filename: Optional[str] = None,
     session_id: Optional[int] = None,
-    variables_to_filter: Union[Set, List[str]] = None,
+    variables_to_filter: Union[Set, List[str], None] = None,
     output: DAFile = None,
 ) -> DAFile:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ extend-exclude = '(__init__.py|setup.py)'
 
 [tool.mypy]
 # global options
-no_implicit_optional = false
 exclude = '''(?x)(
     ^setup.py$
   )'''


### PR DESCRIPTION
Apparently not allowed by PEP-484. Personally, I've gotten used to it, but I remember being confused by it, and the change isn't too bad.

Is the real fix to https://github.com/SuffolkLITLab/docassemble-AssemblyLine/actions/runs/3413494344/jobs/5680263993.

Open to leaving the option in, but I'm also always for more strict and direct types.