### PR TITLE
Add a custom error action

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -73,7 +73,7 @@ code: |
   if _internal.get('steps') > 1:
     menu_items = al_menu_items
   else:
-    menu_items = al_menu_items[1:] # Skip the "start over" menu item
+    menu_items = al_menu_items[3:] # Skip the "start over", download, and exit and erase menu item
 ---
 reconsider: True
 code: |
@@ -81,6 +81,12 @@ code: |
     {"url": url_ask(['al_start_over_confirmation','al_start_over']),
     "label": "Start over"
     },
+    {
+      "url": url_ask(['al_exit_logout_confirmation', 'al_exit_logout']),
+      "label": "Exit and delete my answers"
+    },
+    {"url": url_action('al_error_action_download_screen'), 
+    "label": "Download current progress"},
   ]
   
   # Answer set feature is behind a server-wide configuration option
@@ -102,6 +108,10 @@ code: |
     
   al_menu_items = al_menu_items_tmp
   del al_menu_items_tmp
+---
+event: al_exit_logout
+code: |
+  command("exit_logout")
 ---
 event: al_start_over
 code: |
@@ -349,6 +359,22 @@ continue button label: |
   Start over
 continue button field: al_start_over_confirmation
 ---
+id: exit and erase answers
+question: |
+  Do you want to delete your answers?
+subquestion: |
+  Your progress on this document will be completely erased. Any
+  actions that were scheduled, such as reminders from this website,
+  will also be removed.
+  
+  Click "Exit and delete my answers" to delete your progress,
+  or "Back" if you want to keep working.
+back button label: |
+  Back
+continue button label: |
+  Exit and delete my answers
+continue button field: al_exit_logout_confirmation
+---
 ################################### Custom error action ################################
 ---
 metadata:
@@ -386,9 +412,14 @@ subquestion: |
   % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form").strip() == "None":
   * [Download a blank "${ interview_short_title }"](${ MAIN_METADATA.get("original_form") } )
   % endif
-  * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE })
+  * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE }) and try another interview
   
+  ${ action_arguments() }
+
+  ${ action_argument("error_trace") }
+
   ${ collapse_template(al_formatted_error_message) }
+back button label: Back
 buttons:
   - Exit: leave
     url: ${ AL_ORGANIZATION_HOMEPAGE }
@@ -396,18 +427,31 @@ buttons:
 ---
 event: al_error_action_download_screen
 id: emergency download screen
+decoration: triangle-exclamation
 question: |
   Here is your work in progress
 subquestion: |
-  **Warning**: these documents are not complete. Look each document over carefully and enter
+  **Warning**: these documents may not be complete. Look each document over carefully and enter
   any information that is missing once you have downloaded the documents.
+
+  **It is possible that the missing information may make this document unenforceable.**
 
   Here is your current progress on the ${ interview_short_title } documents you started:
 
   ${ al_user_bundle.download_list_html(key="emergency_download") }
+buttons:
+  - Exit: leave
+  - Start over: restart
 ---
 template: al_formatted_error_message
 subject: |
   Technical information
 content: |
   ${ action_argument('error_message') }
+
+  % if get_config("debug") and action_argument("error_trace"):
+  ```
+  ${ action_argument("error_trace")}
+  ${ action_argument("error_history")}  
+  ```
+  % endif

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -410,14 +410,10 @@ subquestion: |
   * [:comment-dots: Tell us what happened](${ feedback_link(user_info(), i=feedback_form, github_repo=github_repo_name, github_user=github_user, package_version=package_version_number) } ){:target="_blank"}
   * Try to [download your work in progress](${ url_action("al_error_action_download_screen") })
   % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form").strip() == "None":
-  * [Download a blank "${ interview_short_title }"](${ MAIN_METADATA.get("original_form") } )
+  * [Download a blank "${ all_variables(special='metadata').get("title").strip() }"](${ MAIN_METADATA.get("original_form") } )
   % endif
   * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE }) and try another interview
   
-  ${ action_arguments() }
-
-  ${ action_argument("error_trace") }
-
   ${ collapse_template(al_formatted_error_message) }
 back button label: Back
 buttons:
@@ -436,7 +432,7 @@ subquestion: |
 
   **It is possible that the missing information may make this document unenforceable.**
 
