### PR TITLE
More declarative method for defining navigation sections

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -141,6 +141,17 @@ code: |
   command('new_session')
 ---
 code: |
+  enable_al_nav_sections = False
+---
+code: |
+  al_nav_sections = []
+---
+initial: True
+code: |
+  if enable_al_nav_sections:
+    nav.set_sections(get_visible_al_nav_items(al_nav_sections))
+---
+code: |
   send_icon = "envelope"
 ---
 code: |

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -1,5 +1,5 @@
 import unittest
-from .al_general import ALIndividual, ALAddress
+from .al_general import ALIndividual, ALAddress, get_visible_al_nav_items
 from unittest.mock import Mock
 from docassemble.base.util import DADict, DAAttributeError
 
@@ -401,6 +401,63 @@ class TestALIndividual(unittest.TestCase):
         with self.assertRaises(DAAttributeError):
             self.individual.pronoun_objective()
 
+class test_get_visible_al_nav_items(unittest.TestCase):
 
+    def test_case_1(self):
+        data = [
+            "Selecting_Legal_Category",
+            {"personal_injury": "Gather Evidence", "hidden": False},
+            {"divorce": "Collect Financial Documents", "hidden": False},
+            {"business_dispute": ["Interview Witnesses", {"subtask": "Document Communication", "hidden": False}]}
+        ]
+        expected = [
+            "Selecting_Legal_Category",
+            {"personal_injury": "Gather Evidence"},
+            {"divorce": "Collect Financial Documents"},
+            {"business_dispute": ["Interview Witnesses", {"subtask": "Document Communication"}]}
+        ]
+        self.assertEqual(get_visible_al_nav_items(data), expected)
+
+    def test_case_2(self):
+        data = [
+            "Drafting_Documents",
+            {"pre_nup": "List Assets"},
+            "Finding_Legal_Representative",
+            {"business_formation": ["Choose Business Type", {"subtask": "Decide Ownership Structure", "hidden": True}]},
+            {"real_estate": "Draft Lease Agreement", "hidden": True}
+        ]
+        expected = [
+            "Drafting_Documents",
+            {"pre_nup": "List Assets"},
+            "Finding_Legal_Representative",
+            {"business_formation": ["Choose Business Type"]}
+        ]
+        self.assertEqual(get_visible_al_nav_items(data), expected)
+
+    def test_case_3(self):
+        data = [
+            "Negotiating_Terms",
+            "Reviewing_Contracts",
+            {"estate_planning": ["Draft Will", {"subtask": "Designate Beneficiaries", "hidden": False}, {"subtask": "Determine Power of Attorney", "hidden": False}]}
+        ]
+        expected = [
+            "Negotiating_Terms",
+            "Reviewing_Contracts",
+            {"estate_planning": ["Draft Will", {"subtask": "Designate Beneficiaries"}, {"subtask": "Determine Power of Attorney"}]}
+        ]
+        self.assertEqual(get_visible_al_nav_items(data), expected)
+
+    def test_case_4(self):
+        data = [
+            {"employment_law": "Understand Employee Rights", "hidden": False},
+            "Preparing_for_Court",
+            {"criminal_defense": ["Know Your Rights", {"subtask": "Hire Defense Attorney", "hidden": True}]}
+        ]
+        expected = [
+            {"employment_law": "Understand Employee Rights"},
+            "Preparing_for_Court",
+            {"criminal_defense": ["Know Your Rights"]}
+        ]
+        self.assertEqual(get_visible_al_nav_items(data), expected)
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix #262 

like #726 does for the drop-down menu, this creates a method to control the navigation items on the left in a more declarative way. The author can provide datastructure that is recalculated fresh on whatever basis makes sense for the interview (reconsider modifier, inline call to reconsider, or `depends on` modifier as appropriate). The datastructure will list every potential menu item and then put the rule for turning the item on or off in the optional `hidden` key.

Because we have a lot of existing interviews that use the simpler `sections` syntax to define static sections, this behavior is turned off by default.

Example:

```
---
code: |
  enable_al_nav_sections = True
---
reconsider: True
variable name: al_nav_sections
data from code:
  - item1: |
      "Label1"
  - item2: |
      "Label2"
  - item3: |
      "Label3"
    hidden: _internal.get('steps') < 2
```