### PR TITLE
handle more situations where user unintentionally left "Unit" out of address field

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -211,8 +211,25 @@ class ALAddress(Address):
 
         return fields
 
-    def formatted_unit(self, language=None, require=False, bare=False):
-        """Returns the unit, formatted appropriately"""
+    def formatted_unit(
+        self, language: Optional[str] = None, require: bool = False, bare: bool = False
+    ) -> str:
+        """
+        Returns the unit, formatted appropriately.
+
+        Args:
+            language (str, optional): The language in which to format the unit. Defaults to None (which uses system language).
+            require (bool, optional): A flag indicating whether the unit is required. If set to True, the function will
+                                    raise an error if the unit attribute does not exist. Defaults to False.
+            bare (bool, optional): A flag indicating whether to add the word 'Unit' before the unit number. If set to
+                                True, the function will not add 'Unit' regardless of other conditions. Defaults to False.
+
+        Returns:
+            str: The formatted unit. If the unit attribute does not exist and require is set to False, this will be an
+                empty string. If the unit attribute exists and is not None or an empty string, the function will return
+                the unit number, possibly prefixed with 'Unit'. If the unit attribute exists and is None or an empty
+                string, the function will return an empty string.
+        """
         if (
             not hasattr(self, "unit")
             and not hasattr(self, "floor")
@@ -222,10 +239,33 @@ class ALAddress(Address):
                 self.unit
             else:
                 return ""
-        if hasattr(self, "unit") and self.unit != "" and self.unit is not None:
-            if not bare and str(self.unit).isnumeric():
+        if hasattr(self, "unit") and self.unit is not None and self.unit != "":
+            unit_lower = str(self.unit).lower()
+            # Sometimes people neglect to add a word before the unit number,
+            # use some heuristics to decide when it's necessary to add one.
+            if not bare and (
+                unit_lower.isnumeric()
+                or (
+                    not " " in self.unit
+                    and not any(
+                        x in unit_lower
+                        for x in [
+                            "apt",
+                            "unit",
+                            "suite",
+                            "bldg",
+                            "fl",
+                            "apartment",
+                            "building",
+                            "floor",
+                            "ste",
+                        ]
+                    )
+                )
+            ):
                 return word("Unit", language=language) + " " + str(self.unit)
-            return str(self.unit)
+            else:
+                return str(self.unit)
         if hasattr(self, "floor") and self.floor != "" and self.floor is not None:
             return word("Floor", language=language) + " " + str(self.floor)
         if hasattr(self, "room") and self.room != "" and self.room is not None:

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -3,9 +3,47 @@ from .al_general import ALIndividual, ALAddress
 
 
 class test_aladdress(unittest.TestCase):
+    def setUp(self):
+        self.addr = ALAddress()
+
     def test_empty_is_empty(self):
         addr = ALAddress(address="", city="")
         self.assertEqual(addr.on_one_line(), "")
+
+    def test_no_unit_floor_room(self):
+        self.assertFalse(hasattr(self.addr, "unit"))
+        self.assertFalse(hasattr(self.addr, "floor"))
+        self.assertFalse(hasattr(self.addr, "room"))
+        self.assertEqual(self.addr.formatted_unit(), "")
+
+    def test_require_unit_exception(self):
+        self.assertFalse(hasattr(self.addr, "unit"))
+        with self.assertRaises(AttributeError):
+            self.addr.formatted_unit(require=True)
+
+    def test_unit_isnumeric(self):
+        self.addr.unit = "123"
+        self.assertEqual(self.addr.formatted_unit(), "Unit 123")
+
+    def test_unit_no_space_without_known_descriptors(self):
+        self.addr.unit = "1A"
+        self.assertEqual(self.addr.formatted_unit(), "Unit 1A")
+
+    def test_unit_with_space_and_known_descriptor(self):
+        self.addr.unit = "Apt 1A"
+        self.assertEqual(self.addr.formatted_unit(), "Apt 1A")
+
+    def test_bare_unit(self):
+        self.addr.unit = "1A"
+        self.assertEqual(self.addr.formatted_unit(bare=True), "1A")
+
+    def test_floor_formatting(self):
+        self.addr.floor = "5"
+        self.assertEqual(self.addr.formatted_unit(), "Floor 5")
+
+    def test_room_formatting(self):
+        self.addr.room = "101"
+        self.assertEqual(self.addr.formatted_unit(), "Room 101")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #706 

Basic algorithm to decide when to add the word "Unit":

1. Check if the unit is not numeric
2. Check if it includes at least one space
3. Check if it uses a known word, like "apt" but the user left out the space

If all tests fail, we add the word Unit.