### PR TITLE
Use "it" for a business, correctness for pronoun methods and handle preferred pronouns

### DIFF
--- a/.github/workflows/run_form_tests.yml
+++ b/.github/workflows/run_form_tests.yml
@@ -1,4 +1,4 @@
-name: Use ALKiln testing framework v4 to run tests
+name: ALKiln v5 tests
 
 on:
   push:
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Run interview tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use ALKiln to run tests
-        uses: SuffolkLITLab/ALKiln@releases/v4
+        uses: SuffolkLITLab/ALKiln@v5
         with:
           SERVER_URL: "${{ secrets.SERVER_URL }}"
           DOCASSEMBLE_DEVELOPER_API_KEY: "${{ secrets.DOCASSEMBLE_DEVELOPER_API_KEY }}"

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1039,7 +1039,7 @@ class ALIndividual(Individual):
         )
 
     def pronoun(self, **kwargs):
-        """Returns a pronoun as appropriate, based on attributes.
+        """Returns an objective pronoun as appropriate, based on attributes.
 
         The pronoun could be "you," "her," "him," "it," or "them". It depends
         on the `gender` and `person_type` attributes and whether the individual

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Literal, Union, Optional
 from docassemble.base.util import (
     Address,
     as_datetime,
+    capitalize,
     comma_and_list,
     comma_list,
     country_name,
@@ -13,18 +14,23 @@ from docassemble.base.util import (
     ensure_definition,
     get_config,
     get_country,
+    her,
+    his,
     Individual,
     IndividualName,
+    its,
     name_suffix,
     phone_number_formatted,
     phone_number_is_valid,
     state_name,
     states_list,
     subdivision_type,
+    their,
     this_thread,
     url_action,
     validation_error,
     word,
+    your,
 )
 import random
 import re
@@ -952,13 +958,13 @@ class ALIndividual(Individual):
     def gender_male(self):
         """Provide True/False for 'male' gender to assist with checkbox filling
         in PDFs with "skip undefined" turned on."""
-        return self.gender == "male"
+        return self.gender.lower() == "male"
 
     @property
     def gender_female(self):
         """Provide True/False for 'female' gender to assist with checkbox filling
         in PDFs with "skip undefined" turned on."""
-        return self.gender == "female"
+        return self.gender.lower() == "female"
 
     @property
     def gender_other(self):
@@ -971,19 +977,19 @@ class ALIndividual(Individual):
     def gender_nonbinary(self):
         """Provide True/False for 'nonbinary' gender to assist with checkbox filling
         in PDFs with "skip undefined" turned on."""
-        return self.gender == "nonbinary"
+        return self.gender.lower() == "nonbinary"
 
     @property
     def gender_unknown(self):
         """Provide True/False for 'unknown' gender to assist with checkbox filling
         in PDFs with "skip undefined" turned on."""
-        return self.gender == "unknown"
+        return self.gender.lower() == "unknown"
 
     @property
     def gender_undisclosed(self):
         """Provide True/False for 'prefer-not-to-say' gender to assist with checkbox filling
         in PDFs with "skip undefined" turned on."""
-        return self.gender == "prefer-not-to-say"
+        return self.gender.lower() == "prefer-not-to-say"
 
     @property
     def gender_self_described(self):
@@ -1030,6 +1036,99 @@ class ALIndividual(Individual):
                 bare=bare,
             )
         )
