### PR TITLE
Change OCR to use ocrmypdf in the background

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1511,17 +1511,24 @@ class ALExhibit(DAObject):
 
     def _start_ocr(self):
         """
-        Starts the OCR (optical character resolution) process on the uploaded documents.
+        Starts the OCR (optical character recognition) process on the uploaded documents.
+        This adds a searchable text layer to any images of text that have been uploaded.
 
         Makes a background action for each page in the document.
         """
         if len(self.pages):
-            # We cannot OCR in place. It is too fragile.
             self.ocr_version = DAFile(self.attr_name("ocr_version"))
             self.ocr_version.initialize(filename="tmp_ocrd.pdf")
-            self.ocr_status = background_action(
-                "al_exhibit_ocr_pages", to_pdf=self.ocr_version, from_file=self.pages
-            )
+            if get_config("assembly line", {}).get("ocr engine") == "ocrmypdf":
+                self.ocr_status = background_action(
+                    "al_exhibit_ocr_pages",
+                    to_pdf=self.ocr_version,
+                    from_file=self.pages,
+                )
+            else:
+                self.ocr_status = self.ocr_version.make_ocr_pdf_in_background(
+                    self.pages, psm=1
+                )
 
     def ocr_ready(self) -> bool:
         """

--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -55,4 +55,10 @@ generic object: ALDocumentBundle
 template: x.zip_label
 content: |
   Download zip
-  
+---
+id: al exhibit ocr pages bg
+event: al_exhibit_ocr_pages
+code: |
+  to_pdf = action_argument('to_pdf')
+  from_file = action_argument('from_file')
+  background_response(ocrmypdf_task(from_file, to_pdf))


### PR DESCRIPTION
Triggers an event in `al_document.yml`, which calls back into a module.

`--skip-text` is the fastest and probably what we want. Tried with `--redo-ocr` , but it was very slow (4 minutes for just 14 pages), and only 3 of those pages had any text. Don't think `--force-ocr` is what we want.

Difficult to get performance on it, since it runs in celery on a random worker, so I can't really use `py-spy`, but it's probably good enough for now.o

Still leaving things flexible as to when in an interview you want to wait for the fully ocr'd text; at these speeds, I'd be okay with making people wait before the final screen, but I'll also try putting e-filing in the background, if it's not too hard.

I've been testing with:

```yml
---
include:
  - docassemble.AssemblyLine:assembly_line.yml
---
objects:
  - exhibit_doc: ALExhibitDocument.using(title="Exhibits", filename="exhibits", bates_prefix="EX-", include_exhibit_cover_page=True, include_table_of_contents=True, add_page_numbers=True, auto_ocr=True, enabled=True)
---
mandatory: True
code: |
  exhibit_doc.exhibits.has_exhibits
  exhibit_doc.exhibits.gather()
  start
  if not exhibit_doc.ocr_ready():
    waiting_screen
  end = current_datetime()
  all_done
---
event: waiting_screen
reload: True
question: |
  <i class="fas fa-cog fa-spin"></i> Please wait while we process your documents . . . <i class="fas fa-cog fa-spin"></i>
---
event: all_done
question: Done!
subquestion: |
  ${ exhibit_doc.as_pdf() }
  
  ${ end - start }
---
code: |
  start = current_datetime()
---
```