### PR TITLE
Add marriage questions

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1147,7 +1147,7 @@ fields:
 generic object: ALIndividual
 id: x marital status
 question: |
-  ${ x }'s current marital status
+  What is ${ x }'s current marital status
 fields:
   - ${ x } is: x.marital_status
     choices:


### PR DESCRIPTION
fix #630 - two options for getting an individual's marital status.

Sometimes detailed marital information is required. I borrowed the options from the [Census Bureau's American Community Survey](https://www.census.gov/acs/www/about/why-we-ask-each-question/marital/).

Other times, you just need to know if the user has a spouse to decide if a second petitioner is required on a family law form, e.g.

