### PR TITLE
Readd newlines between each step on intro screen

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -44,8 +44,8 @@ subquestion: |
   ${ AL_ORGANIZATION_TITLE } can help you complete and download forms in 3 steps:
   % endif
   
-  Step 1. Answer questions that will fill in your form for you.  
-  Step 2. Preview the completed form.
+  Step 1. Answer questions that will fill in your form for you.<br>
+  Step 2. Preview the completed form.<br>
   % if form_approved_for_email_filing:
   Step 3. Email the form to the court using this secure website and save copies
   for yourself for later reference.  


### PR DESCRIPTION
2 or more trailing whitespaces in markdown will add a line break (<br>) to the line. One of the trailing whitespaces that were separating out the 3 introduction steps for each AL interview was mistakenly removed in https://github.com/SuffolkLITLab/docassemble-AssemblyLine/commit/57df4abad5af35d86793527ba7f1a898cc19147a#diff-55dff7108dded7bbc3ce8459dd669a79baec6674c1558af86f66dbc878268288L44, putting steps 2 and 3 on the same line.

This PR replaces those trailing whitespaces with a more explicit `<br>`.