### PR TITLE
Experimenting with not running Kiln on non-functional commits

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -10,7 +10,7 @@ on:
       - 'requirements.txt'
       - '**.py'
       - '**.yml'
-      - 'docassemble/AssemblyLine/**'
+      - 'docassemble/**'
   workflow_dispatch:
     inputs:
       tags:

--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -6,6 +6,11 @@ on:
       - "**"
     tags-ignore:
       - "**"
+    paths:
+      - 'requirements.txt'
+      - '**.py'
+      - '**.yml'
+      - 'docassemble/AssemblyLine/**'
   workflow_dispatch:
     inputs:
       tags:


### PR DESCRIPTION
Tests shouldn't need to run when change the README or the CHANGELOG.