### PR TITLE
Addendum whole words - integrate with ALDocument-level version of the API

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -814,6 +814,7 @@ class ALDocument(DADict):
         overflow_message: Optional[str] = None,
         preserve_newlines: bool = False,
         input_width: int = 80,
+        preserve_words: bool = True,
     ):
         """
         Shortcut syntax for accessing the "safe" (shorter than overflow trigger)
@@ -825,6 +826,7 @@ class ALDocument(DADict):
             overflow_message=overflow_message,
             preserve_newlines=preserve_newlines,
             input_width=input_width,
+            preserve_words=preserve_words,
         )
 
     def overflow_value(
@@ -833,6 +835,7 @@ class ALDocument(DADict):
         overflow_message: Optional[str] = None,
         preserve_newlines: bool = False,
         input_width: int = 80,
+        preserve_words: bool = True,
     ):
         """
         Shortcut syntax for accessing the "overflow" value (amount that exceeds overflow trigger)
@@ -846,6 +849,7 @@ class ALDocument(DADict):
             overflow_message=overflow_message,
             preserve_newlines=preserve_newlines,
             input_width=input_width,
+            preserve_words=preserve_words,
         )
 
     def is_enabled(self, refresh=True):


### PR DESCRIPTION
I noticed I had skipped this API, but it's the more common way of invoking the addendum code.