### PR TITLE
More flexible API for menu items

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -69,54 +69,68 @@ features:
 ---
 initial: True
 code: |
-  # Set the dropdown/hamburger menu items
-  # by default we just add a "Start over" link
-  if _internal.get('steps') > 1:
-    menu_items = al_menu_items
-  else:
-    # Skip the "start over", download, and exit and erase menu item
-    if al_enable_incomplete_downloads:
-      menu_items = al_menu_items[3:]
-    else:
-      menu_items = al_menu_items[2:]
+  menu_items = [
+    item for item in al_menu_items if not item.get("hidden", False)
+  ]
+---
+code: |
+  al_menu_items_custom_items = []
 ---
 reconsider: True
 code: |
-  al_menu_items_tmp = [
-    {"url": url_ask(['al_start_over_confirmation','al_start_over']),
-    "label": "Start over"
-    },
-    {
-      "url": url_ask(['al_exit_logout_confirmation', 'al_exit_logout']),
-      "label": "Exit and delete my answers"
-    },
-  ]
-
-  if al_enable_incomplete_downloads:
-    al_menu_items_tmp.append({
-        "url": url_action('al_error_action_download_screen'), 
-        "label": "Download current progress"
-    })
-  
-  # Answer set feature is behind a server-wide configuration option
-  if get_config('assembly line',{}).get('enable answer sets'):
-    al_menu_items_tmp.extend([
-    {"url": url_ask(["al_sessions_snapshot_label", {"recompute": ["al_sessions_save_session_snapshot"]}, "al_sessions_save_status"]),
-    "label": "Save answer set"
-    },
-    action_menu_item("Load answer set", "al_load_saved_session"),
-  ]
-  )
-  
-  if get_config('assembly line',{}).get('enable answer set imports'):
-    al_menu_items_tmp.append(
-      {"url": url_ask(["al_sessions_json_file", {"recompute": ["al_sessions_import_json"]}, "al_sessions_load_status"]),
-      "label": "Import answer set"
-      }
-    )
-    
-  al_menu_items = al_menu_items_tmp
-  del al_menu_items_tmp
+  al_menu_items = al_menu_items_custom_items + al_menu_items_default_items
+---
+reconsider: True
+variable name: al_menu_items_default_items
+data from code:
+  - url: 
+      url_ask(['al_start_over_confirmation','al_start_over'])
+    label: str(al_start_over_string)
+    hidden: _internal.get('steps') < 2
+  - url: |
+      url_ask(['al_exit_logout_confirmation', 'al_exit_logout'])
+    label: str(al_exit_logout_string)
+    hidden: _internal.get('steps') < 2
+  - url: |
+      url_action('al_error_action_download_screen')
+    label: str(al_download_progress_string)
+    hidden: (not al_enable_incomplete_downloads) or (_internal.get('steps') < 2)
+  - url: |
+      url_ask(["al_sessions_snapshot_label", {"recompute": ["al_sessions_save_session_snapshot"]}, "al_sessions_save_status"])
+    label: str(al_save_answer_set_string)
+    hidden: (not get_config('assembly line',{}).get('enable answer sets')) or (_internal.get('steps') < 2)
+  - url: |
+      url_action('al_load_saved_session')
+    label: str(al_load_answer_set_string)
+    hidden: (not get_config('assembly line',{}).get('enable answer sets')) or (_internal.get('steps') < 2)
+  - url: |
+      url_action('al_error_action_download_screen')
+    label: str(al_download_answer_set_string)
+    hidden: (not get_config('assembly line',{}).get('enable answer set imports')) or (_internal.get('steps') < 2)
+---
+template: al_start_over_string
+content: >-
+  Start over
+---
+template: al_exit_logout_string
+content: >-
+  Exit and delete my answers
+---
+template: al_download_progress_string
+content: >-
+  Download current progress
+---
+template: al_save_answer_set_string
+content: >-
+  Save answer set
+---
+template: al_load_answer_set_string
+content: >-
+  Load answer set
+---
+template: al_download_answer_set_string
+content: >-
+  Download answer set
 ---
 event: al_exit_logout
 code: |


### PR DESCRIPTION
fix #723

Adds a new user-facing magic keyword: `al_menu_items_custom_items` which should be a list of menu items. Custom items are shown before default menu items.

Each menu items follows the Docassemble menu item format, which is a dictionary with the keys `url` and `label`. It can be convenient, and readable, to use a `data from code` block to define the menu items, but you can use any method to create the right Python datastructure.

Optionally, you can add a key `hidden` which contains a True/False value. If the value is `True` the menu item won't be shown. This can be used to dynamically show or hide the menu item on a given page. If the value is dynamic, you should add a `reconsider` modifier on the block that defines `al_menu_items_custom_items`.

E.g.,

```
reconsider: True
variable name: al_menu_items_custom_items
data from code:
  - url: |
      "http://example.com"
    label: |
       "Example link"
    hidden: user_turned_off_example_link
```

Note that if the visible state isn't dynamic, the author can use a `data` block instead of a `data from code` block. This will make the label translatable. Alternatively, the author can add a template for the label to make it available for translation.