### PR TITLE
Cleanup appearance of error action page

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -495,12 +495,14 @@ content: |
   <h2 class="h4">${ word("Error") }</h2>
   ${ action_argument('error_message') }
 
-  % if get_config("debug") and action_argument("error_trace"):
+  % if get_config("debug") and action_argument("error_history"):
   <h2 class="h4">${ word("History") }</h2>
   <pre>
   ${ action_argument("error_history") }
   </pre>
+  % endif
 
+  % if get_config("debug") and action_argument("error_trace"):
   <h2 class="h4">${ word("Log") }</h2>
   <pre>
   ${ action_argument("error_trace")}

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -448,7 +448,9 @@ subquestion: |
   * ${ al_opt }
   % endfor
 
+  % if not get_config("verbose error messages") == False:
   ${ collapse_template(al_formatted_error_message) }
+  % endif
 back button label: Back
 buttons:
   - Exit: leave
@@ -490,11 +492,17 @@ template: al_formatted_error_message
 subject: |
   Technical information
 content: |
+  <h2 class="h4">${ word("Error") }</h2>
   ${ action_argument('error_message') }
 
   % if get_config("debug") and action_argument("error_trace"):
-  ```
+  <h2 class="h4">${ word("History") }</h2>
+  <pre>
+  ${ action_argument("error_history") }
+  </pre>
+
+  <h2 class="h4">${ word("Log") }</h2>
+  <pre>
   ${ action_argument("error_trace")}
-  ${ action_argument("error_history")}  
-  ```
+  </pre>
   % endif


### PR DESCRIPTION
- Use better formatting to more closely match existing DA 501.html template
- Make it possible to completely hide the technical information when verbose errors are disabled with the existing Docassemble error configuration (https://docassemble.org/docs/config.html#verbose%20error%20messages)

Test interview:

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
question: |
  
  ${ users[dict()] }
```