+    
+    def pronoun(self, **kwargs):
+        """Returns a pronoun as appropriate, based on attributes.
+
+        The pronoun could be "you," "her," "him," "it," or "them". It depends
+        on the `gender` and `person_type` attributes and whether the individual
+        is the current user.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The appropriate pronoun.
+        """
+        if self == this_thread.global_vars.user:
+            output = word('you', **kwargs)
+        elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
+            output = word("it", **kwargs)
+        elif self.gender.lower() == 'female':
+            output = word('her', **kwargs)
+        elif self.gender.lower() == "male":
+            output = word('him', **kwargs)
+        else:
+            output = word('them', **kwargs)
+        if 'capitalize' in kwargs and kwargs['capitalize']:
+            return capitalize(output)
+        return output
+
+    def pronoun_objective(self, **kwargs):
+        """Returns the same pronoun as the `pronoun()` method.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The appropriate objective pronoun.
+        """
+        return self.pronoun(**kwargs)
+    
+    def pronoun_possessive(self, target, **kwargs):
+        """Returns a possessive pronoun and a target word, based on attributes.
+
+        Given a target word, the function returns "{pronoun} {target}". The pronoun could be
+        "her," "his," "its," or "their". It depends on the `gender` and `person_type` attributes
+        and whether the individual is the current user.
+
+        Args:
+            target (str): The target word to follow the pronoun.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The appropriate possessive phrase.
+        """
+        if self == this_thread.global_vars.user and ('thirdperson' not in kwargs or not kwargs['thirdperson']):
+            output = your(target, **kwargs)
+        elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
+            output = its(target, **kwargs)
+        elif self.gender.lower() == 'female':
+            output = her(target, **kwargs)
+        elif self.gender.lower() == "male":
+            output = his(target, **kwargs)
+        else:
+            output = their(target, **kwargs)
+        if 'capitalize' in kwargs and kwargs['capitalize']:
+            return capitalize(output)
+        return output
+
+    def pronoun_subjective(self, **kwargs):
+        """Returns a subjective pronoun, based on attributes.
+
+        The pronoun could be "you," "she," "he," "it," or "they". It depends
+        on the `gender` and `person_type` attributes and whether the individual
+        is the current user.
+
+        Args:
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            str: The appropriate subjective pronoun.
+        """
+        if self == this_thread.global_vars.user and ('thirdperson' not in kwargs or not kwargs['thirdperson']):
+            output = word('you', **kwargs)
+        elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
+            output = word("it", **kwargs)
+        elif self.gender.lower() == 'female':
+            output = word('she', **kwargs)
+        elif self.gender.lower() == "male":
+            output = word('he', **kwargs)
+        else:
+            output = word('they', **kwargs)
+        if 'capitalize' in kwargs and kwargs['capitalize']:
+            return capitalize(output)
+        return output
 
 
 def section_links(nav) -> List[str]:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -7,6 +7,7 @@ from docassemble.base.util import (
     comma_list,
     country_name,
     DADateTime,
+    DADict,
     DAFile,
     DAList,
     date_difference,
@@ -1044,6 +1045,9 @@ class ALIndividual(Individual):
         on the `gender` and `person_type` attributes and whether the individual
         is the current user.
 
+        If the user selected specific pronouns, they take priority over 
+        gender (only if they chose a pronoun from the list)
+
         Args:
             **kwargs: Additional keyword arguments.
 
@@ -1052,6 +1056,15 @@ class ALIndividual(Individual):
         """
         if self == this_thread.global_vars.user:
             output = word('you', **kwargs)
+        elif hasattr(self, "pronouns") and isinstance(self.pronouns, DADict) and len(self.pronouns.true_values()) == 1 and self.pronouns.true_values()[0] in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]:
+            if self.pronouns["she/her/hers"]:
+                output = word("her", **kwargs)
+            elif self.pronouns["he/him/his"]:
+                output = word("him", **kwargs)
+            elif self.pronouns["they/them/theirs"]:
+                output = word("them", **kwargs)
+            elif self.pronouns["ze/zir/zirs"]:
+                output = word("zir", **kwargs)
         elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
             output = word("it", **kwargs)
         elif self.gender.lower() == 'female':
@@ -1091,6 +1104,15 @@ class ALIndividual(Individual):
         """
         if self == this_thread.global_vars.user and ('thirdperson' not in kwargs or not kwargs['thirdperson']):
             output = your(target, **kwargs)
+        elif hasattr(self, "pronouns") and isinstance(self.pronouns, DADict) and len(self.pronouns.true_values()) == 1 and self.pronouns.true_values()[0] in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]:
+            if self.pronouns["she/her/hers"]:
+                output = her(target, **kwargs)
+            elif self.pronouns["he/him/his"]:
+                output = his(target, **kwargs)
+            elif self.pronouns["they/them/theirs"]:
+                output = their(target, **kwargs)
+            elif self.pronouns["ze/zir/zirs"]:
+                output = word("zir", **kwargs) + " " + target
         elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
             output = its(target, **kwargs)
         elif self.gender.lower() == 'female':