-  Here is your current progress on the ${ interview_short_title } documents you started:
+  Here is your current progress on the "${ all_variables(special='metadata').get("title").strip() }" documents you started:
 
   ${ al_user_bundle.download_list_html(key="emergency_download") }
 buttons:

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -348,7 +348,56 @@ back button label: |
 continue button label: |
   Start over
 continue button field: al_start_over_confirmation
+---
+################################### Custom error action ################################
+---
+metadata:
+  error action: al_custom_error_action
+---
+id: custom error action
+event: al_custom_error_action
+decoration: bug
+question: |
+  Something went wrong
+subquestion: |
+  % if interview_metadata.get("main_interview_key"):
+    <%
+      MAIN_METADATA = interview_metadata[interview_metadata["main_interview_key"]]
+    %>
+  % elif len(interview_metadata) > 1:    
+    <% 
+      del(interview_metadata["main_interview_key"]) # DADict creates the key on lookup above
+      MAIN_METADATA = next(iter(interview_metadata.values())) 
+    %>
+  % else:
+    <% MAIN_METADATA = {} %>
+  % endif
+
+  We ran into an error when we tried to load this screen.
+
+  You can try one of these steps to recover your work:
+
+  * Click "Back" and try again.
+  * [:comment-dots: Tell us what happened](${ feedback_link(user_info(), i=feedback_form, github_repo=github_repo_name, github_user=github_user, package_version=package_version_number) } ){:target="_blank"}
+  % if len(al_court_bundle.elements):
+  * [Download your work in progress](${ al_court_bundle.as_pdf().url_for() })
+  % endif
+  % if len(al_recipient_bundle.elements):
+  * [Download your work in progress](${ al_recipient_bundle.as_pdf().url_for() })
+  % endif
+  % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form").strip() == "None":
+  * [Download a blank "${ interview_short_title }"](${ MAIN_METADATA.get("original_form") } )
+  % endif
+  * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE })
   
-
-
-
+  ${ collapse_template(al_formatted_error_message) }
+buttons:
+  - Exit: leave
+    url: ${ AL_ORGANIZATION_HOMEPAGE }
+  - Start over: restart
+---
+template: al_formatted_error_message
+subject: |
+  Technical information
+content: |
+  ${ action_argument('error_message') }

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -73,7 +73,11 @@ code: |
   if _internal.get('steps') > 1:
     menu_items = al_menu_items
   else:
-    menu_items = al_menu_items[3:] # Skip the "start over", download, and exit and erase menu item
+    # Skip the "start over", download, and exit and erase menu item
+    if get_config("assembly line", {}).get("enable incomplete downloads"):
+      menu_items = al_menu_items[3:]
+    else:
+      menu_items = al_menu_items[2:]
 ---
 reconsider: True
 code: |
@@ -85,9 +89,13 @@ code: |
       "url": url_ask(['al_exit_logout_confirmation', 'al_exit_logout']),
       "label": "Exit and delete my answers"
     },
-    {"url": url_action('al_error_action_download_screen'), 
-    "label": "Download current progress"},
   ]
+
+  if get_config("assembly line", {}).get("enable incomplete downloads"):
+    al_menu_items_tmp.append({
+        "url": url_action('al_error_action_download_screen'), 
+        "label": "Download current progress"
+    })
   
   # Answer set feature is behind a server-wide configuration option
   if get_config('assembly line',{}).get('enable answer sets'):

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -74,7 +74,7 @@ code: |
     menu_items = al_menu_items
   else:
     # Skip the "start over", download, and exit and erase menu item
-    if get_config("assembly line", {}).get("enable incomplete downloads"):
+    if al_enable_incomplete_downloads:
       menu_items = al_menu_items[3:]
     else:
       menu_items = al_menu_items[2:]
@@ -91,7 +91,7 @@ code: |
     },
   ]
 
-  if get_config("assembly line", {}).get("enable incomplete downloads"):
+  if al_enable_incomplete_downloads:
     al_menu_items_tmp.append({
         "url": url_action('al_error_action_download_screen'), 
         "label": "Download current progress"
@@ -415,19 +415,42 @@ subquestion: |
   You can try one of these steps to recover your work:
 
   * Click "Back" and try again.
+  % if al_enable_error_action_feedback_link:
   * [:comment-dots: Tell us what happened](${ feedback_link(user_info(), i=feedback_form, github_repo=github_repo_name, github_user=github_user, package_version=package_version_number) } ){:target="_blank"}
+  % endif
+  % if al_enable_incomplete_downloads:
   * Try to [download your work in progress](${ url_action("al_error_action_download_screen") })
+  % endif
   % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form").strip() == "None":
   * [Download a blank "${ all_variables(special='metadata').get("title").strip() }"](${ MAIN_METADATA.get("original_form") } )
   % endif
   * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE }) and try another interview
