### PR TITLE
Remove words 'the' and 'project' from opening screen 

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -35,9 +35,9 @@ question: |
   ${interview_short_title}: ${ AL_ORGANIZATION_TITLE}
 subquestion: |
   % if form_approved_for_email_filing:
-  The ${ AL_ORGANIZATION_TITLE } Project can help you complete and file court forms in 3 steps:
+  ${ AL_ORGANIZATION_TITLE } can help you complete and file court forms in 3 steps:
   % else:
-  The ${ AL_ORGANIZATION_TITLE } Project can help you complete and download forms in 3 steps:
+  ${ AL_ORGANIZATION_TITLE } can help you complete and download forms in 3 steps:
   % endif
   
   Step 1. Answer questions that will fill in your form for you.  


### PR DESCRIPTION
Fix #611