@@ -1118,6 +1140,15 @@ class ALIndividual(Individual):
         """
         if self == this_thread.global_vars.user and ('thirdperson' not in kwargs or not kwargs['thirdperson']):
             output = word('you', **kwargs)
+        elif hasattr(self, "pronouns") and isinstance(self.pronouns, DADict) and len(self.pronouns.true_values()) == 1 and self.pronouns.true_values()[0] in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]:
+            if self.pronouns["she/her/hers"]:
+                output = word("she", **kwargs)
+            elif self.pronouns["he/him/his"]:
+                output = word("he", **kwargs)
+            elif self.pronouns["they/them/theirs"]:
+                output = word("they", **kwargs)
+            elif self.pronouns["ze/zir/zirs"]:
+                output = word("ze", **kwargs)
         elif hasattr(self, "person_type") and self.person_type in ["business", "organization"]:
             output = word("it", **kwargs)
         elif self.gender.lower() == 'female':

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -1,7 +1,7 @@
 import unittest
 from .al_general import ALIndividual, ALAddress
 from unittest.mock import Mock
-from docassemble.base.util import DADict
+from docassemble.base.util import DADict, DAAttributeError
 
 
 class test_aladdress(unittest.TestCase):
@@ -340,6 +340,28 @@ class TestALIndividual(unittest.TestCase):
         self.assertEqual(self.individual.pronoun_subjective(), "it")
         self.assertEqual(self.individual.pronoun_subjective(capitalize=True), "It")
 
+    def test_custom_pronouns(self):
+        self.individual.pronouns = DADict(
+            auto_gather=False,
+            gathered=True,
+            elements={
+                "she/her/hers": False,
+                "he/him/his": False,
+                "they/them/theirs": False,
+                "ze/zir/zirs": False,
+                "self-described": True,
+            },
+        )
+
+        self.individual.pronouns_self_described = "Xe/Xir/Xem"
+        self.assertEqual(self.individual.pronoun_objective(), "xe")
+        self.assertEqual(self.individual.pronoun_subjective(), "xir")
+        self.assertEqual(self.individual.pronoun_possessive("fish"), "xem fish")
+
+        self.individual.pronouns_self_described = "Xe/Xir/Xirs/xem/xirself"
+        # Should raise an exception
+        with self.assertRaises(DAAttributeError):
+            self.individual.pronoun_objective()
 
 if __name__ == "__main__":
     unittest.main()

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -1,6 +1,7 @@
 import unittest
 from .al_general import ALIndividual, ALAddress
 from unittest.mock import Mock
+from docassemble.base.util import DADict
 
 
 class test_aladdress(unittest.TestCase):
@@ -23,6 +24,9 @@ class TestALIndividual(unittest.TestCase):
         self.individual.this_thread = self.this_thread
 
     def test_pronoun(self):
+        self.individual.pronouns = None
+        self.individual.person_type = 'individual'
+
         self.individual.gender = 'female'
         self.assertEqual(self.individual.pronoun(), 'her')
         self.assertEqual(self.individual.pronoun(capitalize=True), 'Her')
@@ -35,12 +39,34 @@ class TestALIndividual(unittest.TestCase):
         self.assertEqual(self.individual.pronoun(), 'them')
         self.assertEqual(self.individual.pronoun(capitalize=True), 'Them')
 
+        # Checks for preferred pronouns
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": True, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun(), 'her')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Her')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": True, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun(), 'him')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Him')
+        
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": True, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun(), 'them')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Them')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": True})
+        self.assertEqual(self.individual.pronoun(), 'zir')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Zir')
+
+        self.individual.pronouns = None
         self.individual.gender = None
         self.individual.person_type = 'business'
         self.assertEqual(self.individual.pronoun(), 'it')
         self.assertEqual(self.individual.pronoun(capitalize=True), 'It')
 
+
     def test_pronoun_objective(self):
+        self.individual.pronouns = None
+        self.individual.person_type = 'individual'
+
         self.individual.gender = 'female'
         self.assertEqual(self.individual.pronoun_objective(), 'her')
         self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Her')
@@ -48,35 +74,79 @@ class TestALIndividual(unittest.TestCase):
         self.individual.gender = 'male'
         self.assertEqual(self.individual.pronoun_objective(), 'him')
         self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Him')
-
+        
         self.individual.gender = 'nonbinary'
         self.assertEqual(self.individual.pronoun_objective(), 'them')
         self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Them')
 
+        # Checks for preferred pronouns
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": True, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_objective(), 'her')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Her')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": True, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_objective(), 'him')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Him')
+        
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": True, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_objective(), 'them')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Them')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": True})
+        self.assertEqual(self.individual.pronoun_objective(), 'zir')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Zir')
+
+        self.individual.pronouns = None
         self.individual.gender = None
         self.individual.person_type = 'business'
         self.assertEqual(self.individual.pronoun_objective(), 'it')
         self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'It')
 
     def test_pronoun_possessive(self):
+        self.individual.pronouns = None
+        self.individual.person_type = 'individual'
+        item = 'fish'
+
         self.individual.gender = 'female'
-        self.assertEqual(self.individual.pronoun_possessive('fish'), 'her fish')
-        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Her fish')
+        self.assertEqual(self.individual.pronoun_possessive(item), 'her fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Her fish')
 
         self.individual.gender = 'male'
-        self.assertEqual(self.individual.pronoun_possessive('fish'), 'his fish')
-        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'His fish')
-
+        self.assertEqual(self.individual.pronoun_possessive(item), 'his fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'His fish')
+        
         self.individual.gender = 'nonbinary'
-        self.assertEqual(self.individual.pronoun_possessive('fish'), 'their fish')
-        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Their fish')
+        self.assertEqual(self.individual.pronoun_possessive(item), 'their fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Their fish')
 
+        # Checks for preferred pronouns
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": True, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_possessive(item), 'her fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Her fish')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": True, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_possessive(item), 'his fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'His fish')
+        
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": True, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_possessive(item), 'their fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Their fish')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": True})
+        self.assertEqual(self.individual.pronoun_possessive(item), 'zir fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Zir fish')
+
+        self.individual.pronouns = None
         self.individual.gender = None
         self.individual.person_type = 'business'
-        self.assertEqual(self.individual.pronoun_possessive('fish'), 'its fish')
-        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Its fish')
+        self.assertEqual(self.individual.pronoun_possessive(item), 'its fish')
+        self.assertEqual(self.individual.pronoun_possessive(item, capitalize=True), 'Its fish')
+
 
     def test_pronoun_subjective(self):
+        self.individual.pronouns = None
+        self.individual.person_type = 'individual'
+
         self.individual.gender = 'female'
         self.assertEqual(self.individual.pronoun_subjective(), 'she')
         self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'She')
@@ -84,11 +154,29 @@ class TestALIndividual(unittest.TestCase):
         self.individual.gender = 'male'
         self.assertEqual(self.individual.pronoun_subjective(), 'he')
         self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'He')
-
+        
         self.individual.gender = 'nonbinary'
         self.assertEqual(self.individual.pronoun_subjective(), 'they')
         self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'They')
 
+        # Checks for preferred pronouns
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": True, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_subjective(), 'she')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'She')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": True, "they/them/theirs": False, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_subjective(), 'he')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'He')
+        
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": True, "ze/zir/zirs": False})
+        self.assertEqual(self.individual.pronoun_subjective(), 'they')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'They')
+
+        self.individual.pronouns = DADict(auto_gather=False, gathered=True, elements={"she/her/hers": False, "he/him/his": False, "they/them/theirs": False, "ze/zir/zirs": True})
+        self.assertEqual(self.individual.pronoun_subjective(), 'ze')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'Ze')
+
+        self.individual.pronouns = None
         self.individual.gender = None
         self.individual.person_type = 'business'
         self.assertEqual(self.individual.pronoun_subjective(), 'it')

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -1,11 +1,98 @@
 import unittest
 from .al_general import ALIndividual, ALAddress
+from unittest.mock import Mock
 
 
 class test_aladdress(unittest.TestCase):
     def test_empty_is_empty(self):
         addr = ALAddress(address="", city="")
         self.assertEqual(addr.on_one_line(), "")
+
+class TestALIndividual(unittest.TestCase):
+
+    def setUp(self):
+        self.individual = ALIndividual()
+        
+        # Creating a mock object for this_thread
+        self.this_thread = Mock()
+
+        # Mocking this_thread.global_vars.user as a distinct object
+        self.this_thread.global_vars.user = Mock()
+
+        # Assigning this_thread to self.individual
+        self.individual.this_thread = self.this_thread
+
+    def test_pronoun(self):
+        self.individual.gender = 'female'
+        self.assertEqual(self.individual.pronoun(), 'her')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Her')
+
+        self.individual.gender = 'male'
+        self.assertEqual(self.individual.pronoun(), 'him')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Him')
+        
+        self.individual.gender = 'nonbinary'
+        self.assertEqual(self.individual.pronoun(), 'them')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'Them')
+
+        self.individual.gender = None
+        self.individual.person_type = 'business'
+        self.assertEqual(self.individual.pronoun(), 'it')
+        self.assertEqual(self.individual.pronoun(capitalize=True), 'It')
+
+    def test_pronoun_objective(self):
+        self.individual.gender = 'female'
+        self.assertEqual(self.individual.pronoun_objective(), 'her')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Her')
+
+        self.individual.gender = 'male'
+        self.assertEqual(self.individual.pronoun_objective(), 'him')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Him')
+
+        self.individual.gender = 'nonbinary'
+        self.assertEqual(self.individual.pronoun_objective(), 'them')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'Them')
+
+        self.individual.gender = None
+        self.individual.person_type = 'business'
+        self.assertEqual(self.individual.pronoun_objective(), 'it')
+        self.assertEqual(self.individual.pronoun_objective(capitalize=True), 'It')
+
+    def test_pronoun_possessive(self):
+        self.individual.gender = 'female'
+        self.assertEqual(self.individual.pronoun_possessive('fish'), 'her fish')
+        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Her fish')
+
+        self.individual.gender = 'male'
+        self.assertEqual(self.individual.pronoun_possessive('fish'), 'his fish')
+        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'His fish')
+
+        self.individual.gender = 'nonbinary'
+        self.assertEqual(self.individual.pronoun_possessive('fish'), 'their fish')
+        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Their fish')
+
+        self.individual.gender = None
+        self.individual.person_type = 'business'
+        self.assertEqual(self.individual.pronoun_possessive('fish'), 'its fish')
+        self.assertEqual(self.individual.pronoun_possessive('fish', capitalize=True), 'Its fish')
+
+    def test_pronoun_subjective(self):
+        self.individual.gender = 'female'
+        self.assertEqual(self.individual.pronoun_subjective(), 'she')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'She')
+
+        self.individual.gender = 'male'
+        self.assertEqual(self.individual.pronoun_subjective(), 'he')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'He')
+
+        self.individual.gender = 'nonbinary'
+        self.assertEqual(self.individual.pronoun_subjective(), 'they')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'They')
+
+        self.individual.gender = None
+        self.individual.person_type = 'business'
+        self.assertEqual(self.individual.pronoun_subjective(), 'it')
+        self.assertEqual(self.individual.pronoun_subjective(capitalize=True), 'It')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #672 

I also realized Jonathan's original code had some mistakes, including a default "he/him/his" when gender wasn't one of "male", "female" or "other."

Finally, this code handles the user's preferred pronouns in priority to the pronouns that come from the default of their gender if the author has a question that asks for pronouns (and we can unambiguously parse those pronouns)