### PR TITLE
Make answer sets unencrypted to match interview state

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions_store.yml
@@ -4,12 +4,18 @@ metadata:
     Saved answer set
   description: |
     An interview that is the target for saving and loading answer sets.
+
+    Note: answer sets are not encrypted by default.
   tags:
     - Answer_set
 ---
 modules:
   - docassemble.ALToolbox.misc
   - .sessions
+---
+mandatory: True
+code: |
+  multi_user = True
 ---
 features:
   css:


### PR DESCRIPTION
Fix #625

Can still consider expanding the API to allow conditional encryption of answer sets without changing the answer set target, but I think this is the right default for now.