### PR TITLE
Move unittest action externally

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,18 +8,5 @@ jobs:
   test-assemblyline:
     runs-on: ubuntu-latest
     name: Run python only unit tests
-    env:
-      ISUNITTEST: true
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov libzbar0
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: 'pip'
-          cache-dependency-path: |
-              setup.py
-              **/requirements.txt
-      - run: pip install --editable . -r docassemble/*/requirements.txt
-      - run: python -m mypy .
-      - run: python -m unittest discover
+      - uses: SuffolkLITLab/ALActions/pythontests@main

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ISUNITTEST: true
     steps:
-      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov libzbar0
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
@@ -19,8 +19,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
               setup.py
-              docassemble/*/requirements.txt
-      - run: pip install --editable .
-      - run: pip install -r docassemble/*/requirements.txt
+              **/requirements.txt
+      - run: pip install --editable . -r docassemble/*/requirements.txt
       - run: python -m mypy .
       - run: python -m unittest discover

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,6 @@ jobs:
           cache-dependency-path: |
               setup.py
               **/requirements.txt
-      - run: pip install --editable . -r docassemble/*/requirements.txt --use-pep517
+      - run: pip install --editable . -r docassemble/*/requirements.txt
       - run: python -m mypy .
       - run: python -m unittest discover

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,6 +20,6 @@ jobs:
           cache-dependency-path: |
               setup.py
               **/requirements.txt
-      - run: pip install --editable . -r docassemble/*/requirements.txt
+      - run: pip install --editable . -r docassemble/*/requirements.txt --use-pep517
       - run: python -m mypy .
       - run: python -m unittest discover

--- a/docassemble/AssemblyLine/requirements.txt
+++ b/docassemble/AssemblyLine/requirements.txt
@@ -1,5 +1,6 @@
 docassemble.base>=1.3
 docassemble.webapp
+wheel
 mypy
 pandas-stubs
 sqlalchemy[mypy]

--- a/docassemble/AssemblyLine/requirements.txt
+++ b/docassemble/AssemblyLine/requirements.txt
@@ -1,6 +1,5 @@
 docassemble.base>=1.3
 docassemble.webapp
-wheel
 mypy
 pandas-stubs
 sqlalchemy[mypy]


### PR DESCRIPTION
Moved the unittest action externally, in the [ALActions](https://github.com/SuffolkLITLab/ALActions) repo.

I also moved the publish step over, but the unittest one is a lot easier to test (and is currently breaking in all repos, so going forward, I want to fix things once and have the action fixed across all repos).