### PR TITLE
Document bundle compatibility

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -31,6 +31,7 @@ from docassemble.base.pdfa import pdf_to_pdfa
 from textwrap import wrap
 from math import floor
 import subprocess
+from collections import ChainMap
 
 __all__ = [
     "ALAddendumField",
@@ -1541,7 +1542,86 @@ class ALDocumentBundle(DAList):
         """Returns true if the bundle itself is enabled, and it has at least one enabled child document"""
         self_enabled = self._is_self_enabled(refresh=refresh)
         return self_enabled and self.has_enabled_documents(refresh=refresh)
+    
+    def _is_docx(self, key: str = "final"):
+        if all(
+            f._is_docx()
+            for f
+            in self.enabled_documents()
+        ):
+            return True
+        return False
+    
+    def as_docx(
+        self,
+        key: str = "final",
+        refresh: bool = True,
+        append_matching_suffix: bool = True,
+    ) -> DAFile:
+        if append_matching_suffix and key == self.suffix_to_append:
+            filename = f"{base_name(self.filename)}_{key}"
+        else:
+            filename = f"{base_name(self.filename)}"        
+        if self._is_docx():
+            try:
+                the_file = docx_concatenate(
+                    self.as_docx_list(key=key, refresh=refresh),
+                    filename=filename + ".docx",
+                )
+                the_file.title = self.title
+                return the_file
+            except:
+                return self.as_pdf(key=key, refresh=refresh, append_matching_suffix=append_matching_suffix)
+        return self.as_pdf(key=key, refresh=refresh, append_matching_suffix=append_matching_suffix)
 
+    def need_addendum(self) -> bool:
+        return any(
+            f.need_addendum()
+            for f
+            in self.enabled_documents()
+        )
+
+    def has_overflow(self) -> bool:
+        return any(
+            f.has_overflow()
+            for f
+            in self.enabled_documents()
+        )
+
+    def as_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
+        return self.as_flat_list(key=key, refresh=refresh)
+    
+    @property
+    def overflow_fields(self):
+        return ChainMap(
+            f.overflow_fields
+            for f
+            in self.enabled_documents()
+        )
+    
+    def safe_value(
+        self,
+        field_name: str,
+        overflow_message: Optional[str] = None,
+        preserve_newlines: bool = False,
+        input_width: int = 80,
+        preserve_words: bool = True,
+    ):
+        for f in self.enabled_documents():
+            if field_name in f.overflow_fields:
+                return f.safe_value(field_name=field_name, overflow_message=overflow_message, preserve_newlines=preserve_newlines, input_width=input_width, preserve_words=preserve_words)
+
+    def overflow_value(
+        self,
+        field_name: str,
+        overflow_message: Optional[str] = None,
+        preserve_newlines: bool = False,
+        input_width: int = 80,
+        preserve_words: bool = True,
+    ):
+        for f in self.enabled_documents():
+            if field_name in f.overflow_fields:
+                return f.overflow_value(field_name=field_name, overflow_message=overflow_message, preserve_newlines=preserve_newlines, input_width=input_width, preserve_words=preserve_words)
 
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1542,16 +1542,12 @@ class ALDocumentBundle(DAList):
         """Returns true if the bundle itself is enabled, and it has at least one enabled child document"""
         self_enabled = self._is_self_enabled(refresh=refresh)
         return self_enabled and self.has_enabled_documents(refresh=refresh)
-    
+
     def _is_docx(self, key: str = "final"):
-        if all(
-            f._is_docx()
-            for f
-            in self.enabled_documents()
-        ):
+        if all(f._is_docx() for f in self.enabled_documents()):
             return True
         return False
-    
+
     def as_docx(
         self,
         key: str = "final",
@@ -1561,7 +1557,7 @@ class ALDocumentBundle(DAList):
         if append_matching_suffix and key == self.suffix_to_append:
             filename = f"{base_name(self.filename)}_{key}"
         else:
-            filename = f"{base_name(self.filename)}"        
+            filename = f"{base_name(self.filename)}"
         if self._is_docx():
             try:
                 the_file = docx_concatenate(
@@ -1571,34 +1567,28 @@ class ALDocumentBundle(DAList):
                 the_file.title = self.title
                 return the_file
             except:
-                return self.as_pdf(key=key, refresh=refresh, append_matching_suffix=append_matching_suffix)
-        return self.as_pdf(key=key, refresh=refresh, append_matching_suffix=append_matching_suffix)
+                return self.as_pdf(
+                    key=key,
+                    refresh=refresh,
+                    append_matching_suffix=append_matching_suffix,
+                )
+        return self.as_pdf(
+            key=key, refresh=refresh, append_matching_suffix=append_matching_suffix
+        )
 
     def need_addendum(self) -> bool:
-        return any(
-            f.need_addendum()
-            for f
-            in self.enabled_documents()
-        )
+        return any(f.need_addendum() for f in self.enabled_documents())
 
     def has_overflow(self) -> bool:
-        return any(
-            f.has_overflow()
-            for f
-            in self.enabled_documents()
-        )
+        return any(f.has_overflow() for f in self.enabled_documents())
 
     def as_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
         return self.as_flat_list(key=key, refresh=refresh)
-    
+
     @property
     def overflow_fields(self):
-        return ChainMap(
-            f.overflow_fields
-            for f
-            in self.enabled_documents()
-        )
-    
+        return ChainMap(f.overflow_fields for f in self.enabled_documents())
+
     def safe_value(
         self,
         field_name: str,
@@ -1609,7 +1599,13 @@ class ALDocumentBundle(DAList):
     ):
         for f in self.enabled_documents():
             if field_name in f.overflow_fields:
-                return f.safe_value(field_name=field_name, overflow_message=overflow_message, preserve_newlines=preserve_newlines, input_width=input_width, preserve_words=preserve_words)
+                return f.safe_value(
+                    field_name=field_name,
+                    overflow_message=overflow_message,
+                    preserve_newlines=preserve_newlines,
+                    input_width=input_width,
+                    preserve_words=preserve_words,
+                )
 
     def overflow_value(
         self,
@@ -1621,7 +1617,14 @@ class ALDocumentBundle(DAList):
     ):
         for f in self.enabled_documents():
             if field_name in f.overflow_fields:
-                return f.overflow_value(field_name=field_name, overflow_message=overflow_message, preserve_newlines=preserve_newlines, input_width=input_width, preserve_words=preserve_words)
+                return f.overflow_value(
+                    field_name=field_name,
+                    overflow_message=overflow_message,
+                    preserve_newlines=preserve_newlines,
+                    input_width=input_width,
+                    preserve_words=preserve_words,
+                )
+
 
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1543,7 +1543,16 @@ class ALDocumentBundle(DAList):
         self_enabled = self._is_self_enabled(refresh=refresh)
         return self_enabled and self.has_enabled_documents(refresh=refresh)
 
-    def _is_docx(self, key: str = "final"):
+    def _is_docx(self, key: str = "final") -> bool:
+        """
+        Determine if all enabled documents are of type DOCX.
+
+        Args:
+            key (str, optional): The key to identify enabled documents. Defaults to "final".
+
+        Returns:
+            bool: True if all enabled documents are DOCX, otherwise False.
+        """
         if all(f._is_docx() for f in self.enabled_documents()):
             return True
         return False
@@ -1554,6 +1563,17 @@ class ALDocumentBundle(DAList):
         refresh: bool = True,
         append_matching_suffix: bool = True,
     ) -> DAFile:
+        """
+        Convert the enabled documents to a single DOCX file or PDF file if conversion fails.
+
+        Args:
+            key (str, optional): The key to identify enabled documents. Defaults to "final".
+            refresh (bool, optional): Refresh the enabled documents before conversion. Defaults to True.
+            append_matching_suffix (bool, optional): Append a matching suffix to the output filename. Defaults to True.
+
+        Returns:
+            DAFile: A DAFile object containing the concatenated DOCX or PDF file.
+        """
         if append_matching_suffix and key == self.suffix_to_append:
             filename = f"{base_name(self.filename)}_{key}"
         else:
@@ -1576,59 +1596,23 @@ class ALDocumentBundle(DAList):
             key=key, refresh=refresh, append_matching_suffix=append_matching_suffix
         )
 
-    def need_addendum(self) -> bool:
-        return any(f.need_addendum() for f in self.enabled_documents())
-
-    def has_overflow(self) -> bool:
-        return any(f.has_overflow() for f in self.enabled_documents())
-
     def as_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
+        """
+        Return a list of enabled documents.
+
+        Args:
+            key (str, optional): The key to identify enabled documents. Defaults to "final".
+            refresh (bool, optional): Refresh the enabled documents before returning the list. Defaults to True.
+
+        Returns:
+            List[DAFile]: A list of enabled DAFile objects.
+        """
         return self.as_flat_list(key=key, refresh=refresh)
-
-    @property
-    def overflow_fields(self):
-        return ChainMap(f.overflow_fields for f in self.enabled_documents())
-
-    def safe_value(
-        self,
-        field_name: str,
-        overflow_message: Optional[str] = None,
-        preserve_newlines: bool = False,
-        input_width: int = 80,
-        preserve_words: bool = True,
-    ):
-        for f in self.enabled_documents():
-            if field_name in f.overflow_fields:
-                return f.safe_value(
-                    field_name=field_name,
-                    overflow_message=overflow_message,
-                    preserve_newlines=preserve_newlines,
-                    input_width=input_width,
-                    preserve_words=preserve_words,
-                )
-
-    def overflow_value(
-        self,
-        field_name: str,
-        overflow_message: Optional[str] = None,
-        preserve_newlines: bool = False,
-        input_width: int = 80,
-        preserve_words: bool = True,
-    ):
-        for f in self.enabled_documents():
-            if field_name in f.overflow_fields:
-                return f.overflow_value(
-                    field_name=field_name,
-                    overflow_message=overflow_message,
-                    preserve_newlines=preserve_newlines,
-                    input_width=input_width,
-                    preserve_words=preserve_words,
-                )
 
 
 class ALExhibit(DAObject):
     """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
-    Atributes:
+    Attributes:
         pages (list): List of individual DAFiles representing uploaded images or documents.
         cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block
           Will typically say something like "Exhibit 1"


### PR DESCRIPTION
Fix #683 

We released the new Affidavit of Indigency as an ALDocumentBundle, not a plain ALDocument anymore. I forgot to make sure it worked in all scenarios; it doesn't work when you show a download screen with DOCX downloads because of the missing is_docx() method.

I went through and tried to implement a basic version of all of the ALDocument methods on ALDocumentBundle so we can try to avoid other issues like this in less commonly tested branches.