### PR TITLE
Actually print the email_to_use in the email code

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -53,7 +53,7 @@ code: |
   # email_to_use = "massaccess@suffolk.edu"
 
   if task_not_yet_performed('send email'):
-    log("Court email is ".format(court_email))
+    log(f"Court email is {court_email}, sending email to {email_to_use}")
     email_success = False
     if should_cc_user:
       log('Sending email to ' + email_to_use + ' and ccing ' + cc_email + ' for ' + str(users) + ' bcc to ' + bcc_email)


### PR DESCRIPTION
Still needs testing, which can be a bit intensive to setup.