-  
+  % if al_show_email_to_user_on_errors and get_config("error notification email"):
+  * [Send us an email](mailto:${ get_config("error notification email") }?subject=User%20error%20report%3A%20${ all_variables(special='metadata').get("title") }%20${ user_info().filename }) (Note: you may not get a reply)
+  % endif
+  % for al_opt in al_custom_error_options:
+  * ${ al_opt }
+  % endfor
+
   ${ collapse_template(al_formatted_error_message) }
 back button label: Back
 buttons:
   - Exit: leave
     url: ${ AL_ORGANIZATION_HOMEPAGE }
   - Start over: restart
+---
+code: |
+  al_show_email_to_user_on_errors = get_config("assembly line", {}).get("show email to user on errors")
+---
+code: |
+  al_enable_incomplete_downloads = get_config("assembly line", {}).get("enable incomplete downloads")
+---
+code: |
+  al_enable_error_action_feedback_link = get_config("assembly line", {}).get("enable error action feedback link")
+---
+code: |
+  # Provide a list of strings
+  al_custom_error_options = get_config("assembly line", {}).get("custom error actions",[])
 ---
 event: al_error_action_download_screen
 id: emergency download screen
@@ -444,7 +467,7 @@ subquestion: |
 
   ${ al_user_bundle.download_list_html(key="emergency_download") }
 buttons:
-  - Exit: leave
+  - Leave: leave
   - Start over: restart
 ---
 template: al_formatted_error_message

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -354,6 +354,9 @@ continue button field: al_start_over_confirmation
 metadata:
   error action: al_custom_error_action
 ---
+objects:
+  - MAIN_METADATA: DAEmpty()
+---
 id: custom error action
 event: al_custom_error_action
 decoration: bug
@@ -379,12 +382,7 @@ subquestion: |
 
   * Click "Back" and try again.
   * [:comment-dots: Tell us what happened](${ feedback_link(user_info(), i=feedback_form, github_repo=github_repo_name, github_user=github_user, package_version=package_version_number) } ){:target="_blank"}
-  % if len(al_court_bundle.elements):
-  * [Download your work in progress](${ al_court_bundle.as_pdf().url_for() })
-  % endif
-  % if len(al_recipient_bundle.elements):
-  * [Download your work in progress](${ al_recipient_bundle.as_pdf().url_for() })
-  % endif
+  * Try to [download your work in progress](${ url_action("al_error_action_download_screen") })
   % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form").strip() == "None":
   * [Download a blank "${ interview_short_title }"](${ MAIN_METADATA.get("original_form") } )
   % endif
@@ -395,6 +393,18 @@ buttons:
   - Exit: leave
     url: ${ AL_ORGANIZATION_HOMEPAGE }
   - Start over: restart
+---
+event: al_error_action_download_screen
+id: emergency download screen
+question: |
+  Here is your work in progress
+subquestion: |
+  **Warning**: these documents are not complete. Look each document over carefully and enter
+  any information that is missing once you have downloaded the documents.
+
+  Here is your current progress on the ${ interview_short_title } documents you started:
+
+  ${ al_user_bundle.download_list_html(key="emergency_download") }
 ---
 template: al_formatted_error_message
 subject: |


### PR DESCRIPTION
Creates a custom error page, with an optional link to download the form in progress. The download depends on the `skip undefined` parameter being correctly used on the attachment block.

In addition, this adds an "Exit and delete answers" link (#615) and a link to download the forms in-progress at any time, per discussion on Coding Deep Dive on 11/20/22 and broader discussion in #232

Fix #620 
Fix #615 

![image](https://user-images.githubusercontent.com/7645641/203426950-bcb67225-b682-4e67-89ff-2ad08e5cc0b6.png)
![image](https://user-images.githubusercontent.com/7645641/203427005-acf125dc-9ae8-4418-9623-3611208c27dd.png)

`DACatchAll` is turned on on our development server. If you want to simulate an error, one that I have been trying is triggering a hashing error. E.g., `users[{}]` in the interview order block.

I probably want to keep thinking about this a bit more over the next week or two, but it should be ready to look at. Specifically, I might want to add some features to the GithubFeedbackForm