### PR TITLE
Better docstrings

### DIFF
--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -242,14 +242,14 @@ class ALCourtLoader(DAObject):
 
     def county_list(self, column_name: str = "address_county"):
         """
-        Get a list of all unique names for the specified column in the given spreadsheet.
+        Get a set of all unique names for the specified column in the given spreadsheet.
         Typically used to get a list of all possible counties that have a court.
 
         Args:
             column_name (str): The name of the column in the dataframe.
 
         Returns:
-            List[str]: A list of all unique values in the specified row in the given spreadsheet
+            Set[str]: A list of all unique values in the specified row in the given spreadsheet
         """
         return self.unique_column_values(column_name)
 

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -47,7 +47,7 @@ class ALCourt(Court):
 
         See: https://docassemble.org/docs/functions.html#map_of
 
-        Returns: 
+        Returns:
             List[Dict[str, Any]] - a list of dictionaries, each of which contains
                 the following keys:
                     - latitude: float
@@ -105,7 +105,7 @@ class ALCourt(Court):
             all_info = f"{ all_info }[BR]{ self.address.on_one_line() }"
         return f"{ all_info }[BR]{ self.description }"
 
-    def from_row(self, df_row: pd.Series, ensure_lat_long:bool=True) -> None:
+    def from_row(self, df_row: pd.Series, ensure_lat_long: bool = True) -> None:
         """
         Loads data from a single Pandas Dataframe into the current court object.
         Note: It will try to convert column names that don't make valid
@@ -190,7 +190,6 @@ class ALCourt(Court):
         self.location = self.address.location
 
 
-
 class ALCourtLoader(DAObject):
     """
     Object to hold some methods surrounding loading/filtering courts.
@@ -198,7 +197,7 @@ class ALCourtLoader(DAObject):
     Built around Pandas dataframe.
 
     Attributes:
-        filename (str): Path to the file containing court information.    
+        filename (str): Path to the file containing court information.
     """
 
     def init(self, *pargs, **kwargs):
@@ -215,12 +214,12 @@ class ALCourtLoader(DAObject):
     # Only solution I can think of would require court database owners to assign each court a unique ID
     # and something that triggers recalculating the court address/etc info.
 
-    def all_courts(self) -> List[ALCourt]:
+    def all_courts(self) -> List[Dict[int, str]]:
         """
         Return a list of all courts in the spreadsheet.
 
-        Returns: 
-            List[ALCourt]: List of all ALCourt instances without filtering.
+        Returns:
+            List[Dict[int, str]]: List of all ALCourt instances without filtering.
         """
         return self.filter_courts(None)
 
@@ -245,10 +244,10 @@ class ALCourtLoader(DAObject):
         """
         Get a list of all unique names for the specified column in the given spreadsheet.
         Typically used to get a list of all possible counties that have a court.
-        
+
         Args:
             column_name (str): The name of the column in the dataframe.
-        
+
         Returns:
             List[str]: A list of all unique values in the specified row in the given spreadsheet
         """
@@ -282,15 +281,15 @@ class ALCourtLoader(DAObject):
         """
         Return the first court matching the county name. Should only be used
         when you know there is exactly one match
-        
+
         Args:
             intrinsicName (str): The intrinsic name you want the newly returned object to have (used for DA namespace searching).
             county_name (str): The name of the county to check.
             county_column (str): The name of the column in the dataframe that contains the county names.
                                     Defaults to "address_county".
-        
+
         Returns:
-            ALCourt: The first court matching the county name.    
+            ALCourt: The first court matching the county name.
 
         """
         matches = self.filter_courts(court_types=county_name, column=county_column)
@@ -305,12 +304,12 @@ class ALCourtLoader(DAObject):
         display_column: str = "name",
         search_string: Optional[str] = None,
         search_columns: Optional[Union[List[str], str]] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[int, str]]:
         """
         Retrieve a list of all courts in the specified county.
 
-        This function fetches courts suitable for displaying as a drop-down or radio button list 
-        in Docassemble. The results are dictionaries where the key is the index in the dataframe, 
+        This function fetches courts suitable for displaying as a drop-down or radio button list
+        in Docassemble. The results are dictionaries where the key is the index in the dataframe,
         useful for retrieving the court's full details later using the as_court() method.
 
         Args:
@@ -318,11 +317,11 @@ class ALCourtLoader(DAObject):
             county_column (str, optional): Column heading which contains county name. Defaults to "address_county".
             display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
             search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
-            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with 
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with
                 the search_string in a case-insensitive manner. Defaults to None.
 
         Returns:
-            List[dict]: List of dictionaries representing matching courts.
+            List[Dict[int, str]]: List of dictionaries representing matching courts.
         """
         return self.filter_courts(
             court_types=county_name,
@@ -343,16 +342,16 @@ class ALCourtLoader(DAObject):
         """
         Return a filtered subset of courts represented as a list of dictionaries.
 
-        Each dictionary has the format {index: name}, where "index" refers to the dataframe index and "name" 
+        Each dictionary has the format {index: name}, where "index" refers to the dataframe index and "name"
         is determined by the `display_column`.
 
         Args:
-            court_types (Optional[Union[List[str], str]]): Exact string match or matches used to filter results 
+            court_types (Optional[Union[List[str], str]]): Exact string match or matches used to filter results
                 (inclusive). Examples include "District" or ["Municipal","Superior"].
             column (str, optional): Column heading to search. Defaults to "department".
             display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
             search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
-            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with 
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with
                 the search_string in a case-insensitive manner. Defaults to None.
 
         Returns:
@@ -375,9 +374,11 @@ class ALCourtLoader(DAObject):
             filtered = filtered[
                 filtered["__search_col"].str.contains(search_string, case=False)
             ]
-        return list(filtered[display_column].items())
+        return list(filtered[display_column].items())  # type: ignore
 
-    def as_court(self, intrinsicName: str, index: int, ensure_lat_long: bool = True) -> ALCourt:
+    def as_court(
+        self, intrinsicName: str, index: Union[int, str], ensure_lat_long: bool = True
+    ) -> ALCourt:
         """
         Retrieve the court at the specified index as an ALCourt object.
 

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -43,7 +43,17 @@ class ALCourt(Court):
 
     def _map_info(self) -> List[Dict[str, Any]]:
         """
-        Create information that can be used to display court locations on a map.
+        Create information that can be used to display court locations on a Docassemble map.
+
+        See: https://docassemble.org/docs/functions.html#map_of
+
+        Returns: 
+            List[Dict[str, Any]] - a list of dictionaries, each of which contains
+                the following keys:
+                    - latitude: float
+                    - longitude: float
+                    - info: str
+                    - icon: str (optional)
         """
         the_info = str(self.name)
         the_info += "  [NEWLINE]  " + self.address.block()
@@ -62,6 +72,8 @@ class ALCourt(Court):
         This may not match the court's name. If the name omits city, we
         append city name to the court name. This is good for a drop-down selection
         list.
+
+        Returns: str
         """
         # Avoid forcing the interview to define the court's address
         if hasattr(self, "address") and hasattr(self.address, "city"):
@@ -75,6 +87,8 @@ class ALCourt(Court):
         """
         Returns a markdown formatted string with the name and address of the court.
         More concise version without description; suitable for a responsive case.
+
+        Returns: str
         """
         return f"**{ self.short_label() }**[BR]{ self.address.on_one_line() }"
 
@@ -83,18 +97,24 @@ class ALCourt(Court):
         Returns a Markdown formatted string that includes the disambiguated name and
         the description of the court, for inclusion in the results page with radio
         buttons.
+
+        Returns: str
         """
         all_info = f"**{ self.short_label() }**"
         if hasattr(self, "address"):
             all_info = f"{ all_info }[BR]{ self.address.on_one_line() }"
         return f"{ all_info }[BR]{ self.description }"
 
-    def from_row(self, df_row, ensure_lat_long=True) -> None:
+    def from_row(self, df_row: pd.Series, ensure_lat_long:bool=True) -> None:
         """
-        Loads data from a single Pandas Dataframe into a court object.
+        Loads data from a single Pandas Dataframe into the current court object.
         Note: It will try to convert column names that don't make valid
         attributes. Best practice is to use good attribute names (no spaces) that don't interfere
         with existing attributes or methods of DAObject
+
+        Args:
+            df_row: Pandas Series object
+            ensure_lat_long: bool, whether to use Google Maps to geocode the address if we don't have coordinates
         """
         # A few columns we expect to see:
         # name
@@ -155,8 +175,20 @@ class ALCourt(Court):
                 # self.location = self.address.location
 
     def geolocate(self):
-        self.address.geolocate()
+        """
+        Use Google Maps to geocode the court's address and store the result in the location attribute.
+
+        Deprecated: use geocode() instead.
+        """
+        self.geocode()
+
+    def geocode(self):
+        """
+        Use Google Maps to geocode the court's address and store the result in the location attribute.
+        """
+        self.address.geocode()
         self.location = self.address.location
+
 
 
 class ALCourtLoader(DAObject):
@@ -164,6 +196,9 @@ class ALCourtLoader(DAObject):
     Object to hold some methods surrounding loading/filtering courts.
 
     Built around Pandas dataframe.
+
+    Attributes:
+        filename (str): Path to the file containing court information.    
     """
 
     def init(self, *pargs, **kwargs):
@@ -180,12 +215,26 @@ class ALCourtLoader(DAObject):
     # Only solution I can think of would require court database owners to assign each court a unique ID
     # and something that triggers recalculating the court address/etc info.
 
-    def all_courts(self) -> list:
-        """Return all courts without any filtering"""
+    def all_courts(self) -> List[ALCourt]:
+        """
+        Return a list of all courts in the spreadsheet.
+
+        Returns: 
+            List[ALCourt]: List of all ALCourt instances without filtering.
+        """
         return self.filter_courts(None)
 
-    def unique_column_values(self, column_name) -> Set[str]:
-        """get a list of all unique values in the given column"""
+    def unique_column_values(self, column_name: str) -> Set[str]:
+        """
+        Retrieve a set of unique values present in a specified dataframe column.
+
+        Args:
+            column_name (str): The name of the column in the dataframe.
+
+        Returns:
+            Set[str]: A set containing unique values from the specified column.
+                      Returns an empty set if an error occurs.
+        """
         df = self._load_courts()
         try:
             return set(df[column_name].unique())
@@ -193,13 +242,33 @@ class ALCourtLoader(DAObject):
             return set()
 
     def county_list(self, column_name: str = "address_county"):
-        """Get a list of all unique county names in the given spreadsheet"""
+        """
+        Get a list of all unique names for the specified column in the given spreadsheet.
+        Typically used to get a list of all possible counties that have a court.
+        
+        Args:
+            column_name (str): The name of the column in the dataframe.
+        
+        Returns:
+            List[str]: A list of all unique values in the specified row in the given spreadsheet
+        """
         return self.unique_column_values(column_name)
 
     def county_has_one_court(
         self, county_name: str, county_column: str = "address_county"
     ) -> bool:
-        """Returns True if there is only one court associated with the specified county"""
+        """
+        Returns True if there is only one court associated with the specified county
+        in the spreadsheet. Returns False otherwise.
+
+        Args:
+            county_name (str): The name of the county to check.
+            county_column (str): The name of the column in the dataframe that contains the county names.
+                                    Defaults to "address_county".
+
+        Returns:
+            bool: True if there is only one court associated with the specified county in the spreadsheet.
+        """
         return (
             len(self.filter_courts(court_types=county_name, column=county_column)) == 1
         )
@@ -210,8 +279,20 @@ class ALCourtLoader(DAObject):
         county_name: str,
         county_column: str = "address_county",
     ) -> ALCourt:
-        """Return the first court matching the county name. Should only be used
-        when you know there is exactly one match"""
+        """
+        Return the first court matching the county name. Should only be used
+        when you know there is exactly one match
+        
+        Args:
+            intrinsicName (str): The intrinsic name you want the newly returned object to have (used for DA namespace searching).
+            county_name (str): The name of the county to check.
+            county_column (str): The name of the column in the dataframe that contains the county names.
+                                    Defaults to "address_county".
+        
+        Returns:
+            ALCourt: The first court matching the county name.    
+
+        """
         matches = self.filter_courts(court_types=county_name, column=county_column)
         if len(matches) > 0:
             return self.as_court(intrinsicName, next(iter(matches))[0])
@@ -225,16 +306,23 @@ class ALCourtLoader(DAObject):
         search_string: Optional[str] = None,
         search_columns: Optional[Union[List[str], str]] = None,
     ) -> List[dict]:
-        """Get a list of all courts in the provided county, suitable for displaying
-        as a drop-down or radio button list in Docassemble. The results will be a
-        dictionary where the key is the index in the dataframe, to be used to
-        retrieve the court's full details later with the as_court() method.
+        """
+        Retrieve a list of all courts in the specified county.
 
-        :param county_name: str name of a county
-        :param county_column: str column heading which contains county name. Defaults to "address_county"
-        :param display_column: str column heading which will be used for display in drop down
-        :param search_string: str, optional a keyword that will be checked in the filtered list of results
-        :param search_columns: str or List[str], optional columns to aggregate and then do case-insensitive search across with the search_string
+        This function fetches courts suitable for displaying as a drop-down or radio button list 
+        in Docassemble. The results are dictionaries where the key is the index in the dataframe, 
+        useful for retrieving the court's full details later using the as_court() method.
+
+        Args:
+            county_name (str): Name of the county.
+            county_column (str, optional): Column heading which contains county name. Defaults to "address_county".
+            display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
+            search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with 
+                the search_string in a case-insensitive manner. Defaults to None.
+
+        Returns:
+            List[dict]: List of dictionaries representing matching courts.
         """
         return self.filter_courts(
             court_types=county_name,
@@ -251,16 +339,24 @@ class ALCourtLoader(DAObject):
         display_column: str = "name",
         search_string: Optional[str] = None,
         search_columns: Optional[Union[List[str], str]] = None,
-    ) -> List[dict]:
+    ) -> List[Dict[int, str]]:
         """
-        Return a subset of courts as a list of dictionaries, like:
-        index: name
+        Return a filtered subset of courts represented as a list of dictionaries.
 
-        :param court_types: List[str] or str, exact string match[es] you want to use to filter results (inclusive). E.g., "District" or ["Municipal","Superior"]
-        :param column: str column heading which you want to search. Defaults to "department"
-        :param display_column: str column heading which will be used for display in drop down
-        :param search_string: str, optional a keyword that will be checked in the filtered list of results
-        :param search_columns: str or List[str], optional columns to aggregate and then do case-insensitive search across with the search_string
+        Each dictionary has the format {index: name}, where "index" refers to the dataframe index and "name" 
+        is determined by the `display_column`.
+
+        Args:
+            court_types (Optional[Union[List[str], str]]): Exact string match or matches used to filter results 
+                (inclusive). Examples include "District" or ["Municipal","Superior"].
+            column (str, optional): Column heading to search. Defaults to "department".
+            display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
+            search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with 
+                the search_string in a case-insensitive manner. Defaults to None.
+
+        Returns:
+            List[Dict[int, str]]: List of dictionaries representing filtered courts.
         """
         df = self._load_courts()
         if court_types:
@@ -281,9 +377,17 @@ class ALCourtLoader(DAObject):
             ]
         return list(filtered[display_column].items())
 
-    def as_court(self, intrinsicName, index, ensure_lat_long=True):
+    def as_court(self, intrinsicName: str, index: int, ensure_lat_long: bool = True) -> ALCourt:
         """
-        Return the court at the specified index as an ALCourt object
+        Retrieve the court at the specified index as an ALCourt object.
+
+        Args:
+            intrinsicName (str): The intrinsic name you want to assign to the returned object (used for DA namespace searching).
+            index (int): The index position of the court in the dataframe.
+            ensure_lat_long (bool, optional): Whether to ensure the presence of latitude and longitude data. Defaults to True.
+
+        Returns:
+            ALCourt: An ALCourt object initialized with data from the specified index.
         """
         court = ALCourt(intrinsicName)
         df = self._load_courts()
@@ -294,9 +398,17 @@ class ALCourtLoader(DAObject):
         court.from_row(row, ensure_lat_long=ensure_lat_long)
         return court
 
-    def _load_courts(self):
+    def _load_courts(self) -> pd.DataFrame:
         """
-        Return list of courts
+        Load and return the list of courts from the specified file.
+
+        The method determines the file type (.csv, .xlsx, or .json) based on its extension and reads it accordingly.
+
+        Returns:
+            pd.DataFrame: A dataframe containing the list of courts.
+
+        Raises:
+            Exception: If the file type is neither CSV, XLSX, nor JSON.
         """
         if not hasattr(self, "filename") and hasattr(self, "file_name"):
             self.filename = self.file_name

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -73,7 +73,7 @@ class ALCourt(Court):
         append city name to the court name. This is good for a drop-down selection
         list.
 
-        Returns: 
+        Returns:
             str: string representing the court's name, with city if needed to disambiguate
         """
         # Avoid forcing the interview to define the court's address
@@ -89,7 +89,7 @@ class ALCourt(Court):
         Returns a markdown formatted string with the name and address of the court.
         More concise version without description; suitable for a responsive case.
 
-        Returns: 
+        Returns:
             str: string representing the court's name and address
         """
         return f"**{ self.short_label() }**[BR]{ self.address.on_one_line() }"
@@ -100,7 +100,7 @@ class ALCourt(Court):
         the description of the court, for inclusion in the results page with radio
         buttons.
 
-        Returns: 
+        Returns:
             str: string representing the court's name and description
         """
         all_info = f"**{ self.short_label() }**"
@@ -243,7 +243,7 @@ class ALCourtLoader(DAObject):
         except:
             return set()
 
-    def county_list(self, column_name: str = "address_county")-> Set[str]:
+    def county_list(self, column_name: str = "address_county") -> Set[str]:
         """
         Get a set of all unique names for the specified column in the given spreadsheet.
         Typically used to get a list of all possible counties that have a court.

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -384,7 +384,7 @@ class ALCourtLoader(DAObject):
 
         Args:
             intrinsicName (str): The intrinsic name you want to assign to the returned object (used for DA namespace searching).
-            index (int): The index position of the court in the dataframe.
+            index (Union[int, str]): The index position of the court in the dataframe.
             ensure_lat_long (bool, optional): Whether to ensure the presence of latitude and longitude data. Defaults to True.
 
         Returns:

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -73,7 +73,8 @@ class ALCourt(Court):
         append city name to the court name. This is good for a drop-down selection
         list.
 
-        Returns: str
+        Returns: 
+            str: string representing the court's name, with city if needed to disambiguate
         """
         # Avoid forcing the interview to define the court's address
         if hasattr(self, "address") and hasattr(self.address, "city"):
@@ -88,7 +89,8 @@ class ALCourt(Court):
         Returns a markdown formatted string with the name and address of the court.
         More concise version without description; suitable for a responsive case.
 
-        Returns: str
+        Returns: 
+            str: string representing the court's name and address
         """
         return f"**{ self.short_label() }**[BR]{ self.address.on_one_line() }"
 
@@ -98,7 +100,8 @@ class ALCourt(Court):
         the description of the court, for inclusion in the results page with radio
         buttons.
 
-        Returns: str
+        Returns: 
+            str: string representing the court's name and description
         """
         all_info = f"**{ self.short_label() }**"
         if hasattr(self, "address"):
@@ -174,7 +177,7 @@ class ALCourt(Court):
                 # self.address.geolocate() # Note that Docassemble has misnamed geocoding to "geolocate"
                 # self.location = self.address.location
 
-    def geolocate(self):
+    def geolocate(self) -> None:
         """
         Use Google Maps to geocode the court's address and store the result in the location attribute.
 
@@ -182,7 +185,7 @@ class ALCourt(Court):
         """
         self.geocode()
 
-    def geocode(self):
+    def geocode(self) -> None:
         """
         Use Google Maps to geocode the court's address and store the result in the location attribute.
         """
@@ -240,7 +243,7 @@ class ALCourtLoader(DAObject):
         except:
             return set()
 
-    def county_list(self, column_name: str = "address_county"):
+    def county_list(self, column_name: str = "address_county")-> Set[str]:
         """
         Get a set of all unique names for the specified column in the given spreadsheet.
         Typically used to get a list of all possible counties that have a court.

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -651,7 +651,7 @@ class ALAddendumField(DAObject):
                                   Defaults to a predetermined path.
 
         Returns:
-            IncludeDocxTemplate: A docx template with the inserted table.
+            A docx template with the inserted table.
         """
         return include_docx_template(
             path, columns=self.columns(), rows=self.overflow_value()
@@ -667,7 +667,7 @@ class ALAddendumFieldDict(DAOrderedDict):
     if an overflow condition exists and to correctly display fields in various
     contexts, ensuring only the necessary text is shown.
 
-    Each entry in this dictionary has an associated `field_name` to facilitate identification.
+    Adding a new entry will implicitly set the `field_name` attribute of the field
 
     Attributes:
         style (str): Determines the display behavior. If set to "overflow_only",
@@ -1279,7 +1279,7 @@ class ALStaticDocument(DAStaticFile):
         Get the document as a list.
 
         Returns:
-            List[DAStaticFile]: A list containing the document.
+            List[DAStaticFile]: A list containing this document.
         """
         return [self]
 
@@ -1648,7 +1648,7 @@ class ALDocumentBundle(DAList):
 
         Args:
             key (str): Identifier for the document version, default is "final".
-            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+            refresh (bool): Flag to reconsider the 'enabled' attribute and regenerate the enabled documents, default is True.
             pdfa (bool): Flag to return the documents in PDF/A format, default is False.
 
         Returns:
@@ -2766,9 +2766,9 @@ class ALExhibitDocument(ALDocument):
         Despite the name, renders the document as a PDF. Provided for signature compatibility.
 
         Args:
-            key (str): Identifier key for the document. Default is "final".
-            refresh (bool): If True, refreshes the DOCX document. Default is True.
-            append_matching_suffix (bool): If True, appends a matching suffix to the filename (for automated tests).
+            key (str, optional): Identifier key for the document. Default is "final".
+            refresh (bool, optional): If True, refreshes the DOCX document. Default is True.
+            append_matching_suffix (bool, optional): If True, appends a matching suffix to the filename (for automated tests).
 
         Returns:
             DAFile: The document rendered as a PDF.

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -72,7 +72,7 @@ def label(dictionary: dict) -> str:
     """
     Return the value of the first dictionary item.
 
-    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the value of the first 
+    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the value of the first
     dictionary item. Useful for working with the `columns` method of an ALAddendumField.
 
     Args:
@@ -91,7 +91,7 @@ def key(dictionary: dict) -> str:
     """
     Return the key of the first dictionary item.
 
-    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the key of the first 
+    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the key of the first
     dictionary item. Useful for working with the `columns` method of an ALAddendumField.
 
     Args:
@@ -144,8 +144,6 @@ def html_safe_str(the_string: str) -> str:
     return re.sub(r"[^A-Za-z0-9]+", "_", the_string)
 
 
-
-
 def table_row(title: str, button_htmls: List[str] = []) -> str:
     """
     Generate an HTML row string for an AL document-styled table.
@@ -176,23 +174,24 @@ class ALAddendumField(DAObject):
     """
     Represents a field with attributes determining its display in an addendum, typically for PDF templates.
 
-    The field can manage items that are either strings or list-like structures. Handling of dictionary overflow 
+    The field can manage items that are either strings or list-like structures. Handling of dictionary overflow
     is not currently supported.
 
     Attributes:
         field_name (str): The name of a docassemble variable that this object represents.
-        overflow_trigger (Union[int, bool]): Specifies the limit after which the text is truncated and moved 
-            to an addendum. If set to `True`, it will always overflow. If set to `False`, it will never overflow. 
+        overflow_trigger (Union[int, bool]): Specifies the limit after which the text is truncated and moved
+            to an addendum. If set to `True`, it will always overflow. If set to `False`, it will never overflow.
             An integer value represents the maximum character count before overflow.
-        
-        headers (Optional[Dict[str, str]]): Mapping of attributes to their display labels for a table representation. 
+
+        headers (Optional[Dict[str, str]]): Mapping of attributes to their display labels for a table representation.
             Planned for future implementation.
-        field_style (Optional[str]): Style of the field, can be one of ["list", "table", "string"]. 
+        field_style (Optional[str]): Style of the field, can be one of ["list", "table", "string"].
             Defaults to "string". Planned for future implementation.
 
     Note:
         The attributes `headers` and `field_style` are planned for future releases and are not currently implemented.
     """
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
 
@@ -206,29 +205,29 @@ class ALAddendumField(DAObject):
         """
         Retrieve the overflow portion of a variable which exceeds the content of `safe_value()`.
 
-        This function addresses both list-like objects and strings. It ensures that the returned overflow 
+        This function addresses both list-like objects and strings. It ensures that the returned overflow
         content has been modified to meet whitespace preferences specified by the parameters.
 
         Parameters:
-            preserve_newlines (bool, optional): 
-                If True, the returned string can contain single newline characters. Any sequence of 
-                newline characters (including Windows-style "\r\n") will be reduced to a single "\n". 
-                Double spaces will be replaced with a single space. If False, all kinds of whitespace, 
+            preserve_newlines (bool, optional):
+                If True, the returned string can contain single newline characters. Any sequence of
+                newline characters (including Windows-style "\r\n") will be reduced to a single "\n".
+                Double spaces will be replaced with a single space. If False, all kinds of whitespace,
                 including newlines and tabs, will be replaced with a single space. Defaults to False.
-                
-            input_width (int, optional): 
-                The width of the input field or display area, used for determining overflow. 
+
+            input_width (int, optional):
+                The width of the input field or display area, used for determining overflow.
                 Defaults to 80.
-                
-            overflow_message (str, optional): 
+
+            overflow_message (str, optional):
                 A message to indicate overflow in the safe value. Defaults to an empty string.
-                
+
             preserve_words (bool, optional):
                 If True, ensures that words are not split between the main content and the overflow.
                 Defaults to True.
 
         Returns:
-            str: The portion of the variable that exceeds the content safe to display and should be 
+            str: The portion of the variable that exceeds the content safe to display and should be
             considered as overflow.
         """
         # Handle a Boolean overflow first
@@ -288,7 +287,7 @@ class ALAddendumField(DAObject):
         """
         Retrieve the complete value without considering overflow constraints.
 
-        This can be especially helpful in appendices where there's a desire to showcase the entire value 
+        This can be especially helpful in appendices where there's a desire to showcase the entire value
         without the necessity of toggling between various sections or pages.
 
         Returns:
@@ -474,7 +473,7 @@ class ALAddendumField(DAObject):
     def value_if_defined(self) -> Any:
         """
         Fetch the value of the designated field if it exists; otherwise, return an empty string.
-        
+
         This method ensures that the addendum does not inadvertently trigger docassemble's variable gathering.
 
         Returns:
@@ -498,7 +497,7 @@ class ALAddendumField(DAObject):
         Return a list of the attributes present within the object that would make sense to go
         in the table of an addendum.
 
-        If the `headers` attribute exists, this will be prioritized. Otherwise, the method will infer columns 
+        If the `headers` attribute exists, this will be prioritized. Otherwise, the method will infer columns
         from the first value in the list. Empty attributes and the `complete` attribute are typically ignored.
 
         Returns:
@@ -589,8 +588,8 @@ class ALAddendumField(DAObject):
         """
         Generate a markdown representation of the overflow values.
 
-        The method returns either a markdown table or a bulleted list based on the structure of the values. 
-        This utility offers a standardized way to represent overflow content, though users might prefer 
+        The method returns either a markdown table or a bulleted list based on the structure of the values.
+        This utility offers a standardized way to represent overflow content, though users might prefer
         to manually control the output's format.
 
         Returns:
@@ -643,12 +642,12 @@ class ALAddendumField(DAObject):
         """
         Insert a formatted table into a docx file, representing the overflow values.
 
-        This method provides a convenient way to add overflow content into a docx file, although it 
-        doesn't offer formatting control. If more formatting flexibility is required, consider directly 
+        This method provides a convenient way to add overflow content into a docx file, although it
+        doesn't offer formatting control. If more formatting flexibility is required, consider directly
         fetching the overflow values using the `overflow_value()` method.
 
         Parameters:
-            path (str, optional): Path to the template docx file to be used. 
+            path (str, optional): Path to the template docx file to be used.
                                   Defaults to a predetermined path.
 
         Returns:
@@ -663,9 +662,9 @@ class ALAddendumFieldDict(DAOrderedDict):
     """
     A specialized dictionary for managing fields that may overflow in a document.
 
-    This class assists in organizing and controlling fields that might exceed 
-    a specified character limit in a document. It provides utilities to determine 
-    if an overflow condition exists and to correctly display fields in various 
+    This class assists in organizing and controlling fields that might exceed
+    a specified character limit in a document. It provides utilities to determine
+    if an overflow condition exists and to correctly display fields in various
     contexts, ensuring only the necessary text is shown.
 
     Each entry in this dictionary has an associated `field_name` to facilitate identification.
@@ -688,8 +687,8 @@ class ALAddendumFieldDict(DAOrderedDict):
     def initializeObject(self, *pargs, **kwargs):
         """
         Initializes a new dictionary entry and sets its `field_name` attribute.
-        
-        When an entry is implicitly created, this method ensures the item knows 
+
+        When an entry is implicitly created, this method ensures the item knows
         its own field name by setting the `field_name` attribute.
         """
         the_key = pargs[0]
@@ -701,7 +700,7 @@ class ALAddendumFieldDict(DAOrderedDict):
         Populate the dictionary using a list of field data.
 
         Args:
-            data (list): List of dictionaries containing field data with keys "field_name" 
+            data (list): List of dictionaries containing field data with keys "field_name"
                          and "overflow_trigger".
         """
         for entry in data:
@@ -712,11 +711,11 @@ class ALAddendumFieldDict(DAOrderedDict):
     def defined_fields(self, style="overflow_only") -> list:
         """
         Fetch a list of fields that are defined.
-        
+
         Args:
-            style (str, optional): If set to "overflow_only", only the fields with overflow values 
+            style (str, optional): If set to "overflow_only", only the fields with overflow values
                                    will be returned. Defaults to "overflow_only".
-        
+
         Returns:
             list: List of defined fields based on the specified style.
         """
@@ -750,11 +749,11 @@ class ALAddendumFieldDict(DAOrderedDict):
 class DALazyAttribute(DAObject):
     """
     Extends the `DAObject` to support attributes that are re-evaluated with every page load.
-    
-    This is particularly helpful when there's a need to cache information on a per-page basis. 
-    The implementation leverages Docassemble's object pickling process by customizing the 
+
+    This is particularly helpful when there's a need to cache information on a per-page basis.
+    The implementation leverages Docassemble's object pickling process by customizing the
     `__getstate__` method that Pickle uses for serialization.
-    
+
     Attributes:
         instanceName (str): A unique identifier for the object instance, if available.
     """
@@ -762,9 +761,9 @@ class DALazyAttribute(DAObject):
     def __getstate__(self) -> dict:
         """
         Overrides the default method used by Pickle for object serialization.
-        
-        If the object has an `instanceName` attribute, it is retained during serialization. 
-        Otherwise, an empty dictionary is returned, ensuring that other attributes are not 
+
+        If the object has an `instanceName` attribute, it is retained during serialization.
+        Otherwise, an empty dictionary is returned, ensuring that other attributes are not
         persisted across page loads.
 
         Returns:
@@ -1151,7 +1150,7 @@ class ALDocument(DADict):
     ) -> str:
         """
         Retrieve the "safe" value of a specified field, which is shorter than the overflow trigger.
-        
+
         Args:
             field_name (str): The name of the field to retrieve the safe value from.
             overflow_message (Optional[str]): Message to display when the field value overflows. Defaults to the class's default overflow message.
@@ -1181,7 +1180,7 @@ class ALDocument(DADict):
     ) -> str:
         """
         Retrieve the "overflow" value of a specified field, which is the amount exceeding the overflow trigger.
-        
+
         Args:
             field_name (str): The name of the field to retrieve the overflow value from.
             overflow_message (Optional[str]): Message to display when the field value overflows. Defaults to the object's default overflow message.
@@ -1201,16 +1200,15 @@ class ALDocument(DADict):
             preserve_words=preserve_words,
         )
 
-
     def is_enabled(self, refresh: bool = True) -> bool:
         """
         Determine if a document is considered "enabled" based on various conditions.
-        
+
         A document is "enabled" if:
         1. The .always_enabled attribute is set to true (i.e., enabled at initialization).
         2. The .enabled attribute is set to true (calculated fresh once per page load).
         3. The cache.enabled attribute is set to true.
-        
+
         Args:
             refresh (bool): If True, refreshes the enabled status of the document. Defaults to True.
 
@@ -1233,7 +1231,7 @@ class ALDocument(DADict):
 class ALStaticDocument(DAStaticFile):
     """
     A class for initializing static documents for inclusion in an ALDocumentBundle with a one-liner.
-    
+
     Note:
         Static files should always be placed in the `/data/static` folder of a package. The `/data/templates` folder is private
         and the ALDocumentBundle requires publicly accessible files.
@@ -1270,7 +1268,7 @@ class ALStaticDocument(DAStaticFile):
     def __getitem__(self, key):
         """
         Override to ensure 'final' and 'private' keys always exist and reference the same file.
-        
+
         Returns:
             ALStaticDocument: Returns self.
         """
@@ -1310,7 +1308,6 @@ class ALStaticDocument(DAStaticFile):
             filename = self.filename
         return pdf_concatenate(self, pdfa=pdfa, filename=f"{base_name(filename)}.pdf")
 
-
     def as_docx(
         self,
         key: str = "final",
@@ -1335,7 +1332,6 @@ class ALStaticDocument(DAStaticFile):
             # be difficult to make consistent between DOCX and PDF, and would have
             # negative performance implications. By definition static files have only one version
             return self.as_pdf(key=key, append_matching_suffix=False)
-
 
     def _is_docx(self, key: str = "final") -> bool:
         """
@@ -1385,10 +1381,10 @@ class ALDocumentBundle(DAList):
 
     This class provides functionalities for grouping multiple documents or nested bundles
     in a specific order. For instance, you might want to bundle documents differently for the court,
-    the user, and the opposing party. Each ALDocument within this bundle can be individually "enabled" 
+    the user, and the opposing party. Each ALDocument within this bundle can be individually "enabled"
     or "disabled", which will determine its inclusion in the generated bundle.
 
-    A bundle can be output as a single merged PDF or as a list of individual documents. For nested 
+    A bundle can be output as a single merged PDF or as a list of individual documents. For nested
     bundles, each can be rendered as a merged PDF or a list of documents.
 
     Attributes:
@@ -1399,10 +1395,10 @@ class ALDocumentBundle(DAList):
         gathered (bool, optional): Specifies if attributes have been gathered. Defaults to True.
 
     Examples:
-        Given three documents: `Cover page`, `Main motion form`, and `Notice of Interpreter Request`, 
+        Given three documents: `Cover page`, `Main motion form`, and `Notice of Interpreter Request`,
         bundle them as follows:
         ```
-        bundle = ALDocumentBundle(elements=[cover_page, main_motion, notice_of_request], 
+        bundle = ALDocumentBundle(elements=[cover_page, main_motion, notice_of_request],
                                   filename="documents_bundle", title="Document Set")
         ```
 
@@ -1625,7 +1621,6 @@ class ALDocumentBundle(DAList):
                 flat_list.extend(document.as_list(key=key, refresh=refresh))
         return flat_list
 
-
     def get_titles(self, key: str = "final", refresh: bool = True) -> List[str]:
         """
         Retrieves the titles of all enabled documents in the bundle.
@@ -1682,7 +1677,9 @@ class ALDocumentBundle(DAList):
             for doc in self.enabled_documents(refresh=refresh)
         ]
 
-    def as_editable_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
+    def as_editable_list(
+        self, key: str = "final", refresh: bool = True
+    ) -> List[DAFile]:
         """
         Generates a list of editable (DOCX or RTF) versions of the documents in the bundle.
 
@@ -1867,7 +1864,9 @@ class ALDocumentBundle(DAList):
 
         Deprecated; use download_list_html instead
         """
-        log("ALDocumentBundle.download_html is deprecated; use download_list_html instead")
+        log(
+            "ALDocumentBundle.download_html is deprecated; use download_list_html instead"
+        )
         if format == "docx":
             the_file = self.as_docx(key=key)
         else:
@@ -1913,7 +1912,7 @@ class ALDocumentBundle(DAList):
 
         Args:
             key (str): A key used to identify which version of the ALDocument to send. Defaults to "final".
-        
+
         Returns:
             str: The generated HTML string for the table row.
         """
@@ -2138,7 +2137,7 @@ class ALDocumentBundle(DAList):
 
         Args:
             refresh (bool): Whether to refresh the enabled status. Defaults to True.
-        
+
         Returns:
             bool: Indicates if the document is enabled.
         """
@@ -2160,7 +2159,7 @@ class ALDocumentBundle(DAList):
 
         Args:
             refresh (bool): Whether to refresh the enabled status. Defaults to True.
-        
+
         Returns:
             bool: Indicates if the bundle and its child documents are enabled.
         """
@@ -2237,7 +2236,7 @@ class ALDocumentBundle(DAList):
 class ALExhibit(DAObject):
     """
     Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
-    
+
     Attributes:
         pages (list): List of individual DAFiles representing uploaded images or documents.
         cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block
@@ -2287,7 +2286,7 @@ class ALExhibit(DAObject):
         That situation is likely a developer error, as you shouldn't wait for OCR if it never started
 
         Returns:
-            bool: True iff OCR process has finished on all pages.            
+            bool: True iff OCR process has finished on all pages.
         """
         if hasattr(self, "ocr_status") and not self.ocr_status.ready():
             return False
@@ -2298,7 +2297,7 @@ class ALExhibit(DAObject):
     def ocr_pages(self):
         """
         Retrieve the OCR-processed version of pages if available, else return the original pages.
-        
+
         Returns:
             List[DAFile]: List of pages, either OCR-processed or original.
         """
@@ -2316,53 +2315,6 @@ class ALExhibit(DAObject):
             pages.append(page)
         return pages
 
-Here's an improved version of the docstring for the class and its methods:
-
-python
-
-class ALExhibit(DAObject):
-    """
-    Represents an exhibit with an optional cover page and multiple documents (pages).
-
-    Attributes:
-        pages (List[DAFile]): Individual documents or images uploaded for this exhibit.
-        cover_page (Union[DAFile, DAFileCollection]): Optional cover page for the exhibit, typically indicating its label.
-        label (str): Identifier for this exhibit, such as "A" or "1".
-        starting_page (int): The starting page number for table of contents or pagination purposes.
-    """
-
-    def init(self, *pargs, **kwargs):
-        """
-        Initialize the ALExhibit object with default attributes and inheritance from DAObject.
-        """
-        ...
-
-    def _start_ocr(self):
-        """
-        Initiates OCR (Optical Character Recognition) on the exhibit's pages, adding a text layer for any images of text.
-        
-        Launches background actions for OCR processing on each page.
-        """
-        ...
-
-    def ocr_ready(self) -> bool:
-        """
-        Checks if the OCR process is complete for all pages.
-
-        Returns:
-            bool: True if the OCR process has finished; False otherwise.
-        """
-        ...
-
-    def ocr_pages(self):
-        """
-        Retrieve the OCR-processed version of pages if available, else return the original pages.
-        
-        Returns:
-            List[DAFile]: List of pages, either OCR-processed or original.
-        """
-        ...
-
     def as_pdf(
         self,
         *,
@@ -2376,7 +2328,7 @@ class ALExhibit(DAObject):
     ) -> DAFile:
         """
         Generates a PDF version of the exhibit, with optional features like Bates numbering or a cover page.
-        
+
         Args:
             prefix (str): Prefix for Bates numbering if 'add_page_numbers' is True.
             add_page_numbers (bool): If True, apply Bates numbering starting from 'self.start_page'.
@@ -2425,14 +2377,13 @@ class ALExhibit(DAObject):
         """
         For purposes of list gathering, trigger the attributes in order that are necessary
         to gather a complete exhibit object.
-        
+
         Returns:
             bool: True if exhibit is complete.
         """
         self.title
         self.pages.gather()
         return True
-
 
     def __str__(self) -> str:
         """
@@ -2450,7 +2401,7 @@ def ocrmypdf_task(
     """
     Processes the provided files using the 'ocrmypdf' utility to apply Optical Character Recognition (OCR).
 
-    If the source file is an image (e.g., png, jpg, jpeg, gif), this function sets the image DPI to 300. 
+    If the source file is an image (e.g., png, jpg, jpeg, gif), this function sets the image DPI to 300.
     For non-image files, the text in the file is skipped during OCR.
 
     This function is designed to be executed as a background task (id: al_exhibit_ocr_pages_bg).
@@ -2499,7 +2450,7 @@ class ALExhibitList(DAList):
     """
     A list representation of ALExhibit objects. Provides utility functions for managing exhibits
     and rendering them into a single PDF file.
-    
+
     Attributes:
         maximum_size (int): The maximum allowed size in bytes of the entire document.
         auto_label (bool): If True, automatically numbers exhibits for cover page and table of contents. Defaults to True.
@@ -2584,7 +2535,7 @@ class ALExhibitList(DAList):
         Updates labels of all exhibits in the list based on their index.
 
         Args:
-            auto_labeler (Callable): An optional function or lambda to customize label generation. 
+            auto_labeler (Callable): An optional function or lambda to customize label generation.
                                      Uses the class's auto_labeler by default.
         """
         if auto_labeler is None:
@@ -2630,10 +2581,9 @@ class ALExhibitList(DAList):
         for exhibit in self.elements:
             exhibit._start_ocr()
 
-
     def hook_after_gather(self) -> None:
         """
-        Callback function executed after the entire list of exhibits is collected. 
+        Callback function executed after the entire list of exhibits is collected.
         Manages auto-labeling and initiates OCR if necessary.
         """
         if len(self):
@@ -2646,14 +2596,14 @@ class ALExhibitList(DAList):
 
 class ALExhibitDocument(ALDocument):
     """
-    Represents a collection of uploaded documents, formatted like a record appendix 
+    Represents a collection of uploaded documents, formatted like a record appendix
     or an exhibit list, complete with an optional table of contents and page numbering.
 
     Attributes:
-        exhibits (ALExhibitList): A list of ALExhibit documents. Each item represents 
+        exhibits (ALExhibitList): A list of ALExhibit documents. Each item represents
                                   a distinct exhibit, which can span multiple pages.
         table_of_contents (DAFile or DAFileCollection): Generated by an `attachment:` block.
-        _cache (DAFile): A cached version of the exhibit list. Caching is used due to 
+        _cache (DAFile): A cached version of the exhibit list. Caching is used due to
                          potential long processing times.
         include_table_of_contents (bool): Indicates if a table of contents should be generated.
         include_exhibit_cover_pages (bool): Determines if cover pages should accompany each exhibit.
@@ -2661,7 +2611,7 @@ class ALExhibitDocument(ALDocument):
         auto_labeler (Callable): A function or lambda for labeling exhibits.
 
     Todo:
-        * Implement a method for a safe link in place of the attachment 
+        * Implement a method for a safe link in place of the attachment
           (considering potential filesize constraints on emails).
 
     Examples:
@@ -2765,15 +2715,15 @@ class ALExhibitDocument(ALDocument):
         key: str = "final",
         refresh: bool = True,
         pdfa: bool = False,
-        append_matching_suffix: bool = True
+        append_matching_suffix: bool = True,
     ) -> DAFile:
         """
         Render the document as a PDF.
 
         Args:
-            key (str): Identifier key for the document. Default is "final". 
+            key (str): Identifier key for the document. Default is "final".
                        For compatibility with ALDocument.
-            refresh (bool): If True, refreshes the PDF document. Default is True. 
+            refresh (bool): If True, refreshes the PDF document. Default is True.
                             For compatibility with ALDocument.
             pdfa (bool): If True, the output PDF will be in PDF/A format. Default is False.
             append_matching_suffix (bool): If True, appends a matching suffix to the filename.
@@ -2810,7 +2760,7 @@ class ALExhibitDocument(ALDocument):
         self,
         key: str = "final",
         refresh: bool = True,
-        append_matching_suffix: bool = True
+        append_matching_suffix: bool = True,
     ) -> DAFile:
         """
         Despite the name, renders the document as a PDF. Provided for signature compatibility.
@@ -2828,7 +2778,7 @@ class ALExhibitDocument(ALDocument):
 
 class ALTableDocument(ALDocument):
     """
-    Represents a document tailored for table-like data presentation. 
+    Represents a document tailored for table-like data presentation.
     This class provides functionality to export data as a table in various formats such as PDF and DOCX.
 
     Attributes:
@@ -2837,6 +2787,7 @@ class ALTableDocument(ALDocument):
         file (DAFile, optional): Reference to the generated file (can be PDF, DOCX, etc.).
         table (???): Represents the actual table data. Type and attributes need more context to document.
     """
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -2869,7 +2820,9 @@ class ALTableDocument(ALDocument):
         """
         return self.as_pdf()
 
-    def as_list(self, key: str = "final", refresh: bool = True, **kwargs) -> List[DAFile]:
+    def as_list(
+        self, key: str = "final", refresh: bool = True, **kwargs
+    ) -> List[DAFile]:
         """
         Retrieve the document as a list.
 
@@ -2938,13 +2891,14 @@ class ALTableDocument(ALDocument):
 class ALUntransformedDocument(ALDocument):
     """
     Represents an untransformed document. The class provides methods to access the document
-    without making any modifications to it. The provided methods are mainly for duck-typing 
+    without making any modifications to it. The provided methods are mainly for duck-typing
     compatibility with ALDocument.
 
     Attributes:
         has_addendum (bool): A flag indicating the presence of an addendum in the document.
         suffix_to_append (str): Suffix that can be appended to file names, defaulting to "preview".
     """
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -2962,7 +2916,9 @@ class ALUntransformedDocument(ALDocument):
         """
         return False
 
-    def as_list(self, key: str = "final", refresh: bool = True, **kwargs) -> List[DAFile]:
+    def as_list(
+        self, key: str = "final", refresh: bool = True, **kwargs
+    ) -> List[DAFile]:
         """
         Retrieve the document as a list.
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -56,12 +56,30 @@ DEBUG_MODE = get_config("debug")
 
 
 def base_name(filename: str) -> str:
+    """
+    Extracts the base name of a file without its extension.
+
+    Args:
+        filename (str): The full name of the file.
+
+    Returns:
+        str: The base name of the file without its extension.
+    """
     return os.path.splitext(filename)[0]
 
 
-def label(dictionary):
-    """Given a dictionary like: {"some_attribute":"Some label"}, return the `value` of the first dictionary item.
-    Useful for working with the `columns` method of an ALAddendumField.
+def label(dictionary: dict) -> str:
+    """
+    Return the value of the first dictionary item.
+
+    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the value of the first 
+    dictionary item. Useful for working with the `columns` method of an ALAddendumField.
+
+    Args:
+        dictionary (dict): The dictionary to extract the value from.
+
+    Returns:
+        str: The value of the first dictionary item or an empty string if not found.
     """
     try:
         return next(iter(dictionary.values()), "")
@@ -69,9 +87,18 @@ def label(dictionary):
         return ""
 
 
-def key(dictionary):
-    """Given a dictionary like: {"some_attribute":"Some label"}, return the `key` of the first dictionary item.
-    Useful for working with the `columns` method of an ALAddendumField.
+def key(dictionary: dict) -> str:
+    """
+    Return the key of the first dictionary item.
+
+    Given a dictionary like: {"some_attribute":"Some label"}, this function returns the key of the first 
+    dictionary item. Useful for working with the `columns` method of an ALAddendumField.
+
+    Args:
+        dictionary (dict): The dictionary to extract the key from.
+
+    Returns:
+        str: The key of the first dictionary item or an empty string if not found.
     """
     try:
         return next(iter(dictionary.keys()), "")
@@ -79,7 +106,17 @@ def key(dictionary):
         return ""
 
 
-def safeattr(object, key):
+def safeattr(object: Any, key: str) -> str:
+    """
+    Safely retrieve an attribute or key value from an object.
+
+    Args:
+        object (Any): The object (which could be a dict, DADict, or DAObject) from which to retrieve the value.
+        key (str): The key or attribute name.
+
+    Returns:
+        str: The retrieved value or an empty string if not found or if an error occurred.
+    """
     try:
         if isinstance(object, dict) or isinstance(object, DADict):
             return str(object.get(key, ""))
@@ -96,15 +133,29 @@ def safeattr(object, key):
 
 def html_safe_str(the_string: str) -> str:
     """
-    Return a string that can be used as an html class or id
+    Convert a string into a format that's safe for use as an HTML class or ID.
+
+    Args:
+        the_string (str): The string to be converted.
+
+    Returns:
+        str: A string that's safe for use as an HTML class or ID.
     """
     return re.sub(r"[^A-Za-z0-9]+", "_", the_string)
 
 
+
+
 def table_row(title: str, button_htmls: List[str] = []) -> str:
     """
-    Uses the provided title and list of button html strings to
-    return the row of an AL document-styled table in HTML format.
+    Generate an HTML row string for an AL document-styled table.
+
+    Args:
+        title (str): The title to display in the row.
+        button_htmls (List[str], optional): A list of HTML strings representing buttons. Defaults to an empty list.
+
+    Returns:
+        str: An HTML string representing a row in an AL document-styled table.
     """
     html = (
         f'\n\t<div class="row al_doc_table_row">'
@@ -123,21 +174,25 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
 
 class ALAddendumField(DAObject):
     """
-    Object representing a single field and its attributes as related to whether
-    it should be displayed in an addendum. Useful for PDF templates.
+    Represents a field with attributes determining its display in an addendum, typically for PDF templates.
 
-    The items can be strings or lists/list-like objects. It does not know
-    how to handle overflow for a dictionary, e.g.
+    The field can manage items that are either strings or list-like structures. Handling of dictionary overflow 
+    is not currently supported.
 
-    Required attributes:
-      - field_name (str): represents the name of a docassemble variable
-      - overflow_trigger (int | bool): determines when text is cut off and sent to addendum
+    Attributes:
+        field_name (str): The name of a docassemble variable that this object represents.
+        overflow_trigger (Union[int, bool]): Specifies the limit after which the text is truncated and moved 
+            to an addendum. If set to `True`, it will always overflow. If set to `False`, it will never overflow. 
+            An integer value represents the maximum character count before overflow.
+        
+        headers (Optional[Dict[str, str]]): Mapping of attributes to their display labels for a table representation. 
+            Planned for future implementation.
+        field_style (Optional[str]): Style of the field, can be one of ["list", "table", "string"]. 
+            Defaults to "string". Planned for future implementation.
 
-    Optional/planned (not implemented yet):
-      - headers->dict(attribute: display label for table)
-      - field_style->"list"|"table"|"string" (optional: defaults to "string")
+    Note:
+        The attributes `headers` and `field_style` are planned for future releases and are not currently implemented.
     """
-
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
 
@@ -149,15 +204,32 @@ class ALAddendumField(DAObject):
         preserve_words: bool = True,
     ):
         """
-        Try to return just the portion of the variable (list-like object or string)
-        that is not contained in the safe_value().
+        Retrieve the overflow portion of a variable which exceeds the content of `safe_value()`.
 
-        Whitespace will be altered. If preserve_newlines is true, the return value may have newlines,
-        but double newlines and Windows style (\r\n) will be replaced with \n. Double spaces will replaced
-        with a single space.
+        This function addresses both list-like objects and strings. It ensures that the returned overflow 
+        content has been modified to meet whitespace preferences specified by the parameters.
 
-        If preserve_newlines is false, all whitespace, including newlines and tabs, will be replaced
-        with a single space.
+        Parameters:
+            preserve_newlines (bool, optional): 
+                If True, the returned string can contain single newline characters. Any sequence of 
+                newline characters (including Windows-style "\r\n") will be reduced to a single "\n". 
+                Double spaces will be replaced with a single space. If False, all kinds of whitespace, 
+                including newlines and tabs, will be replaced with a single space. Defaults to False.
+                
+            input_width (int, optional): 
+                The width of the input field or display area, used for determining overflow. 
+                Defaults to 80.
+                
+            overflow_message (str, optional): 
+                A message to indicate overflow in the safe value. Defaults to an empty string.
+                
+            preserve_words (bool, optional):
+                If True, ensures that words are not split between the main content and the overflow.
+                Defaults to True.
+
+        Returns:
+            str: The portion of the variable that exceeds the content safe to display and should be 
+            considered as overflow.
         """
         # Handle a Boolean overflow first
         if isinstance(self.overflow_trigger, bool) and self.overflow_trigger:
@@ -202,15 +274,25 @@ class ALAddendumField(DAObject):
 
     def max_lines(self, input_width: int = 80) -> int:
         """
-        Calculate the number of lines of text that will fit in the specified input
+        Compute the maximum number of lines that can fit in the input given the specified input width.
+
+        Parameters:
+            input_width (int, optional): The width of the input or display area. Defaults to 80.
+
+        Returns:
+            int: The maximum number of lines accommodated by the input width.
         """
         return floor(self.overflow_trigger / input_width)
 
     def value(self) -> Any:
         """
-        Return the full value, disregarding overflow. Could be useful in addendum
-        if you want to show the whole value without making user flip back/forth between multiple
-        pages.
+        Retrieve the complete value without considering overflow constraints.
+
+        This can be especially helpful in appendices where there's a desire to showcase the entire value 
+        without the necessity of toggling between various sections or pages.
+
+        Returns:
+            Any: The whole value of the field, irrespective of overflow.
         """
         return self.value_if_defined()
 
@@ -391,21 +473,36 @@ class ALAddendumField(DAObject):
 
     def value_if_defined(self) -> Any:
         """
-        Return the value of the field if it is defined, otherwise return an empty string.
-        Addendum should never trigger docassemble's variable gathering.
+        Fetch the value of the designated field if it exists; otherwise, return an empty string.
+        
+        This method ensures that the addendum does not inadvertently trigger docassemble's variable gathering.
+
+        Returns:
+            Any: The value of the field if it exists, otherwise an empty string.
         """
         return showifdef(self.field_name, "")
 
     def __str__(self):
+        """
+        Represent the ALAddendumField instance as a string.
+
+        Returns:
+            str: The string representation of the value contained within the field.
+        """
         return str(self.value_if_defined())
 
     def columns(
         self, skip_empty_attributes: bool = True, skip_attributes: set = {"complete"}
     ) -> Optional[list]:
         """
-        Return a list of the columns in this object.
+        Return a list of the attributes present within the object that would make sense to go
+        in the table of an addendum.
 
-        By default, skip empty attributes and the `complete` attribute.
+        If the `headers` attribute exists, this will be prioritized. Otherwise, the method will infer columns 
+        from the first value in the list. Empty attributes and the `complete` attribute are typically ignored.
+
+        Returns:
+            Optional[list]: A list of columns or None if no meaningful columns can be determined.
         """
         if hasattr(self, "headers"):
             return self.headers
@@ -449,7 +546,15 @@ class ALAddendumField(DAObject):
 
     def type(self) -> str:
         """
-        list | object_list | other
+        Determine the data type of the contained value.
+
+        Categories:
+        - 'list': A simple list.
+        - 'object_list': A list containing dictionaries or objects.
+        - 'other': Any other type.
+
+        Returns:
+            str: The type category of the value.
         """
         value = self.value_if_defined()
         if isinstance(value, list) or isinstance(value, DAList):
@@ -464,23 +569,32 @@ class ALAddendumField(DAObject):
 
     def is_list(self) -> bool:
         """
-        Identify whether the field is a list, whether of objects/dictionaries or just plain variables.
+        Check if the field contains a list value, whether it consists of objects, dictionaries, or standard values.
+
+        Returns:
+            bool: True if the field contains a list, otherwise False.
         """
         return self.type() == "object_list" or self.type() == "list"
 
     def is_object_list(self) -> bool:
         """
-        Identify whether the field represents a list of either dictionaries or objects.
+        Determine if the field contains a list of dictionaries or objects.
+
+        Returns:
+            bool: True if the field contains a list of dictionaries or objects, otherwise False.
         """
         return self.type() == "object_list"
 
     def overflow_markdown(self) -> str:
         """
-        Return a formatted markdown table or bulleted list representing the values in the list.
+        Generate a markdown representation of the overflow values.
 
-        This method does not give you any control over the output other than labels of columns,
-        but you also do not need to use this output if you want to independently control the format
-        of the table.
+        The method returns either a markdown table or a bulleted list based on the structure of the values. 
+        This utility offers a standardized way to represent overflow content, though users might prefer 
+        to manually control the output's format.
+
+        Returns:
+            str: A markdown representation of the overflow values.
         """
         columns = self.columns()
         if not columns:
@@ -527,11 +641,18 @@ class ALAddendumField(DAObject):
         path: str = "docassemble.ALDocumentDict:data/templates/addendum_table.docx",
     ):
         """
-        Light wrapper around insert_docx_template() that inserts a formatted table into a docx
-        file. If the object in the list is a plain string/int, it returns a bulleted list.
+        Insert a formatted table into a docx file, representing the overflow values.
 
-        Using this method will not give you any control at all over the formatting, but you can directly
-        call field.overflow_value() instead of using this method.
+        This method provides a convenient way to add overflow content into a docx file, although it 
+        doesn't offer formatting control. If more formatting flexibility is required, consider directly 
+        fetching the overflow values using the `overflow_value()` method.
+
+        Parameters:
+            path (str, optional): Path to the template docx file to be used. 
+                                  Defaults to a predetermined path.
+
+        Returns:
+            IncludeDocxTemplate: A docx template with the inserted table.
         """
         return include_docx_template(
             path, columns=self.columns(), rows=self.overflow_value()
@@ -540,17 +661,18 @@ class ALAddendumField(DAObject):
 
 class ALAddendumFieldDict(DAOrderedDict):
     """
-    Object representing a list of fields in your output document, together
-    with the character limit for each field.
+    A specialized dictionary for managing fields that may overflow in a document.
 
-    Provides convenient methods to determine if an addendum is needed and to
-    control the display of fields so the appropriate text (overflow or safe amount)
-    is displayed in each context.
+    This class assists in organizing and controlling fields that might exceed 
+    a specified character limit in a document. It provides utilities to determine 
+    if an overflow condition exists and to correctly display fields in various 
+    contexts, ensuring only the necessary text is shown.
 
-    Adding a new entry will implicitly set the `field_name` attribute of the field.
+    Each entry in this dictionary has an associated `field_name` to facilitate identification.
 
-    optional:
-      - style: if set to "overflow_only" will only display the overflow text
+    Attributes:
+        style (str): Determines the display behavior. If set to "overflow_only",
+                     only the overflow text will be displayed.
     """
 
     def init(self, *pargs, **kwargs):
@@ -565,57 +687,89 @@ class ALAddendumFieldDict(DAOrderedDict):
 
     def initializeObject(self, *pargs, **kwargs):
         """
-        When we create a new entry implicitly, make sure we also set the .field_name
-        attribute to the key name so it knows its own field_name.
+        Initializes a new dictionary entry and sets its `field_name` attribute.
+        
+        When an entry is implicitly created, this method ensures the item knows 
+        its own field name by setting the `field_name` attribute.
         """
         the_key = pargs[0]
         super().initializeObject(*pargs, **kwargs)
         self[the_key].field_name = the_key
 
     def from_list(self, data):
+        """
+        Populate the dictionary using a list of field data.
+
+        Args:
+            data (list): List of dictionaries containing field data with keys "field_name" 
+                         and "overflow_trigger".
+        """
         for entry in data:
             new_field = self.initializeObject(entry["field_name"], ALAddendumField)
             new_field.field_name = entry["field_name"]
             new_field.overflow_trigger = entry["overflow_trigger"]
 
-    def defined_fields(self, style="overflow_only"):
+    def defined_fields(self, style="overflow_only") -> list:
         """
-        Return a filtered list of just the defined fields.
-        If the "style" is set to overflow_only, only return the overflow values.
+        Fetch a list of fields that are defined.
+        
+        Args:
+            style (str, optional): If set to "overflow_only", only the fields with overflow values 
+                                   will be returned. Defaults to "overflow_only".
+        
+        Returns:
+            list: List of defined fields based on the specified style.
         """
         if style == "overflow_only":
             return [field for field in self.values() if len(field.overflow_value())]
         else:
             return [field for field in self.values() if defined(field.field_name)]
 
-    def overflow(self):
+    def overflow(self) -> list:
+        """
+        Retrieve fields that have overflowed their character limits.
+
+        Returns:
+            list: A list of fields with overflow values.
+        """
         return self.defined_fields(style="overflow_only")
 
     def has_overflow(self) -> bool:
-        """Returns True if any defined field's length exceeds the overflow trigger.
+        """
+        Determine if any field within the dictionary exceeds its overflow limit.
+
         Returns:
-          bool: True if at least 1 field has "overflow" content, False otherwise.
+            bool: True if at least one field overflows, False otherwise.
         """
         for field in self.values():
             if field.overflow_value():
                 return True
         return False
 
-    # def defined_sections(self):
-    #  if self.style == 'overflow_only':
-    #    return [section for section in self.elements if len(section.defined_fields(style=self.style))]
-
 
 class DALazyAttribute(DAObject):
     """
-    A DAObject with attributes that are reconsidered on every page load. Useful for
-    caching information on a per-page load basis.
-
-    Takes advantage of the way that objects are pickled in Docassemble by overriding the
-    __getstate__ method Pickle uses.
+    Extends the `DAObject` to support attributes that are re-evaluated with every page load.
+    
+    This is particularly helpful when there's a need to cache information on a per-page basis. 
+    The implementation leverages Docassemble's object pickling process by customizing the 
+    `__getstate__` method that Pickle uses for serialization.
+    
+    Attributes:
+        instanceName (str): A unique identifier for the object instance, if available.
     """
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
+        """
+        Overrides the default method used by Pickle for object serialization.
+        
+        If the object has an `instanceName` attribute, it is retained during serialization. 
+        Otherwise, an empty dictionary is returned, ensuring that other attributes are not 
+        persisted across page loads.
+
+        Returns:
+            dict: A dictionary containing only the `instanceName` if it exists, or empty otherwise.
+        """
         if hasattr(self, "instanceName"):
             return dict(instanceName=self.instanceName)
         else:
@@ -769,6 +923,18 @@ class ALDocument(DADict):
         pdfa: bool = False,
         append_matching_suffix: bool = True,
     ) -> DAFile:
+        """
+        Generates a PDF version of the assembled document.
+
+        Args:
+            key (str): Document version key. Defaults to "final".
+            refresh (bool): If True, generates the attachment anew each time. Defaults to True.
+            pdfa (bool): If True, generates a PDF/A compliant document. Defaults to False.
+            append_matching_suffix (bool): If True, appends the key as a suffix to the filename when it matches the suffix to append. Defaults to True.
+
+        Returns:
+            DAFile: Assembled document in PDF format, possibly combined with addendum.
+        """
         # Trigger some stuff up front to avoid idempotency problems
         self.title
         self.need_addendum()
@@ -832,7 +998,15 @@ class ALDocument(DADict):
         append_matching_suffix: bool = True,
     ) -> DAFile:
         """
-        Returns the assembled document as a single DOCX file, if possible. Otherwise returns a PDF.
+        Generates a DOCX version of the assembled document, if possible. Falls back to PDF if not.
+
+        Args:
+            key (str): Document version key. Defaults to "final".
+            refresh (bool): If True, generates the attachment anew each time. Defaults to True.
+            append_matching_suffix (bool): If True, appends the key as a suffix to the filename when it matches the suffix to append. Defaults to True.
+
+        Returns:
+            DAFile: Assembled document in DOCX or PDF format.
         """
         if append_matching_suffix and key == self.suffix_to_append:
             filename = f"{base_name(self.filename)}_{key}"
@@ -857,8 +1031,16 @@ class ALDocument(DADict):
 
         return self.as_pdf(key=key, append_matching_suffix=append_matching_suffix)
 
-    def _is_docx(self, key: str = "final"):
-        """Returns True iff the file is a DOCX."""
+    def _is_docx(self, key: str = "final") -> bool:
+        """
+        Checks if the document file format is DOCX.
+
+        Args:
+            key (str): Document version key. Defaults to "final".
+
+        Returns:
+            bool: True if the document format is DOCX, False otherwise.
+        """
         if isinstance(self[key], DAFileCollection) and hasattr(self[key], "docx"):
             return True
         if isinstance(self[key], DAFile) and hasattr(self[key], "docx"):
@@ -868,9 +1050,14 @@ class ALDocument(DADict):
 
     def as_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
         """
-        Returns a list of the document and its addendum, if any.
-        Specify refresh=True if you want to generate the attachment new each time.
-        This behavior is the default.
+        Generates a list containing the main document and its addendum, if applicable.
+
+        Args:
+            key (str): Document version key. Defaults to "final".
+            refresh (bool): If True, generates the attachments anew each time. Defaults to True.
+
+        Returns:
+            List[DAFile]: List containing the main document and possibly its addendum.
         """
         if refresh:
             if self.has_addendum and self.has_overflow():
@@ -884,14 +1071,33 @@ class ALDocument(DADict):
                 return [self[key]]
 
     def need_addendum(self) -> bool:
+        """
+        Determines if there's a need for an addendum in the document.
+        First checks if the addendum is enabled, and then checks if there's overflow.
+
+        Returns:
+            bool: True if an addendum is needed, False otherwise.
+        """
         return (
             hasattr(self, "has_addendum") and self.has_addendum and self.has_overflow()
         )
 
     def has_overflow(self) -> bool:
+        """
+        Checks if the document has fields that exceed their character limits.
+
+        Returns:
+            bool: True if there are overflow fields, False otherwise.
+        """
         return self.overflow_fields.has_overflow()
 
     def overflow(self):
+        """
+        Retrieves a list of fields that have overflowed their character limits.
+
+        Returns:
+            list: List of overflow fields.
+        """
         return self.overflow_fields.overflow()
 
     def original_or_overflow_message(
@@ -942,10 +1148,19 @@ class ALDocument(DADict):
         preserve_newlines: bool = False,
         input_width: int = 80,
         preserve_words: bool = True,
-    ):
+    ) -> str:
         """
-        Shortcut syntax for accessing the "safe" (shorter than overflow trigger)
-        value of a field that we have specified as needing an addendum.
+        Retrieve the "safe" value of a specified field, which is shorter than the overflow trigger.
+        
+        Args:
+            field_name (str): The name of the field to retrieve the safe value from.
+            overflow_message (Optional[str]): Message to display when the field value overflows. Defaults to the class's default overflow message.
+            preserve_newlines (bool): Whether to maintain newlines in the output. Defaults to False.
+            input_width (int): The expected input width, used for formatting. Defaults to 80.
+            preserve_words (bool): Whether to avoid splitting words during formatting. Defaults to True.
+
+        Returns:
+            str: The "safe" value of the specified field.
         """
         if overflow_message is None:
             overflow_message = self.default_overflow_message
@@ -963,12 +1178,19 @@ class ALDocument(DADict):
         preserve_newlines: bool = False,
         input_width: int = 80,
         preserve_words: bool = True,
-    ):
+    ) -> str:
         """
-        Shortcut syntax for accessing the "overflow" value (amount that exceeds overflow trigger)
-        for the given field as a string.
+        Retrieve the "overflow" value of a specified field, which is the amount exceeding the overflow trigger.
+        
+        Args:
+            field_name (str): The name of the field to retrieve the overflow value from.
+            overflow_message (Optional[str]): Message to display when the field value overflows. Defaults to the object's default overflow message.
+            preserve_newlines (bool): Whether to maintain newlines in the output. Defaults to False.
+            input_width (int): The expected input width, used for formatting. Defaults to 80.
+            preserve_words (bool): Whether to avoid splitting words during formatting. Defaults to True.
 
-        Should mirror the "safe_value" for the same field.
+        Returns:
+            str: The "overflow" value of the specified field.
         """
         if overflow_message is None:
             overflow_message = self.default_overflow_message
@@ -979,12 +1201,21 @@ class ALDocument(DADict):
             preserve_words=preserve_words,
         )
 
-    def is_enabled(self, refresh=True):
+
+    def is_enabled(self, refresh: bool = True) -> bool:
         """
-        A document can be considered "enabled" if:
-        - the .always_enabled attribute is true (enabled at init)
-        - the .enabled attribute is true (calculated fresh once per page load)
-        - the cache.enabled attribute is true
+        Determine if a document is considered "enabled" based on various conditions.
+        
+        A document is "enabled" if:
+        1. The .always_enabled attribute is set to true (i.e., enabled at initialization).
+        2. The .enabled attribute is set to true (calculated fresh once per page load).
+        3. The cache.enabled attribute is set to true.
+        
+        Args:
+            refresh (bool): If True, refreshes the enabled status of the document. Defaults to True.
+
+        Returns:
+            bool: True if the document is enabled, otherwise False.
         """
         if hasattr(self, "always_enabled") and self.always_enabled:
             return True
@@ -1000,16 +1231,17 @@ class ALDocument(DADict):
 
 
 class ALStaticDocument(DAStaticFile):
-    """A class that allows one-line initialization of static documents to include in an ALDocumentBundle.
-
+    """
+    A class for initializing static documents for inclusion in an ALDocumentBundle with a one-liner.
+    
     Note:
-        You should always place the static file within the /data/static folder of a package.
-        ALDocumentBundle relies on a publically accessible file. The /data/templates folder is private.
+        Static files should always be placed in the `/data/static` folder of a package. The `/data/templates` folder is private
+        and the ALDocumentBundle requires publicly accessible files.
 
     Attributes:
-        filename(str): the path to the file within /data/static/.
-        title(str): The title that will display as a row when invoked with `download_list_html()` method
-                    of an ALDocumentBundle.
+        filename (str): Path to the file within `/data/static/`.
+        title (str): Title displayed as a row when invoking `download_list_html()` method from ALDocumentBundle.
+
     Examples:
         Add a static PDF file to a document bundle.
         .. code-block:: yaml
@@ -1021,8 +1253,7 @@ class ALStaticDocument(DAStaticFile):
             - bundle: ALDocumentBundle.using(elements=[static_test], filename="bundle", title="Documents to download now")
 
     Todo:
-        Handle files placed in /data/templates if that turns out to be useful. Likely by copying into
-        a DAFile with pdf_concatenate().
+        Consider handling files in `/data/templates` if deemed useful, potentially by copying into a DAFile using `pdf_concatenate()`.
     """
 
     def init(self, *pargs, **kwargs):
@@ -1037,11 +1268,21 @@ class ALStaticDocument(DAStaticFile):
             self.suffix_to_append = "preview"
 
     def __getitem__(self, key):
-        # This overrides the .get() method so that the 'final' and 'private' key always exist and
-        # point to the same file.
+        """
+        Override to ensure 'final' and 'private' keys always exist and reference the same file.
+        
+        Returns:
+            ALStaticDocument: Returns self.
+        """
         return self
 
     def as_list(self, key: str = "final", refresh: bool = True) -> List[DAStaticFile]:
+        """
+        Get the document as a list.
+
+        Returns:
+            List[DAStaticFile]: A list containing the document.
+        """
         return [self]
 
     def as_pdf(
@@ -1052,9 +1293,23 @@ class ALStaticDocument(DAStaticFile):
         append_matching_suffix: bool = True,
         refresh: bool = False,
     ) -> Union[DAStaticFile, DAFile]:
+        """
+        Convert the document into PDF format.
+
+        Args:
+            key (str): Key to access the document. Defaults to "final".
+            pdfa (bool): Whether to return the document in PDF/A format. Defaults to False.
+            filename (str): Name for the converted file. Defaults to the original filename.
+            append_matching_suffix (bool): Whether to append a matching suffix to the filename. Defaults to True.
+            refresh (bool): Whether to refresh the document. Defaults to False.
+
+        Returns:
+            Union[DAStaticFile, DAFile]: The document in PDF format.
+        """
         if not filename:
             filename = self.filename
         return pdf_concatenate(self, pdfa=pdfa, filename=f"{base_name(filename)}.pdf")
+
 
     def as_docx(
         self,
@@ -1063,9 +1318,15 @@ class ALStaticDocument(DAStaticFile):
         append_matching_suffix: bool = False,
     ) -> Union[DAStaticFile, DAFile]:
         """
-        Returns the assembled document as a single DOCX file, if possible. Otherwise returns a PDF.
-        The "append_matching_suffix" parameter is not used for static documents. They are always
-        left unchanged.
+        Convert the document into DOCX format, if possible. If not, return as PDF.
+
+        Args:
+            key (str): Key to access the document. Defaults to "final".
+            refresh (bool): Whether to refresh the document. Defaults to True.
+            append_matching_suffix (bool): Not used for static documents. They remain unchanged.
+
+        Returns:
+            Union[DAStaticFile, DAFile]: The document in DOCX or PDF format.
         """
         if self._is_docx():
             return self
@@ -1075,7 +1336,17 @@ class ALStaticDocument(DAStaticFile):
             # negative performance implications. By definition static files have only one version
             return self.as_pdf(key=key, append_matching_suffix=False)
 
-    def _is_docx(self, key: str = "final"):
+
+    def _is_docx(self, key: str = "final") -> bool:
+        """
+        Check if the document is in DOCX format.
+
+        Args:
+            key (str): Key to access the document. Defaults to "final".
+
+        Returns:
+            bool: True if the document is in DOCX format, otherwise False.
+        """
         if hasattr(self, "extension") and self.extension.lower() == "docx":
             return True
         if (
@@ -1086,36 +1357,64 @@ class ALStaticDocument(DAStaticFile):
             return True
         return False
 
-    def show(self, **kwargs):
+    def show(self, **kwargs) -> DAFile:
+        """
+        Display the document.
+
+        This method provides a workaround for problems generating thumbnails.
+
+        Returns:
+            DAFile: Displayable version of the document.
+        """
         # TODO: this explicit conversion shouldn't be needed
         # Workaround for problem generating thumbnails without it
         return pdf_concatenate(self).show(**kwargs)
 
     def is_enabled(self, **kwargs) -> bool:
+        """Check if the document is enabled.
+
+        Returns:
+            bool: True if the document is enabled, otherwise False.
+        """
         return self.enabled
 
 
 class ALDocumentBundle(DAList):
     """
-    DAList of ALDocuments or nested ALDocumentBundles.
+    A collection of ALDocuments or nested ALDocumentBundles, represented as a DAList.
 
-    Use case: providing a list of documents in a specific order.
-    Example:
-      - Cover page
-      - Main motion form
-      - Notice of Interpreter Request
+    This class provides functionalities for grouping multiple documents or nested bundles
+    in a specific order. For instance, you might want to bundle documents differently for the court,
+    the user, and the opposing party. Each ALDocument within this bundle can be individually "enabled" 
+    or "disabled", which will determine its inclusion in the generated bundle.
 
-    E.g., you may bundle documents one way for the court, one way for the user, one way for the
-    opposing party. ALDocuments can separately be "enabled" or "disabled" for a particular run, which
-    will affect their inclusion in all bundles.
+    A bundle can be output as a single merged PDF or as a list of individual documents. For nested 
+    bundles, each can be rendered as a merged PDF or a list of documents.
 
-    A bundle can be returned as one PDF or as a list of documents. If the list contains nested
-    bundles, each nested bundle can similarly be returned as a combined PDF or a list of documents.
+    Attributes:
+        filename (str): The name of the output file (without extension).
+        title (str): The title of the bundle.
+        enabled (bool, optional): Determines if the bundle is active. Defaults to True.
+        auto_gather (bool, optional): Automatically gathers attributes. Defaults to False.
+        gathered (bool, optional): Specifies if attributes have been gathered. Defaults to True.
 
-    required attributes:
-      - filename
-      - title
-    optional attribute: enabled
+    Examples:
+        Given three documents: `Cover page`, `Main motion form`, and `Notice of Interpreter Request`, 
+        bundle them as follows:
+        ```
+        bundle = ALDocumentBundle(elements=[cover_page, main_motion, notice_of_request], 
+                                  filename="documents_bundle", title="Document Set")
+        ```
+
+        Convert the bundle to a PDF:
+        ```
+        combined_pdf = bundle.as_pdf()
+        ```
+
+        Convert the bundle to a zip archive containing individual PDFs:
+        ```
+        zipped_files = bundle.as_zip()
+        ```
     """
 
     def init(self, *pargs, **kwargs):
@@ -1139,7 +1438,19 @@ class ALDocumentBundle(DAList):
         pdfa: bool = False,
         append_matching_suffix: bool = True,
     ) -> Optional[DAFile]:
-        """Returns the Bundle as a single PDF DAFile, or None if none of the documents are enabled."""
+        """
+        Returns a consolidated PDF of all enabled documents in the bundle.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to return a newly assembled version, default is True.
+            pdfa (bool): Flag to return the PDF in PDF/A format, default is False.
+            append_matching_suffix (bool): Flag to determine if matching suffix should be appended to file name, default is True.
+                                            Used primarily to enhance automated tests.
+
+        Returns:
+            Optional[DAFile]: Combined PDF file or None if no documents are enabled.
+        """
         safe_key = space_to_underscore(key)
         if pdfa:
             safe_key = safe_key + "-pdfa"
@@ -1181,7 +1492,15 @@ class ALDocumentBundle(DAList):
         return pdf
 
     def __str__(self) -> str:
-        # Could be triggered in many different places unintenionally: don't refresh
+        """
+        Produces a string representation of the PDF in a compatible method
+        with the DAFile class. In an interview, this will show a thumbnail of
+        the PDF by default.
+
+        Returns:
+            str: String representation of the PDF.
+        """
+        # Could be triggered in many different places unintentionally: don't refresh
         return str(self.as_pdf(refresh=False))
 
     def as_zip(
@@ -1193,7 +1512,20 @@ class ALDocumentBundle(DAList):
         format="pdf",
         include_pdf=True,
     ) -> DAFile:
-        """Returns a zip file containing the whole bundle"""
+        """
+        Returns a zip file containing all enabled documents in the bundle in the specified format.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+            pdfa (bool): Flag to include the document in PDF/A format, default is False.
+            title (str): Title of the zip file, default is the bundle's title.
+            format (str): Format of the documents in the zip file (e.g., "pdf", "docx", "original"), default is "pdf".
+            include_pdf (bool): Flag to include a PDF version of the document if it's originally in docx format, default is True.
+
+        Returns:
+            DAFile: A zip file containing the enabled documents.
+        """
 
         zip_key = f"{ space_to_underscore( key )}_zip"
 
@@ -1231,22 +1563,38 @@ class ALDocumentBundle(DAList):
         return zip
 
     def preview(self, refresh: bool = True) -> Optional[DAFile]:
+        """
+        Returns a preview version of the bundle as a PDF.
+
+        Args:
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            Optional[DAFile]: Preview PDF file or None if no documents are enabled.
+        """
         return self.as_pdf(key="preview", refresh=refresh)
 
     def has_enabled_documents(self, refresh=False) -> bool:
         """
-        Return True iff there is at least one enabled document
-        in this bundle.
+        Checks if there is at least one enabled document in the bundle.
+
+        Args:
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is False.
+
+        Returns:
+            bool: True if there's at least one enabled document, otherwise False.
         """
-        # Use a generator expression for speed
         return any(document.is_enabled(refresh=refresh) for document in self.elements)
 
     def enabled_documents(self, refresh: bool = True) -> List[Any]:
         """
-        Returns the enabled documents
+        Retrieves all enabled documents within the bundle.
 
         Args:
-            refresh(bool): Controls whether the 'enabled' attribute is reconsidered.
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            List[Any]: List of enabled documents.
         """
         return [
             document
@@ -1256,8 +1604,14 @@ class ALDocumentBundle(DAList):
 
     def as_flat_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
         """
-        Returns the nested bundle as a single flat list. This could be the preferred way to deliver forms to the
-        court, e.g.--one file per court form/cover letter.
+        Flattens and returns all enabled documents in the bundle, even from nested bundles.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            List[DAFile]: Flattened list of enabled documents.
         """
         # Iterate through the list of self.templates
         # Unpack the list of documents at each step so this can be concatenated into a single list
@@ -1271,9 +1625,17 @@ class ALDocumentBundle(DAList):
                 flat_list.extend(document.as_list(key=key, refresh=refresh))
         return flat_list
 
+
     def get_titles(self, key: str = "final", refresh: bool = True) -> List[str]:
         """
-        Gets all of titles of the documents in a list
+        Retrieves the titles of all enabled documents in the bundle.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            List[str]: Titles of the enabled documents.
         """
         flat_list = []
         for document in self.enabled_documents(refresh=refresh):
@@ -1287,7 +1649,15 @@ class ALDocumentBundle(DAList):
         self, key: str = "final", refresh: bool = True, pdfa: bool = False
     ) -> List[DAFile]:
         """
-        Returns the nested bundles as a list of PDFs that is only one level deep.
+        Returns all enabled documents in the bundle as individual PDFs, even from nested bundles.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+            pdfa (bool): Flag to return the documents in PDF/A format, default is False.
+
+        Returns:
+            List[DAFile]: List of enabled documents as individual PDFs.
         """
         return [
             doc.as_pdf(key=key, refresh=refresh, pdfa=pdfa)
@@ -1296,19 +1666,34 @@ class ALDocumentBundle(DAList):
 
     def as_docx_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
         """
-        Returns the nested bundles as a list of DOCX files. If the file isn't able
-        to be represented as a DOCX, the original file or a PDF will be returned instead.
+        Generates a list of enabled documents from the bundle represented as DOCX files.
+
+        If a particular document can't be represented as a DOCX, its original format or a PDF is returned.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            List[DAFile]: List of documents represented as DOCX files or in their original format.
         """
         return [
             doc.as_docx(key=key, refresh=refresh)
             for doc in self.enabled_documents(refresh=refresh)
         ]
 
-    def as_editable_list(
-        self, key: str = "final", refresh: bool = True
-    ) -> List[DAFile]:
+    def as_editable_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
         """
-        Return a flat list of the DOCX versions of the docs in this bundle, if they exist.
+        Generates a list of editable (DOCX or RTF) versions of the documents in the bundle.
+
+        For documents that are not in DOCX or RTF formats, the original file format is returned.
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+
+        Returns:
+            List[DAFile]: Flat list of documents in DOCX or RTF formats or their original format.
         """
         docs = self.as_flat_list(key=key, refresh=refresh)
         editable = []
@@ -1341,13 +1726,26 @@ class ALDocumentBundle(DAList):
         include_email: bool = False,
     ) -> str:
         """
-        Returns string of a table to display a list
-        of pdfs with 'view' and 'download' buttons.
+        Constructs an HTML table displaying a list of documents with 'view' and 'download' buttons.
 
-        `format` is one of:
-        * pdf
-        * docx
-        * original
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            format (str): Specifies the format of the files in the list. Can be "pdf", "docx", or "original". Default is "pdf".
+            view (bool): Flag to include a 'view' button, default is True.
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+            pdfa (bool): Flag to return documents in PDF/A format, default is False.
+            include_zip (bool): Flag to include a zip option, default is True.
+            view_label (str): Label for the 'view' button, default is "View".
+            view_icon (str): Icon for the 'view' button, default is "eye".
+            download_label (str): Label for the 'download' button, default is "Download".
+            download_icon (str): Icon for the 'download' button, default is "download".
+            zip_label (Optional[str]): Label for the zip option, if not provided, the format will be used.
+            zip_icon (str): Icon for the zip option, default is "file-archive".
+            append_matching_suffix (bool): Flag to determine if matching suffix should be appended to file name, default is True.
+            include_email (bool): Flag to include an email option, default is False.
+
+        Returns:
+            str: HTML representation of a table with documents and their associated actions.
         """
         if not hasattr(self, "_cached_zip_label"):
             self._cached_zip_label = str(self.zip_label)
@@ -1466,7 +1864,10 @@ class ALDocumentBundle(DAList):
         """
         Returns an HTML string of a table to display all the docs
         combined into one pdf with 'view' and 'download' buttons.
+
+        Deprecated; use download_list_html instead
         """
+        log("ALDocumentBundle.download_html is deprecated; use download_list_html instead")
         if format == "docx":
             the_file = self.as_docx(key=key)
         else:
@@ -1509,6 +1910,12 @@ class ALDocumentBundle(DAList):
         """
         Generate HTML doc table row for an input box and button that allows
         someone to send the bundle to the specified email address.
+
+        Args:
+            key (str): A key used to identify which version of the ALDocument to send. Defaults to "final".
+        
+        Returns:
+            str: The generated HTML string for the table row.
         """
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents
@@ -1726,7 +2133,15 @@ class ALDocumentBundle(DAList):
             )
 
     def _is_self_enabled(self, refresh=True) -> bool:
-        """The same as ALDocument.is_enabled"""
+        """
+        Check if the document is always enabled or if it's enabled in the cache.
+
+        Args:
+            refresh (bool): Whether to refresh the enabled status. Defaults to True.
+        
+        Returns:
+            bool: Indicates if the document is enabled.
+        """
         if hasattr(self, "always_enabled") and self.always_enabled:
             return True
         if hasattr(self.cache, "enabled"):
@@ -1740,7 +2155,15 @@ class ALDocumentBundle(DAList):
             return self.enabled
 
     def is_enabled(self, refresh=True) -> bool:
-        """Returns true if the bundle itself is enabled, and it has at least one enabled child document"""
+        """
+        Check if the bundle itself is enabled, and if it has at least one enabled child document.
+
+        Args:
+            refresh (bool): Whether to refresh the enabled status. Defaults to True.
+        
+        Returns:
+            bool: Indicates if the bundle and its child documents are enabled.
+        """
         self_enabled = self._is_self_enabled(refresh=refresh)
         return self_enabled and self.has_enabled_documents(refresh=refresh)
 
@@ -1812,7 +2235,9 @@ class ALDocumentBundle(DAList):
 
 
 class ALExhibit(DAObject):
-    """Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
+    """
+    Class to represent a single exhibit, with cover page, which may contain multiple documents representing pages.
+    
     Attributes:
         pages (list): List of individual DAFiles representing uploaded images or documents.
         cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block
@@ -1854,13 +2279,15 @@ class ALExhibit(DAObject):
 
     def ocr_ready(self) -> bool:
         """
-        Returns:
-            True iff OCR process has finished on all pages. OCR is non-blocking, and assembly will work
-            even if OCR is not complete. Check this status if you want to wait to deliver a document until
-            OCR is complete.
+        Returns True if the OCR process is complete. OCR is non-blocking, and assembly will work
+        even if OCR is not complete. Check this status if you want to wait to deliver a document until
+        OCR is complete.
 
-            Will return true (but log a warning) if OCR was never started on the documents.
-            That situation is likely a developer error, as you shouldn't wait for OCR if it never started
+        Will return true (but log a warning) if OCR was never started on the documents.
+        That situation is likely a developer error, as you shouldn't wait for OCR if it never started
+
+        Returns:
+            bool: True iff OCR process has finished on all pages.            
         """
         if hasattr(self, "ocr_status") and not self.ocr_status.ready():
             return False
@@ -1870,7 +2297,10 @@ class ALExhibit(DAObject):
 
     def ocr_pages(self):
         """
-        Return the OCR version if it exists; otherwise the initial version of each doc in `pages`.
+        Retrieve the OCR-processed version of pages if available, else return the original pages.
+        
+        Returns:
+            List[DAFile]: List of pages, either OCR-processed or original.
         """
         if (
             hasattr(self, "ocr_version")
@@ -1886,6 +2316,53 @@ class ALExhibit(DAObject):
             pages.append(page)
         return pages
 
+Here's an improved version of the docstring for the class and its methods:
+
+python
+
+class ALExhibit(DAObject):
+    """
+    Represents an exhibit with an optional cover page and multiple documents (pages).
+
+    Attributes:
+        pages (List[DAFile]): Individual documents or images uploaded for this exhibit.
+        cover_page (Union[DAFile, DAFileCollection]): Optional cover page for the exhibit, typically indicating its label.
+        label (str): Identifier for this exhibit, such as "A" or "1".
+        starting_page (int): The starting page number for table of contents or pagination purposes.
+    """
+
+    def init(self, *pargs, **kwargs):
+        """
+        Initialize the ALExhibit object with default attributes and inheritance from DAObject.
+        """
+        ...
+
+    def _start_ocr(self):
+        """
+        Initiates OCR (Optical Character Recognition) on the exhibit's pages, adding a text layer for any images of text.
+        
+        Launches background actions for OCR processing on each page.
+        """
+        ...
+
+    def ocr_ready(self) -> bool:
+        """
+        Checks if the OCR process is complete for all pages.
+
+        Returns:
+            bool: True if the OCR process has finished; False otherwise.
+        """
+        ...
+
+    def ocr_pages(self):
+        """
+        Retrieve the OCR-processed version of pages if available, else return the original pages.
+        
+        Returns:
+            List[DAFile]: List of pages, either OCR-processed or original.
+        """
+        ...
+
     def as_pdf(
         self,
         *,
@@ -1898,12 +2375,16 @@ class ALExhibit(DAObject):
         append_matching_suffix: bool = True,
     ) -> DAFile:
         """
-        Params:
-            prefix (str): the prefix for the bates numbering that is applied if
-              add_page_numbers is true
-            add_page_numbers (bool): adds bates numbering to the exhibit if true,
-              starting at the number self.start_page
-            add_cover_page (bool): adds a cover to this exhibit if true
+        Generates a PDF version of the exhibit, with optional features like Bates numbering or a cover page.
+        
+        Args:
+            prefix (str): Prefix for Bates numbering if 'add_page_numbers' is True.
+            add_page_numbers (bool): If True, apply Bates numbering starting from 'self.start_page'.
+            add_cover_page (bool): If True, prepend the exhibit with a cover page.
+            filename (Optional[str]): Custom filename for the generated PDF. Default is "exhibits.pdf".
+
+        Returns:
+            DAFile: PDF representation of the exhibit.
         """
         safe_key = "_file"
         if pdfa:
@@ -1931,23 +2412,59 @@ class ALExhibit(DAObject):
         return getattr(self._cache, safe_key)
 
     def num_pages(self) -> int:
+        """
+        Calculate the total number of pages in the exhibit.
+
+        Returns:
+            int: Total page count.
+        """
         return self.pages.num_pages()
 
     @property
-    def complete(self):
+    def complete(self) -> bool:
+        """
+        For purposes of list gathering, trigger the attributes in order that are necessary
+        to gather a complete exhibit object.
+        
+        Returns:
+            bool: True if exhibit is complete.
+        """
         self.title
         self.pages.gather()
         return True
 
-    def __str__(self):
+
+    def __str__(self) -> str:
+        """
+        Return the title of the exhibit.
+
+        Returns:
+            str: Title of the exhibit.
+        """
         return self.title
 
 
 def ocrmypdf_task(
     from_file: Union[DAFile, DAFileList], to_pdf: DAFile
 ) -> Optional[str]:
-    """A function that calls ocr my pdf in a subprocess.
-    Built to be called from a background action (id: al exhibit ocr pages bg)"""
+    """
+    Processes the provided files using the 'ocrmypdf' utility to apply Optical Character Recognition (OCR).
+
+    If the source file is an image (e.g., png, jpg, jpeg, gif), this function sets the image DPI to 300. 
+    For non-image files, the text in the file is skipped during OCR.
+
+    This function is designed to be executed as a background task (id: al_exhibit_ocr_pages_bg).
+
+    Args:
+        from_file (Union[DAFile, DAFileList]): The source file or list of files to be OCR-processed.
+        to_pdf (DAFile): The destination file where the OCR-processed output will be saved.
+
+    Returns:
+        Optional[str]: The path of the OCR-processed file if successful; None otherwise.
+
+    Raises:
+        subprocess.TimeoutExpired: If the ocrmypdf process takes longer than an hour.
+    """
     if not from_file or not to_pdf:
         log(
             "Developer error: in ocrmypdf_task, shouldn't pass None to from_file or to_pdf"
@@ -1980,14 +2497,15 @@ def ocrmypdf_task(
 
 class ALExhibitList(DAList):
     """
+    A list representation of ALExhibit objects. Provides utility functions for managing exhibits
+    and rendering them into a single PDF file.
+    
     Attributes:
-        maximum_size (int): the maximum size in bytes that the whole document is allowed to be
-        auto_label (bool): Set to True if you want exhibits to be automatically numbered for purposes of cover page
-                           and table of contents. Defaults to True.
-        auto_labeler (Callable): (optional) a function or lambda to transform the index for each exhibit to a label.
-                                 Defaults to labels like A..Z if unspecified.
-        auto_ocr (bool): Set to True if you would like exhibits to be OCR'ed in the background after they are uploaded.
-                         Defaults to True.
+        maximum_size (int): The maximum allowed size in bytes of the entire document.
+        auto_label (bool): If True, automatically numbers exhibits for cover page and table of contents. Defaults to True.
+        auto_labeler (Callable): An optional function or lambda to transform the exhibit's index to a label.
+                                 Uses A..Z labels by default.
+        auto_ocr (bool): If True, automatically starts OCR processing for uploaded exhibits. Defaults to True.
     """
 
     def init(self, *pargs, **kwargs):
@@ -2019,12 +2537,17 @@ class ALExhibitList(DAList):
         append_matching_suffix: bool = True,
     ) -> DAFile:
         """
-        Return a single PDF containing all exhibits.
+        Compiles all exhibits in the list into a single PDF.
+
         Args:
-            filename (str): the filename to be assigned to the generated PDF document.
-            add_cover_pages (bool): True if each exhibit should have a cover page, like "Exhibit A".
+            filename (str): Desired filename for the generated PDF.
+            pdfa (bool): If True, generates the PDF in PDF/A format.
+            add_page_numbers (bool): If True, adds page numbers to the generated PDF.
+            toc_pages (int): Expected number of pages in the table of contents.
+            append_matching_suffix (bool): If True, appends matching suffix to the filename.
+
         Returns:
-            A DAfile containing the rendered exhibit list as a single file.
+            DAFile: A single PDF containing all exhibits.
         """
         if self.include_exhibit_cover_pages:
             for exhibit in self:
@@ -2044,8 +2567,13 @@ class ALExhibitList(DAList):
             pdfa=pdfa,
         )
 
-    def size_in_bytes(self):
-        """Gets the total size in bytes of each of the exhibit documents."""
+    def size_in_bytes(self) -> int:
+        """
+        Calculates the total size in bytes of all exhibits in the list.
+
+        Returns:
+            int: Total size of all exhibits in bytes.
+        """
         full_size = 0
         for exhibit in self.complete_elements():
             full_size += sum((a_page.size_in_bytes() for a_page in exhibit.pages))
@@ -2053,9 +2581,11 @@ class ALExhibitList(DAList):
 
     def _update_labels(self, auto_labeler: Optional[Callable] = None) -> None:
         """
-        Private method to refresh labels on all exhibits.
+        Updates labels of all exhibits in the list based on their index.
+
         Args:
-            auto_labeler (Callable): (optional) a lambda or function to transform index to a label, like A.
+            auto_labeler (Callable): An optional function or lambda to customize label generation. 
+                                     Uses the class's auto_labeler by default.
         """
         if auto_labeler is None:
             auto_labeler = self.auto_labeler
@@ -2065,7 +2595,10 @@ class ALExhibitList(DAList):
 
     def ocr_ready(self) -> bool:
         """
-        Returns `True` iff all individual exhibit pages have been OCRed, or if the OCR process hasn't started.
+        Checks if all exhibits in the list have completed the OCR process.
+
+        Returns:
+            bool: True if all exhibits are OCRed or if OCR hasn't started. False otherwise.
         """
         ready = True
         for exhibit in self.elements:
@@ -2076,7 +2609,11 @@ class ALExhibitList(DAList):
         self, starting_number: Optional[int] = None, toc_guess_pages: int = 1
     ) -> None:
         """
-        Update the `start_page` attribute of all exhibits so it reflects current position in the list + number of pages of each document.
+        Updates the starting page number of each exhibit in the list to reflect their position.
+
+        Args:
+            starting_number (Optional[int]): Optional starting number for the first exhibit.
+            toc_guess_pages (int): Estimated number of pages for the table of contents.
         """
         toc_pages = toc_guess_pages if self.include_table_of_contents else 0
         cover_pages = 1 if self.include_exhibit_cover_pages else 0
@@ -2086,13 +2623,18 @@ class ALExhibitList(DAList):
             exhibit.start_page = current_index
             current_index = current_index + exhibit.num_pages() + cover_pages
 
-    def _start_ocr(self):
+    def _start_ocr(self) -> None:
+        """
+        Initiates the OCR process for each exhibit in the list.
+        """
         for exhibit in self.elements:
             exhibit._start_ocr()
 
-    def hook_after_gather(self):
+
+    def hook_after_gather(self) -> None:
         """
-        Private method automatically triggered when the list is fully gathered.
+        Callback function executed after the entire list of exhibits is collected. 
+        Manages auto-labeling and initiates OCR if necessary.
         """
         if len(self):
             self._update_page_numbers()
@@ -2103,22 +2645,24 @@ class ALExhibitList(DAList):
 
 
 class ALExhibitDocument(ALDocument):
-    """Represents a collection of uploaded documents, formatted like a record appendix or exhibit list, with a table of contents and
-    optional page numbering.
+    """
+    Represents a collection of uploaded documents, formatted like a record appendix 
+    or an exhibit list, complete with an optional table of contents and page numbering.
 
     Attributes:
-        exhibits (ALExhibitList): list of ALExhibit documents. Each item is a separate exhibit, which may be multiple pages.
-        table_of_contents: DAFile or DAFileCollection object created by an `attachment:` block
-        _cache (DAFile): a cached version of the list of exhibits. It may take
-          a long time to process.
-        include_table_of_contents (bool): flag to control whether a table of contents is generated for this form
-        include_exhibit_cover_pages (bool): flag to control whether cover pages are included with each separate exhibit
-        add_page_numbers (bool): Flag that controls whether the as_pdf() method
-          also will add Bates-stamp style page numbers and labels on each page.
-        auto_labeler (callable): a Lambda or Python function that will be used to label exhibits.
+        exhibits (ALExhibitList): A list of ALExhibit documents. Each item represents 
+                                  a distinct exhibit, which can span multiple pages.
+        table_of_contents (DAFile or DAFileCollection): Generated by an `attachment:` block.
+        _cache (DAFile): A cached version of the exhibit list. Caching is used due to 
+                         potential long processing times.
+        include_table_of_contents (bool): Indicates if a table of contents should be generated.
+        include_exhibit_cover_pages (bool): Determines if cover pages should accompany each exhibit.
+        add_page_numbers (bool): If True, the as_pdf() method will add page numbers and labels.
+        auto_labeler (Callable): A function or lambda for labeling exhibits.
 
     Todo:
-        * Method of making a safe link in place of the attachment (e.g., filesize limits on email)
+        * Implement a method for a safe link in place of the attachment 
+          (considering potential filesize constraints on emails).
 
     Examples:
     ```
@@ -2171,37 +2715,71 @@ class ALExhibitDocument(ALDocument):
             # When the key is "preview", append it to the file name
             self.suffix_to_append = "preview"
 
-    def has_overflow(self):
+    def has_overflow(self) -> bool:
         """
-        Provided for signature compatibility with ALDocument. Exhibits do not have overflow.
+        Check if there is any overflow in the document.
+
+        This is for compatibility with ALDocument; Exhibits inherently don't have overflow.
+
+        Returns:
+            bool: Always False for this implementation.
         """
         return False
 
     def ocr_ready(self) -> bool:
         """
-        Returns `True` iff each individual exhibit has been OCRed, or if the OCR process was not started.
+        Determine if all exhibits within the document have undergone OCR processing.
+
+        Returns:
+            bool: True if all exhibits have been OCRed or if the OCR process hasn't been initiated.
         """
         return self.exhibits.ocr_ready()
 
     def __getitem__(self, key):
-        # This overrides the .get() method so that the 'final' and 'private' key always exist and
-        # point to the same file.
+        """
+        Overridden method to ensure 'final' and 'private' keys always reference the same file.
+
+        Args:
+            key: The key to fetch the item.
+
+        Returns:
+            ALExhibitDocument: Returns the current instance of the class.
+        """
         return self
 
     def as_list(self, key: str = "final", refresh: bool = True) -> List[DAFile]:
+        """
+        Retrieve the document as a list.
+
+        Args:
+            key (str): Identifier key for the document. Default is "final".
+            refresh (bool): If True, the document list will be refreshed. Default is True.
+
+        Returns:
+            List[DAFile]: A list containing the document.
+        """
         return [self]
 
     def as_pdf(
         self,
-        key="final",
+        key: str = "final",
         refresh: bool = True,
         pdfa: bool = False,
-        append_matching_suffix: bool = True,
+        append_matching_suffix: bool = True
     ) -> DAFile:
         """
+        Render the document as a PDF.
+
         Args:
-            key (str): unused, for signature compatibility with ALDocument
-            refresh (bool): unused, for signature compatibility with ALDocument
+            key (str): Identifier key for the document. Default is "final". 
+                       For compatibility with ALDocument.
+            refresh (bool): If True, refreshes the PDF document. Default is True. 
+                            For compatibility with ALDocument.
+            pdfa (bool): If True, the output PDF will be in PDF/A format. Default is False.
+            append_matching_suffix (bool): If True, appends a matching suffix to the filename.
+
+        Returns:
+            DAFile: The document rendered as a PDF.
         """
         if not hasattr(self, "suffix_to_append"):
             self.suffix_to_append = "preview"
@@ -2230,14 +2808,35 @@ class ALExhibitDocument(ALDocument):
 
     def as_docx(
         self,
-        key: str = "bool",
+        key: str = "final",
         refresh: bool = True,
-        append_matching_suffix: bool = True,
+        append_matching_suffix: bool = True
     ) -> DAFile:
+        """
+        Despite the name, renders the document as a PDF. Provided for signature compatibility.
+
+        Args:
+            key (str): Identifier key for the document. Default is "final".
+            refresh (bool): If True, refreshes the DOCX document. Default is True.
+            append_matching_suffix (bool): If True, appends a matching suffix to the filename (for automated tests).
+
+        Returns:
+            DAFile: The document rendered as a PDF.
+        """
         return self.as_pdf()
 
 
 class ALTableDocument(ALDocument):
+    """
+    Represents a document tailored for table-like data presentation. 
+    This class provides functionality to export data as a table in various formats such as PDF and DOCX.
+
+    Attributes:
+        has_addendum (bool): A flag indicating the presence of an addendum in the document.
+        suffix_to_append (str): Suffix that can be appended to file names, defaulting to "preview".
+        file (DAFile, optional): Reference to the generated file (can be PDF, DOCX, etc.).
+        table (???): Represents the actual table data. Type and attributes need more context to document.
+    """
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -2245,20 +2844,42 @@ class ALTableDocument(ALDocument):
             # When the key is "preview", append it to the file name
             self.suffix_to_append = "preview"
 
-    def has_overflow(self):
+    def has_overflow(self) -> bool:
         """
-        Provided for signature compatibility with ALDocument.
+        Check for overflow in the document.
+
+        For compatibility with ALDocument; Tables inherently don't have overflow.
+
+        Returns:
+            bool: Always False for this implementation.
         """
         return False
 
     def __getitem__(self, key):
-        # This overrides the .get() method so that the 'final' and 'private' key always exist and
-        # point to the same file.
+        """
+        Allows for index-based retrieval of a document.
+
+        Overridden to ensure 'final' and 'private' keys always return the same document.
+
+        Args:
+            key: The key to fetch the item.
+
+        Returns:
+            DAFile: The document in its PDF format.
+        """
         return self.as_pdf()
 
-    def as_list(
-        self, key: str = "final", refresh: bool = True, **kwargs
-    ) -> List[DAFile]:
+    def as_list(self, key: str = "final", refresh: bool = True, **kwargs) -> List[DAFile]:
+        """
+        Retrieve the document as a list.
+
+        Args:
+            key (str): Identifier key for the document. Default is "final".
+            refresh (bool): If True, the document list will be refreshed. Default is True.
+
+        Returns:
+            List[DAFile]: A list containing the document.
+        """
         return [self[key]]
 
     def as_pdf(
@@ -2270,8 +2891,17 @@ class ALTableDocument(ALDocument):
         **kwargs,
     ) -> DAFile:
         """
+        Despite the name, returns the document as an Excel Spreadsheet (XLSX file).
+        Name retained for signature compatibility.
+
         Args:
-            key (str): unused, for signature compatibility with ALDocument
+            key (str): Identifier key for the document, mainly for compatibility with ALDocument.
+            refresh (bool): For signature compatibility
+            pdfa (bool): For signature compatibility
+            append_matching_suffix (bool): For signature compatibility
+
+        Returns:
+            DAFile: The table rendered as an XLSX spreadsheet
         """
         if not hasattr(self, "suffix_to_append"):
             # When the key is "preview", append it to the file name
@@ -2289,25 +2919,60 @@ class ALTableDocument(ALDocument):
         refresh: bool = True,
         append_matching_suffix: bool = True,
     ) -> DAFile:
+        """
+        Despite the name, returns the document as an Excel Spreadsheet (XLSX file).
+        Name retained for signature compatibility.
+
+        Args:
+            key (str): Identifier key for the document, mainly for compatibility with ALDocument.
+            refresh (bool): For signature compatibility
+            pdfa (bool): For signature compatibility
+            append_matching_suffix (bool): For signature compatibility
+
+        Returns:
+            DAFile: The table rendered as an XLSX spreadsheet
+        """
         return self.as_pdf()
 
 
 class ALUntransformedDocument(ALDocument):
+    """
+    Represents an untransformed document. The class provides methods to access the document
+    without making any modifications to it. The provided methods are mainly for duck-typing 
+    compatibility with ALDocument.
+
+    Attributes:
+        has_addendum (bool): A flag indicating the presence of an addendum in the document.
+        suffix_to_append (str): Suffix that can be appended to file names, defaulting to "preview".
+    """
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.has_addendum = False
         if not hasattr(self, "suffix_to_append"):
             self.suffix_to_append = "preview"
 
-    def has_overflow(self):
+    def has_overflow(self) -> bool:
         """
-        Provided for signature compatibility with ALDocument.
+        Check for overflow in the document.
+
+        For compatibility with ALDocument. Untransformed documents inherently don't have overflow.
+
+        Returns:
+            bool: Always False for this implementation.
         """
         return False
 
-    def as_list(
-        self, key: str = "final", refresh: bool = True, **kwargs
-    ) -> List[DAFile]:
+    def as_list(self, key: str = "final", refresh: bool = True, **kwargs) -> List[DAFile]:
+        """
+        Retrieve the document as a list.
+
+        Args:
+            key (str): Identifier key for the document. Default is "final".
+            refresh (bool): If True, the document list will be refreshed. Default is True.
+
+        Returns:
+            List[DAFile]: A list containing the document.
+        """
         return [self[key]]
 
     def as_pdf(
@@ -2319,17 +2984,40 @@ class ALUntransformedDocument(ALDocument):
         **kwargs,
     ) -> DAFile:
         """
+        Fetch the document in its original form, without any transformations.
+
+        This method is primarily for duck-typing compatibility with ALDocument.
+
         Args:
-            key (str): unused, for signature compatibility with ALDocument
+            key (str): Identifier key for the document. Unused, but included for compatibility.
+            refresh (bool): If True, fetches the latest version of the document. Default is True.
+            pdfa (bool): Unused argument for compatibility.
+            append_matching_suffix (bool): Unused argument for compatibility.
+
+        Returns:
+            DAFile: The original, untransformed document.
         """
         return self[key]
 
     def as_docx(
         self,
-        key: str = "bool",
+        key: str = "final",
         refresh: bool = True,
         append_matching_suffix: bool = True,
     ) -> DAFile:
+        """
+        Fetch the document in its original form, without any transformations.
+
+        This method is primarily for duck-typing compatibility with ALDocument.
+
+        Args:
+            key (str): Identifier key for the document. Default is "final".
+            refresh (bool): If True, fetches the latest version of the document. Default is True.
+            append_matching_suffix (bool): Unused argument for compatibility.
+
+        Returns:
+            DAFile: The original, untransformed document.
+        """
         return self[key]
 
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -201,34 +201,30 @@ class ALAddendumField(DAObject):
         input_width: int = 80,
         overflow_message: str = "",
         preserve_words: bool = True,
-    ):
+    ) -> Any:
         """
-        Retrieve the overflow portion of a variable which exceeds the content of `safe_value()`.
+        Retrieve the overflow portion of a variable that exceeds the content of `safe_value()`.
 
-        This function addresses both list-like objects and strings. It ensures that the returned overflow
-        content has been modified to meet whitespace preferences specified by the parameters.
+        This function addresses both list-like objects and strings, ensuring that the returned overflow
+        content adheres to whitespace preferences specified by the parameters.
 
-        Parameters:
-            preserve_newlines (bool, optional):
-                If True, the returned string can contain single newline characters. Any sequence of
-                newline characters (including Windows-style "\r\n") will be reduced to a single "\n".
-                Double spaces will be replaced with a single space. If False, all kinds of whitespace,
-                including newlines and tabs, will be replaced with a single space. Defaults to False.
-
-            input_width (int, optional):
-                The width of the input field or display area, used for determining overflow.
-                Defaults to 80.
-
-            overflow_message (str, optional):
-                A message to indicate overflow in the safe value. Defaults to an empty string.
-
-            preserve_words (bool, optional):
-                If True, ensures that words are not split between the main content and the overflow.
-                Defaults to True.
+        Args:
+            preserve_newlines (bool, optional): Determines the treatment of newline characters. 
+                If True, the returned string can contain single newline characters. Sequences of newline 
+                characters, including Windows-style "rn", will be reduced to a single "n". Double spaces
+                will be replaced with a single space. If False, all whitespace, including newlines and 
+                tabs, will be replaced with a single space. Defaults to False.
+            
+            input_width (int, optional): The width of the input field or display area, used for determining
+                overflow. Defaults to 80.
+            
+            overflow_message (str, optional): Message indicating overflow in the safe value. Defaults to "".
+            
+            preserve_words (bool, optional): If True, ensures words are not split between the main content 
+                and the overflow. Defaults to True.
 
         Returns:
-            str: The portion of the variable that exceeds the content safe to display and should be
-            considered as overflow.
+            Any: The portion of the variable exceeding the content safe for display, considered as overflow.
         """
         # Handle a Boolean overflow first
         if isinstance(self.overflow_trigger, bool) and self.overflow_trigger:
@@ -318,6 +314,9 @@ class ALAddendumField(DAObject):
             preserve_words (bool): If True, the algorithm will try to preserve whole words when
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
+        
+        Returns:
+            bool: True if the value's length exceeds the overflow trigger, False otherwise.
         """
         if _original_value:
             val = _original_value
@@ -360,6 +359,9 @@ class ALAddendumField(DAObject):
             preserve_words (bool): If True, the algorithm will try to preserve whole words when
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
+
+        Returns:
+            Union[str, List[Any]]: Either a string representing the overflow message or the original value
         """
         if _original_value:
             val = _original_value
@@ -387,17 +389,17 @@ class ALAddendumField(DAObject):
     ) -> Union[str, List[Any]]:
         """
         Return just the portion of the variable that heuristics suggest will fit in the specified overflow_trigger
-        limit. If the value is not defined, return empty string.
+        limit. If the value is not defined, return an empty string.
 
         When `preserve_newlines` is `True`, the output will be limited to a number of lines, not a number
         of characters. The max number of lines will be calculated as `floor(self.overflow_trigger/input_width)`.
         Therefore, it is important that `input_width` is a divisor of `overflow_trigger`.
 
-        Whitespace will be altered. If preserve_newlines is true, the return value may have newlines,
-        but double newlines and Windows style (\r\n) will be replaced with \n. Double spaces will replaced
+        Whitespace will be altered. If `preserve_newlines` is true, the return value may have newlines,
+        but double newlines and Windows style (rn) will be replaced with n. Double spaces will be replaced
         with a single space.
 
-        If preserve_newlines is false, all whitespace, including newlines and tabs, will be replaced
+        If `preserve_newlines` is false, all whitespace, including newlines and tabs, will be replaced
         with a single space.
 
         Args:
@@ -406,11 +408,14 @@ class ALAddendumField(DAObject):
             preserve_newlines (bool): Determines whether newlines are preserved in the "safe" text.
                 Defaults to False, which means all newlines are removed. This allows more text to appear
                 before being sent to the addendum.
-            _original_value (Any): for speed reasons, you can provide the full text and just use this
-                method to determine if the overflow trigger is exceeded. If no _original_value is
-                provided, this method will determine it using the value_if_defined() method.
-        """
+            _original_value (Optional[str]): For speed reasons, you can provide the full text and just use this
+                method to determine if the overflow trigger is exceeded. If no `_original_value` is
+                provided, this method will determine it using the `value_if_defined()` method.
+            preserve_words (bool): Indicates whether words should be preserved in their entirety without being split.
 
+        Returns:
+            Union[str, List[Any]]: The portion of the variable that fits within the overflow trigger.
+        """
         # Handle simplest case first
         if _original_value:
             value = _original_value
@@ -491,7 +496,7 @@ class ALAddendumField(DAObject):
         return str(self.value_if_defined())
 
     def columns(
-        self, skip_empty_attributes: bool = True, skip_attributes: set = {"complete"}
+        self, skip_empty_attributes: bool = True, skip_attributes: Optional[set] = None
     ) -> Optional[list]:
         """
         Return a list of the attributes present within the object that would make sense to go
@@ -500,9 +505,16 @@ class ALAddendumField(DAObject):
         If the `headers` attribute exists, this will be prioritized. Otherwise, the method will infer columns
         from the first value in the list. Empty attributes and the `complete` attribute are typically ignored.
 
+        Args:
+            skip_empty_attributes (bool, optional): Determines whether empty attributes are included in the list.
+                                                    Defaults to True.
+            skip_attributes (Optional[set], optional): A set of attributes to ignore. Defaults to {"complete"}.
+        
         Returns:
             Optional[list]: A list of columns or None if no meaningful columns can be determined.
         """
+        if not skip_attributes:
+            skip_attributes = {"complete"}
         if hasattr(self, "headers"):
             return self.headers
         else:
@@ -638,7 +650,7 @@ class ALAddendumField(DAObject):
     def overflow_docx(
         self,
         path: str = "docassemble.ALDocumentDict:data/templates/addendum_table.docx",
-    ):
+    ) -> Any:
         """
         Insert a formatted table into a docx file, representing the overflow values.
 
@@ -695,7 +707,7 @@ class ALAddendumFieldDict(DAOrderedDict):
         super().initializeObject(*pargs, **kwargs)
         self[the_key].field_name = the_key
 
-    def from_list(self, data):
+    def from_list(self, data) -> None:
         """
         Populate the dictionary using a list of field data.
 
@@ -707,6 +719,7 @@ class ALAddendumFieldDict(DAOrderedDict):
             new_field = self.initializeObject(entry["field_name"], ALAddendumField)
             new_field.field_name = entry["field_name"]
             new_field.overflow_trigger = entry["overflow_trigger"]
+        return
 
     def defined_fields(self, style="overflow_only") -> list:
         """
@@ -1090,7 +1103,7 @@ class ALDocument(DADict):
         """
         return self.overflow_fields.has_overflow()
 
-    def overflow(self):
+    def overflow(self) -> list:
         """
         Retrieves a list of fields that have overflowed their character limits.
 
@@ -1128,6 +1141,9 @@ class ALDocument(DADict):
             preserve_words (bool): If True, the algorithm will try to preserve whole words when
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
+
+        Returns:
+            Union[str, List[Any]]: Either the original value or the overflow message, never a truncated value.
         """
         if overflow_message is None:
             overflow_message = self.default_overflow_message
@@ -1278,6 +1294,10 @@ class ALStaticDocument(DAStaticFile):
         """
         Get the document as a list.
 
+        Args:
+            key (str): Key to access the document. Defaults to "final".
+            refresh (bool): Whether to refresh the document. Defaults to True.
+
         Returns:
             List[DAStaticFile]: A list containing this document.
         """
@@ -1368,6 +1388,9 @@ class ALStaticDocument(DAStaticFile):
 
     def is_enabled(self, **kwargs) -> bool:
         """Check if the document is enabled.
+
+        Args:
+            **kwargs: Unused (for signature compatibility only)
 
         Returns:
             bool: True if the document is enabled, otherwise False.
@@ -1863,6 +1886,20 @@ class ALDocumentBundle(DAList):
         combined into one pdf with 'view' and 'download' buttons.
 
         Deprecated; use download_list_html instead
+
+        Args:
+            key (str): Identifier for the document version, default is "final".
+            format (str): Specifies the format of the files in the list. Can be "pdf", "docx", or "original". Default is "pdf".
+            pdfa (bool): Flag to return the documents in PDF/A format, default is False.
+            view (bool): Flag to include a 'view' button, default is True.
+            refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
+            view_label (str): Label for the 'view' button, default is "View".
+            view_icon (str): Icon for the 'view' button, default is "eye".
+            download_label (str): Label for the 'download' button, default is "Download".
+            download_icon (str): Icon for the 'download' button, default is "download".
+        
+        Returns:
+            str: HTML representation of a table with documents and their associated actions.
         """
         log(
             "ALDocumentBundle.download_html is deprecated; use download_list_html instead"
@@ -2029,6 +2066,7 @@ class ALDocumentBundle(DAList):
             show_editable_checkbox (bool, optional): Flag indicating if the checkbox
                 for deciding the inclusion of an editable (Word) copy should be displayed.
                 Defaults to True.
+            template_name (str, optional): The name of the template to be used. Defaults to an empty string.
 
         Returns:
             str: The generated HTML string for the input box and button.
@@ -2294,7 +2332,7 @@ class ALExhibit(DAObject):
             log("developer warning: ocr_ready was called but _ocr_start wasn't!")
         return True
 
-    def ocr_pages(self):
+    def ocr_pages(self) -> List[DAFile]:
         """
         Retrieve the OCR-processed version of pages if available, else return the original pages.
 
@@ -2329,11 +2367,16 @@ class ALExhibit(DAObject):
         """
         Generates a PDF version of the exhibit, with optional features like Bates numbering or a cover page.
 
+        Note that these are keyword only parameters, not positional.
+
         Args:
+            refresh (bool): If True, forces the exhibit to refresh before generating the PDF. (unused, provided for signature compatibility)
             prefix (str): Prefix for Bates numbering if 'add_page_numbers' is True.
+            pdfa (bool): If True, the generated PDF will be in PDF/A format.
             add_page_numbers (bool): If True, apply Bates numbering starting from 'self.start_page'.
             add_cover_page (bool): If True, prepend the exhibit with a cover page.
             filename (Optional[str]): Custom filename for the generated PDF. Default is "exhibits.pdf".
+            append_matching_suffix (bool): If True, appends a suffix to the filename based on certain matching criteria.
 
         Returns:
             DAFile: PDF representation of the exhibit.
@@ -2375,11 +2418,12 @@ class ALExhibit(DAObject):
     @property
     def complete(self) -> bool:
         """
-        For purposes of list gathering, trigger the attributes in order that are necessary
-        to gather a complete exhibit object.
+        For purposes of list gathering, trigger the attributes in the order necessary 
+        to gather a complete exhibit object. 
 
-        Returns:
-            bool: True if exhibit is complete.
+        Indicates if the exhibit is complete.
+
+        Note: This property always returns True after triggering the required attributes.
         """
         self.title
         self.pages.gather()

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -209,18 +209,18 @@ class ALAddendumField(DAObject):
         content adheres to whitespace preferences specified by the parameters.
 
         Args:
-            preserve_newlines (bool, optional): Determines the treatment of newline characters. 
-                If True, the returned string can contain single newline characters. Sequences of newline 
+            preserve_newlines (bool, optional): Determines the treatment of newline characters.
+                If True, the returned string can contain single newline characters. Sequences of newline
                 characters, including Windows-style "rn", will be reduced to a single "n". Double spaces
-                will be replaced with a single space. If False, all whitespace, including newlines and 
+                will be replaced with a single space. If False, all whitespace, including newlines and
                 tabs, will be replaced with a single space. Defaults to False.
-            
+
             input_width (int, optional): The width of the input field or display area, used for determining
                 overflow. Defaults to 80.
-            
+
             overflow_message (str, optional): Message indicating overflow in the safe value. Defaults to "".
-            
-            preserve_words (bool, optional): If True, ensures words are not split between the main content 
+
+            preserve_words (bool, optional): If True, ensures words are not split between the main content
                 and the overflow. Defaults to True.
 
         Returns:
@@ -314,7 +314,7 @@ class ALAddendumField(DAObject):
             preserve_words (bool): If True, the algorithm will try to preserve whole words when
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
-        
+
         Returns:
             bool: True if the value's length exceeds the overflow trigger, False otherwise.
         """
@@ -509,7 +509,7 @@ class ALAddendumField(DAObject):
             skip_empty_attributes (bool, optional): Determines whether empty attributes are included in the list.
                                                     Defaults to True.
             skip_attributes (Optional[set], optional): A set of attributes to ignore. Defaults to {"complete"}.
-        
+
         Returns:
             Optional[list]: A list of columns or None if no meaningful columns can be determined.
         """
@@ -1897,7 +1897,7 @@ class ALDocumentBundle(DAList):
             view_icon (str): Icon for the 'view' button, default is "eye".
             download_label (str): Label for the 'download' button, default is "Download".
             download_icon (str): Icon for the 'download' button, default is "download".
-        
+
         Returns:
             str: HTML representation of a table with documents and their associated actions.
         """
@@ -2418,8 +2418,8 @@ class ALExhibit(DAObject):
     @property
     def complete(self) -> bool:
         """
-        For purposes of list gathering, trigger the attributes in the order necessary 
-        to gather a complete exhibit object. 
+        For purposes of list gathering, trigger the attributes in the order necessary
+        to gather a complete exhibit object.
 
         Indicates if the exhibit is complete.
 

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -649,7 +649,7 @@ class ALNameList(DAList):
 
 class ALPeopleList(DAList):
     """Class to store a list of ALIndividual objects, representing people.
-    
+
     For example, defendants, plaintiffs, or children."""
 
     def init(self, *pargs, **kwargs):
@@ -859,16 +859,13 @@ class ALIndividual(Individual):
             and_string=word("or"),
         )
 
-    def merge_letters(self, new_letters: str) -> str:
+    def merge_letters(self, new_letters: str) -> None:
         """If the Individual has a child_letters attribute, add the new letters to the existing list
-        
+
         Avoid using. Only used in 209A.
 
         Args:
             new_letters (str): The new letters to add to the existing list of letters
-        
-        Returns:
-            str: The updated list of letters
         """
         # TODO: move to 209A package
         if hasattr(self, "child_letters"):
@@ -1555,7 +1552,7 @@ class ALIndividual(Individual):
 # (DANav isn't in public DA API, but currently in functions.py)
 def section_links(nav) -> List[str]:  # type: ignore
     """Returns a list of clickable navigation links without animation.
-    
+
     Args:
         nav: The navigation object.
 
@@ -1645,7 +1642,7 @@ def will_send_to_real_court() -> bool:
 # This one is only used for 209A--should move there along with the combined_letters() method
 def filter_letters(letter_strings: Union[List[str], str]) -> str:
     """Used to take a list of letters like ["A","ABC","AB"] and filter out any duplicate letters.
-    
+
     Avoid using, this is created for 209A.
 
     Args:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List, Literal, Union, Optional
+from typing import Dict, List, Literal, Union, Optional, Any
 from docassemble.base.util import (
     Address,
     as_datetime,
@@ -75,10 +75,10 @@ def safe_subdivision_type(country_code: str) -> Optional[str]:
     """
     Returns the subdivision type for the country with the given country code.
     If no subdivision type is found, returns None.
-    
+
     Args:
         country_code (str): The ISO-3166-1 alpha-2 code for the country.
-    
+
     Returns:
         str: The subdivision type for the country with the given country code.
     """
@@ -114,10 +114,10 @@ class ALAddress(Address):
     ) -> List[Dict[str, Any]]:
         """
         Return a YAML structure representing the list of fields for the object's address.
-        
-        Optionally, allow the user to specify they do not have an address. When using 
-        `allow_no_address=True`, ensure to trigger the question with `users[0].address.has_no_address` 
-        rather than `users[0].address.address`. If `show_if` is used, it will not be applied when 
+
+        Optionally, allow the user to specify they do not have an address. When using
+        `allow_no_address=True`, ensure to trigger the question with `users[0].address.has_no_address`
+        rather than `users[0].address.address`. If `show_if` is used, it will not be applied when
         `allow_no_address` is also used. Ensure `country_code` adheres to ISO-3166-1 alpha-2 code standard.
 
         NOTE: This function is stateful under specific conditions. Refer to the conditions mentioned below.
@@ -134,15 +134,15 @@ class ALAddress(Address):
             list: A list of YAML structure representing address fields.
 
         Notes:
-            - The function will set the `country` attribute of the Address to `country_code` under these 
+            - The function will set the `country` attribute of the Address to `country_code` under these
             circumstances:
                 1. The `country_code` parameter is used.
                 2. The `show_country` parameter is not used.
                 3. `country_code` differs from the value returned by `get_country()`.
 
-            - Link to ISO-3166-1 alpha-2 codes: 
+            - Link to ISO-3166-1 alpha-2 codes:
             [Officially assigned code elements](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).
-        """        
+        """
         # make sure the state name still returns a meaningful value if the interview country
         # differs from the server's country.
         if country_code and country_code != get_country() and not show_country:
@@ -317,9 +317,9 @@ class ALAddress(Address):
 
     def block(
         self,
-        language: str = None,
+        language: Optional[str] = None,
         international: bool = False,
-        show_country: bool = None,
+        show_country: Optional[bool] = None,
         bare: bool = False,
         long_state: bool = False,
     ):
@@ -329,7 +329,7 @@ class ALAddress(Address):
             include_unit (bool): If True, includes the unit in the formatted address. Defaults to True.
             omit_default_country (bool): If True, omits the default country from the formatted address. Defaults to True.
             language (str, optional): Language for the address format.
-            show_country (bool, optional): If True, includes the country in the formatted address. 
+            show_country (bool, optional): If True, includes the country in the formatted address.
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
@@ -379,7 +379,7 @@ class ALAddress(Address):
             elif hasattr(self, "postal_code") and self.postal_code:
                 i18n_address["postal_code"] = str(self.postal_code)
             i18n_address["country_code"] = self._get_country()
-            return i18n_address.format_address(i18n_address).replace("\n", line_breaker)
+            return i18n_address.format_address(i18n_address).replace("\n", line_breaker)  # type: ignore
         output = ""
         if self.city_only is False:
             if (
@@ -418,7 +418,7 @@ class ALAddress(Address):
             output += line_breaker + country_name(self._get_country())
         return output
 
-    def line_one(self, language: str = None, bare: bool = False) -> str:
+    def line_one(self, language: Optional[str] = None, bare: bool = False) -> str:
         """Returns the first line of the address, including the unit number if it exists.
 
         Args:
@@ -449,7 +449,7 @@ class ALAddress(Address):
             output += ", " + the_unit
         return output
 
-    def line_two(self, language: str = None, long_state: bool = False) -> str:
+    def line_two(self, language: Optional[str] = None, long_state: bool = False) -> str:
         """Returns the second line of the address, including city, state, and postal code.
 
         Args:
@@ -491,7 +491,7 @@ class ALAddress(Address):
             include_unit (bool): If True, includes the unit in the formatted address. Defaults to True.
             omit_default_country (bool): If True, omits the default country from the formatted address. Defaults to True.
             language (str, optional): Language for the address format.
-            show_country (bool, optional): If True, includes the country in the formatted address. 
+            show_country (bool, optional): If True, includes the country in the formatted address.
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
@@ -554,8 +554,8 @@ class ALAddress(Address):
 
         If geocoding is successful, the method returns the "long" normalized version
         of the address. All methods, such as `my_address.normalized_address().block()`, are
-        still available on the returned object. However, note that the returned object will 
-        be a standard Address object, not an ALAddress object. If geocoding fails, it returns 
+        still available on the returned object. However, note that the returned object will
+        be a standard Address object, not an ALAddress object. If geocoding fails, it returns
         the version of the address as entered by the user.
 
         Returns:
@@ -570,7 +570,7 @@ class ALAddress(Address):
             return self.norm_long
         return self
 
-    def state_name(self, country_code: str = None) -> str:
+    def state_name(self, country_code: Optional[str] = None) -> str:
         """Returns the full state name based on the state abbreviation.
 
         If a `country_code` is provided, it will override the country attribute of the Address
@@ -581,7 +581,7 @@ class ALAddress(Address):
 
         Args:
             country_code (str, optional): ISO-3166-1 alpha-2 code to override the country attribute of
-            the Address object. For valid codes, refer to: 
+            the Address object. For valid codes, refer to:
             https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
 
         Returns:
@@ -607,8 +607,8 @@ class ALAddress(Address):
 class ALAddressList(DAList):
     """A class to store a list of ALAddress objects.
 
-    Extends the DAList class and specifically caters to ALAddress objects. 
-    It provides methods to initialize the list and get a string representation 
+    Extends the DAList class and specifically caters to ALAddress objects.
+    It provides methods to initialize the list and get a string representation
     of the list in a formatted manner.
     """
 
@@ -619,12 +619,12 @@ class ALAddressList(DAList):
     def __str__(self) -> str:
         """Provide a string representation of the ALAddressList.
 
-        This method returns the addresses in the list formatted in a 
+        This method returns the addresses in the list formatted in a
         comma-separated manner using the on_one_line method of ALAddress.
 
         Returns:
             str: Formatted string of all addresses in the list.
-        """        
+        """
         return comma_and_list([item.on_one_line() for item in self])
 
 
@@ -633,6 +633,7 @@ class ALNameList(DAList):
 
     Extends the DAList class and is tailored for IndividualName objects.
     """
+
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.object_type = IndividualName
@@ -647,8 +648,8 @@ class ALNameList(DAList):
 
 
 class ALPeopleList(DAList):
-    """Class to store a list of ALIndividual objects, representing people.
-    """
+    """Class to store a list of ALIndividual objects, representing people."""
+
     def init(self, *pargs, **kwargs):
         super(ALPeopleList, self).init(*pargs, **kwargs)
         self.object_type = ALIndividual
@@ -678,7 +679,7 @@ class ALPeopleList(DAList):
 
         Returns:
             str: Formatted string of familiar names.
-        """        
+        """
         return comma_and_list([person.name.familiar() for person in self])
 
     def familiar_or(self) -> str:
@@ -686,7 +687,7 @@ class ALPeopleList(DAList):
 
         Returns:
             str: Formatted string of familiar names separated by 'or'.
-        """        
+        """
         return comma_and_list(
             [person.name.familiar() for person in self], and_string=word("or")
         )
@@ -726,8 +727,8 @@ class ALPeopleList(DAList):
 class ALIndividual(Individual):
     """Used to represent an Individual on the assembly line project.
 
-    This class extends the Individual class and adds more tailored attributes and methods 
-    relevant for the assembly line project. Specifically, it has attributes for previous addresses, 
+    This class extends the Individual class and adds more tailored attributes and methods
+    relevant for the assembly line project. Specifically, it has attributes for previous addresses,
     other addresses, mailing addresses, previous names, aliases, and a preferred name.
 
     Attributes:
@@ -740,7 +741,7 @@ class ALIndividual(Individual):
         preferred_name (IndividualName): The preferred name.
 
     Note:
-        Objects as attributes should not be passed directly to the constructor due to 
+        Objects as attributes should not be passed directly to the constructor due to
         initialization requirements in the Docassemble framework. See the `init` method.
     """
 
@@ -783,13 +784,13 @@ class ALIndividual(Individual):
 
         Returns:
             Union[DAFile, str]: The signature if the condition is met, otherwise an empty string.
-        """        
+        """
         if i == "final":
             return self.signature
         else:
             return ""
 
-    def phone_numbers(self, country:Optional[str]=None) -> str:
+    def phone_numbers(self, country: Optional[str] = None) -> str:
         """Fetches and formats the phone numbers of the individual.
 
         Args:
@@ -797,7 +798,7 @@ class ALIndividual(Individual):
 
         Returns:
             str: Formatted string of phone numbers.
-        """        
+        """
         nums = []
         if hasattr(self, "mobile_number") and self.mobile_number:
             try:
@@ -872,7 +873,7 @@ class ALIndividual(Individual):
 
         Returns:
             str: Formatted age string in years, months, weeks, or days.
-        """        
+        """
         dd = date_difference(self.birthdate)
         if dd.years >= 2:
             return "%d years" % (int(dd.years),)
@@ -887,7 +888,7 @@ class ALIndividual(Individual):
 
         Returns:
             Union[Address, ALAddress]: The normalized address object.
-        """        
+        """
         return self.address.normalized_address()
 
     # This design helps us translate the prompts for common fields just once
@@ -906,7 +907,7 @@ class ALIndividual(Individual):
                 Default is "person".
             show_suffix (bool, optional): Determines if the name's suffix (e.g., Jr., Sr.) should be included in the prompts.
                 Default is True.
-            show_if (Union[str, Dict[str, str], None], optional): Condition to determine which fields to show. 
+            show_if (Union[str, Dict[str, str], None], optional): Condition to determine which fields to show.
                 It can be a string, a dictionary with conditions, or None. Default is None.
 
         Returns:
@@ -1031,7 +1032,7 @@ class ALIndividual(Individual):
     ) -> List[Dict[str, str]]:
         """
         Generate field prompts for capturing an address.
-        
+
         Args:
             country_code (str): The default country for the address. Defaults to "US".
             default_state (Optional[str]): Default state if applicable. Defaults to None.
@@ -1039,7 +1040,7 @@ class ALIndividual(Individual):
             show_county (bool): Whether to display the county field. Defaults to False.
             show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
             allow_no_address (bool): Whether to permit entries with no address. Defaults to False.
-        
+
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for addresses.
         """
@@ -1060,11 +1061,11 @@ class ALIndividual(Individual):
         """
         Generate fields for capturing gender information, including a
         self-described option.
-        
+
         Args:
             show_help (bool): Whether to show additional help text. Defaults to False.
             show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
-        
+
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for gender.
         """
@@ -1107,14 +1108,14 @@ class ALIndividual(Individual):
     ):
         """
         Generate fields for capturing pronoun information.
-        
+
         Args:
             show_help (bool): Whether to show additional help text. Defaults to False.
             show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
             required (bool): Whether the field is required. Defaults to False.
             shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
             show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
-        
+
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
@@ -1160,9 +1161,9 @@ class ALIndividual(Individual):
     def get_pronouns(self) -> set:
         """
         Retrieve a set of the individual's pronouns.
-        
+
         If the individual has selected the "self-described" option, it will use their custom input.
-        
+
         Returns:
             set: A set of strings representing the individual's pronouns.
         """
@@ -1181,12 +1182,12 @@ class ALIndividual(Individual):
     ):
         """
         Generate fields for capturing language preferences.
-        
+
         Args:
             choices (Optional[List[Dict[str, str]]]): A list of language choices. Defaults to None.
             style (str): The display style of choices. Defaults to "radio".
             show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
-        
+
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for language preferences.
         """
@@ -1220,8 +1221,8 @@ class ALIndividual(Individual):
         Get the human-readable version of the individual's selected language.
 
         Returns:
-            str: The human-readable version of the language. If 'other' is selected, 
-            it returns the value in `language_other`. Otherwise, it uses the 
+            str: The human-readable version of the language. If 'other' is selected,
+            it returns the value in `language_other`. Otherwise, it uses the
             `language_name` function.
         """
         if self.language == "other":
@@ -1234,7 +1235,7 @@ class ALIndividual(Individual):
         """
         Check if the gender is male.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1247,19 +1248,20 @@ class ALIndividual(Individual):
         """
         Check if the gender is female.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
             bool: True if gender is 'female', False otherwise.
-        """        return self.gender.lower() == "female"
+        """
+        return self.gender.lower() == "female"
 
     @property
     def gender_other(self):
         """
         Check if the gender is not male or female.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1272,7 +1274,7 @@ class ALIndividual(Individual):
         """
         Check if the gender is nonbinary.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1285,7 +1287,7 @@ class ALIndividual(Individual):
         """
         Check if the gender is unknown.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1298,7 +1300,7 @@ class ALIndividual(Individual):
         """
         Check if the gender is not disclosed.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1311,7 +1313,7 @@ class ALIndividual(Individual):
         """
         Check if the gender is self described.
 
-        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
 
         Returns:
@@ -1354,7 +1356,7 @@ class ALIndividual(Individual):
 
         Returns:
             str: The formatted address block.
-        """        
+        """
         if this_thread.evaluation_context == "docx":
             return (
                 self.name.full()
@@ -1567,7 +1569,7 @@ class ALIndividual(Individual):
 
 
 # (DANav isn't in public DA API, but currently in functions.py)
-def section_links(nav) -> List[str]: #type: ignore 
+def section_links(nav) -> List[str]:  # type: ignore
     """Returns a list of clickable navigation links without animation."""
     sections = nav.get_sections()
     section_link = []
@@ -1788,10 +1790,10 @@ def language_name(language_code: str) -> str:
     """Given a 2 digit language code abbreviation, returns the full
     name of the language. The language name will be passed through the `word()`
     function.
-    
+
     Args:
         language_code (str): A 2 digit language code abbreviation.
-    
+
     Returns:
         str: The full name of the language.
     """
@@ -1808,10 +1810,10 @@ def language_name(language_code: str) -> str:
 def safe_states_list(country_code: str) -> List[Dict[str, str]]:
     """Wrapper around states_list that doesn't error if passed
     an invalid country_code (e.g., a country name spelled out)
-    
+
     Args:
         country_code (str): A 2 digit country code abbreviation.
-    
+
     Returns:
         List[Dict[str, str]]: A list of dictionaries with field prompts for states.
     """

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -581,8 +581,8 @@ class ALAddress(Address):
 
         Args:
             country_code (str, optional): ISO-3166-1 alpha-2 code to override the country attribute of
-            the Address object. For valid codes, refer to:
-            https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
+                the Address object. For valid codes, refer to:
+                https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
 
         Returns:
             str: The full state name corresponding to the state abbreviation. If an error occurs
@@ -694,7 +694,7 @@ class ALPeopleList(DAList):
             [person.name.familiar() for person in self], and_string=word("or")
         )
 
-    def short_list(self, limit: int, truncate_string: str = ", et. al."):
+    def short_list(self, limit: int, truncate_string: str = ", et. al.") -> str:
         """Return a subset of the list, truncated with 'et. al.' if it exceeds a given limit.
 
         Args:
@@ -709,7 +709,7 @@ class ALPeopleList(DAList):
         else:
             return comma_and_list(self)
 
-    def full_names(self, comma_string=", ", and_string=word("and")):
+    def full_names(self, comma_string=", ", and_string=word("and")) -> str:
         """Return a formatted list of full names of individuals.
 
         Args:
@@ -859,9 +859,18 @@ class ALIndividual(Individual):
             and_string=word("or"),
         )
 
-    def merge_letters(self, new_letters: str):
+    def merge_letters(self, new_letters: str) -> str:
+        """If the Individual has a child_letters attribute, add the new letters to the existing list
+        
+        Avoid using. Only used in 209A.
+
+        Args:
+            new_letters (str): The new letters to add to the existing list of letters
+        
+        Returns:
+            str: The updated list of letters
+        """
         # TODO: move to 209A package
-        """If the Individual has a child_letters attribute, add the new letters to the existing list"""
         if hasattr(self, "child_letters"):
             self.child_letters: str = filter_letters([new_letters, self.child_letters])
         else:
@@ -1056,7 +1065,7 @@ class ALIndividual(Individual):
 
     def gender_fields(
         self, show_help=False, show_if: Union[str, Dict[str, str], None] = None
-    ):
+    ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing gender information, including a
         self-described option.
@@ -1104,7 +1113,7 @@ class ALIndividual(Individual):
         required: bool = False,
         shuffle: bool = False,
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
-    ):
+    ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing pronoun information.
 
@@ -1178,7 +1187,7 @@ class ALIndividual(Individual):
         choices: Optional[List[Dict[str, str]]] = None,
         style: str = "radio",
         show_if: Union[str, Dict[str, str], None] = None,
-    ):
+    ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing language preferences.
 
@@ -1215,7 +1224,7 @@ class ALIndividual(Individual):
             fields[0]["show if"] = show_if
         return fields
 
-    def language_name(self):
+    def language_name(self) -> str:
         """
         Get the human-readable version of the individual's selected language.
 
@@ -1232,98 +1241,77 @@ class ALIndividual(Individual):
     @property
     def gender_male(self):
         """
-        Check if the gender is male.
+        Returns True only if the gender is male.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is 'male', False otherwise.
         """
         return self.gender.lower() == "male"
 
     @property
     def gender_female(self):
         """
-        Check if the gender is female.
+        Returns True only if the gender is female.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is 'female', False otherwise.
         """
         return self.gender.lower() == "female"
 
     @property
     def gender_other(self):
         """
-        Check if the gender is not male or female.
+        Returns True only if the gender is not male or female.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is neither 'male' or 'female', False otherwise.
         """
         return (self.gender != "male") and (self.gender != "female")
 
     @property
     def gender_nonbinary(self):
         """
-        Check if the gender is nonbinary.
+        Returns True only if the gender is nonbinary.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is 'nobinary', False otherwise.
         """
         return self.gender.lower() == "nonbinary"
 
     @property
     def gender_unknown(self):
         """
-        Check if the gender is unknown.
+        Returns True only if the gender is unknown.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is 'unknown', False otherwise.
         """
         return self.gender.lower() == "unknown"
 
     @property
     def gender_undisclosed(self):
         """
-        Check if the gender is not disclosed.
+        Returns True only if the gender is not disclosed.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is 'prefer-not-to-say', False otherwise.
         """
         return self.gender.lower() == "prefer-not-to-say"
 
     @property
     def gender_self_described(self):
         """
-        Check if the gender is self described.
+        Returns True only if the gender is self described.
 
         Used to assist with checkbox filling in PDFs with "skip undefined"
         turned on.
-
-        Returns:
-            bool: True if gender is none of the Assembly Line's pre-defined choices, False otherwise.
         """
         return not (
             self.gender
             in ["prefer-not-to-say", "male", "female", "unknown", "nonbinary"]
         )
 
-    def contact_fields(self):
+    def contact_fields(self) -> None:
         """
         Return field prompts for other contact info
         """
@@ -1332,12 +1320,9 @@ class ALIndividual(Individual):
     @property
     def initials(self):
         """
-        Compute the initials of the individual.
+        Return the initials of the individual as a string.
 
         For example, "Quinten K Steenhuis" would return "QKS".
-
-        Returns:
-            str: The initials extracted from the individual's name.
         """
         return f"{self.name.first[:1]}{self.name.middle[:1] if hasattr(self.name,'middle') else ''}{self.name.last[:1] if hasattr(self.name, 'last') else ''}"
 
@@ -1569,7 +1554,14 @@ class ALIndividual(Individual):
 
 # (DANav isn't in public DA API, but currently in functions.py)
 def section_links(nav) -> List[str]:  # type: ignore
-    """Returns a list of clickable navigation links without animation."""
+    """Returns a list of clickable navigation links without animation.
+    
+    Args:
+        nav: The navigation object.
+
+    Returns:
+        List[str]: A list of clickable navigation links without animation.
+    """
     sections = nav.get_sections()
     section_link = []
     for section in sections:
@@ -1637,6 +1629,9 @@ def will_send_to_real_court() -> bool:
     is being run on the dev, test, or production server.
 
     The text "dev" or "test" needs to be in the URL root in the DA config: can change in `/config`.
+
+    Returns:
+        bool: True if the form is being run on the dev, test, or production server.
     """
     return not (
         get_config("debug")
@@ -1649,7 +1644,16 @@ def will_send_to_real_court() -> bool:
 # TODO: move to 209A package
 # This one is only used for 209A--should move there along with the combined_letters() method
 def filter_letters(letter_strings: Union[List[str], str]) -> str:
-    """Used to take a list of letters like ["A","ABC","AB"] and filter out any duplicate letters."""
+    """Used to take a list of letters like ["A","ABC","AB"] and filter out any duplicate letters.
+    
+    Avoid using, this is created for 209A.
+
+    Args:
+        letter_strings (Union[List[str], str]): A list of letters.
+
+    Returns:
+        str: A string of unique letters.
+    """
     # There is probably a cute one liner, but this is easy to follow and
     # probably same speed
     unique_letters = set()
@@ -1671,7 +1675,7 @@ def filter_letters(letter_strings: Union[List[str], str]) -> str:
 
 def fa_icon(
     icon: str, color: str = "primary", color_css: Optional[str] = None, size: str = "sm"
-):
+) -> str:
     """
     Return HTML for a font-awesome icon of the specified size and color. You can reference
     a CSS variable (such as Bootstrap theme color) or a true CSS color reference, such as 'blue' or

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -71,7 +71,17 @@ __all__ = [
 # Base classes
 
 
-def safe_subdivision_type(country_code):
+def safe_subdivision_type(country_code: str) -> Optional[str]:
+    """
+    Returns the subdivision type for the country with the given country code.
+    If no subdivision type is found, returns None.
+    
+    Args:
+        country_code (str): The ISO-3166-1 alpha-2 code for the country.
+    
+    Returns:
+        str: The subdivision type for the country with the given country code.
+    """
     try:
         return subdivision_type(country_code)
     except:
@@ -79,10 +89,19 @@ def safe_subdivision_type(country_code):
 
 
 class ALAddress(Address):
-    # Future-proofing TODO: this class can be used to help handle international addresses in the future.
-    # Most likely, ask for international address as just 3 unstructured lines. Key thing is
-    # the built-in address object requires some fields to be defined that we don't want to require of
-    # international addresses when you want to render it to text.
+    """
+    This class is used to store addresses. The ALAddress class extends the Address
+    class with the `address_fields()` method and "smarter"
+    handling of the unit attribute when printing a formatted address.
+
+    Attributes:
+        address (str): The street where the person lives.
+        unit (str): The unit number where the person lives.
+        city (str): The city where the person lives.
+        state (str): The state where the person lives.
+        zip (str): The zip code where the person lives.
+        country (str): The country where the person lives.
+    """
 
     def address_fields(
         self,
@@ -92,25 +111,38 @@ class ALAddress(Address):
         show_county: bool = False,
         show_if: Union[str, Dict[str, str], None] = None,
         allow_no_address: bool = False,
-    ):
+    ) -> List[Dict[str, Any]]:
         """
-            Return a YAML structure representing the list of fields for the object's address.
-            Optionally, allow the user to specify they do not have an address.
-            NOTE: if you set allow_no_address to True, you must make sure to trigger
-            the question with `users[0].address.has_no_address` rather than
-            `users[0].address.address`.
-            Optionally, add a `show if` modifier to each field. The `show if` modifier
-            will not be used if the `allow_no_address` modifier is used.
-        `country_code` should be an ISO-3166-1 alpha-2 code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+        Return a YAML structure representing the list of fields for the object's address.
+        
+        Optionally, allow the user to specify they do not have an address. When using 
+        `allow_no_address=True`, ensure to trigger the question with `users[0].address.has_no_address` 
+        rather than `users[0].address.address`. If `show_if` is used, it will not be applied when 
+        `allow_no_address` is also used. Ensure `country_code` adheres to ISO-3166-1 alpha-2 code standard.
 
-            NOTE: address_fields() is stateful if you:
-            1. Use the `country_code` parameter and;
-            1. Do not use the `show_country` parameter, and
-            1. `country_code` has a different value than `get_country()`.
+        NOTE: This function is stateful under specific conditions. Refer to the conditions mentioned below.
 
-            Under these circumstances, address_fields() will set the `country` attribute of the Address
-            to `country_code`.
-        """
+        Args:
+            country_code (Optional[str]): ISO-3166-1 alpha-2 code of the country. Defaults to None.
+            default_state (Optional[str]): Default state to set. Defaults to None.
+            show_country (bool): Whether to display the country field. Defaults to False.
+            show_county (bool): Whether to display the county field. Defaults to False.
+            show_if (Union[str, Dict[str, str], None]): Condition to display each field. Defaults to None.
+            allow_no_address (bool): Allow users to specify they don't have an address. Defaults to False.
+
+        Returns:
+            list: A list of YAML structure representing address fields.
+
+        Notes:
+            - The function will set the `country` attribute of the Address to `country_code` under these 
+            circumstances:
+                1. The `country_code` parameter is used.
+                2. The `show_country` parameter is not used.
+                3. `country_code` differs from the value returned by `get_country()`.
+
+            - Link to ISO-3166-1 alpha-2 codes: 
+            [Officially assigned code elements](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements).
+        """        
         # make sure the state name still returns a meaningful value if the interview country
         # differs from the server's country.
         if country_code and country_code != get_country() and not show_country:
@@ -285,13 +317,26 @@ class ALAddress(Address):
 
     def block(
         self,
-        language=None,
-        international=False,
-        show_country=None,
-        bare=False,
-        long_state=False,
+        language: str = None,
+        international: bool = False,
+        show_country: bool = None,
+        bare: bool = False,
+        long_state: bool = False,
     ):
-        """Returns the address formatted as a block, as in a mailing."""
+        """Returns a one-line formatted address, primarily for geocoding.
+
+        Args:
+            include_unit (bool): If True, includes the unit in the formatted address. Defaults to True.
+            omit_default_country (bool): If True, omits the default country from the formatted address. Defaults to True.
+            language (str, optional): Language for the address format.
+            show_country (bool, optional): If True, includes the country in the formatted address. 
+                If None, decides based on the country attribute.
+            bare (bool): If True, excludes certain formatting elements. Defaults to False.
+            long_state (bool): If True, uses the full state name. Defaults to False.
+
+        Returns:
+            str: The one-line formatted address.
+        """
         if this_thread.evaluation_context == "docx":
             line_breaker = '</w:t><w:br/><w:t xml:space="preserve">'
         else:
@@ -373,9 +418,16 @@ class ALAddress(Address):
             output += line_breaker + country_name(self._get_country())
         return output
 
-    def line_one(self, language=None, bare=False):
-        """Returns the first line of the address, including the unit
-        number if there is one."""
+    def line_one(self, language: str = None, bare: bool = False) -> str:
+        """Returns the first line of the address, including the unit number if it exists.
+
+        Args:
+            language (str, optional): Language for the address format.
+            bare (bool): If True, excludes certain formatting elements. Defaults to False.
+
+        Returns:
+            str: The first line of the address.
+        """
         if (
             hasattr(self, "has_no_address")
             and self.has_no_address
@@ -397,9 +449,16 @@ class ALAddress(Address):
             output += ", " + the_unit
         return output
 
-    def line_two(self, language=None, long_state=False):
-        """Returns the second line of the address, including the city,
-        state and zip code."""
+    def line_two(self, language: str = None, long_state: bool = False) -> str:
+        """Returns the second line of the address, including city, state, and postal code.
+
+        Args:
+            language (str, optional): Language for the address format.
+            long_state (bool): If True, uses the full state name. Defaults to False.
+
+        Returns:
+            str: The second line of the address.
+        """
         output = ""
         # if hasattr(self, 'sublocality') and self.sublocality:
         #    output += str(self.sublocality) + ", "
@@ -419,14 +478,27 @@ class ALAddress(Address):
 
     def on_one_line(
         self,
-        include_unit=True,
-        omit_default_country=True,
-        language=None,
-        show_country=None,
-        bare=False,
-        long_state=False,
-    ):
-        """Returns a one-line address.  Primarily used internally for geocoding."""
+        include_unit: bool = True,
+        omit_default_country: bool = True,
+        language: Optional[str] = None,
+        show_country: Optional[bool] = None,
+        bare: bool = False,
+        long_state: bool = False,
+    ) -> str:
+        """Returns a one-line formatted address.
+
+        Args:
+            include_unit (bool): If True, includes the unit in the formatted address. Defaults to True.
+            omit_default_country (bool): If True, omits the default country from the formatted address. Defaults to True.
+            language (str, optional): Language for the address format.
+            show_country (bool, optional): If True, includes the country in the formatted address. 
+                If None, decides based on the country attribute.
+            bare (bool): If True, excludes certain formatting elements. Defaults to False.
+            long_state (bool): If True, uses the full state name. Defaults to False.
+
+        Returns:
+            str: The one-line formatted address.
+        """
         if (
             hasattr(self, "has_no_address")
             and self.has_no_address
@@ -449,8 +521,7 @@ class ALAddress(Address):
                     output += ", " + the_unit
             if output != "":
                 output += ", "
-        # if hasattr(self, 'sublocality') and self.sublocality:
-        #    output += str(self.sublocality) + ", "
+
         if hasattr(self, "sublocality_level_1") and self.sublocality_level_1:
             if not (
                 hasattr(self, "street_number")
@@ -479,12 +550,17 @@ class ALAddress(Address):
         return output
 
     def normalized_address(self) -> Union[Address, "ALAddress"]:
-        """
-        Try geocoding the address, and if it succeeds, return the "long" normalized version of
-        the address. All methods are still available, such as my_address.normalized_address().block(), etc.,
-        but note that this will be a standard Address object, not an ALAddress object.
+        """Try geocoding the address, returning the normalized version if successful.
 
-        If geocoding fails, return the version of the address as entered by the user instead.
+        If geocoding is successful, the method returns the "long" normalized version
+        of the address. All methods, such as `my_address.normalized_address().block()`, are
+        still available on the returned object. However, note that the returned object will 
+        be a standard Address object, not an ALAddress object. If geocoding fails, it returns 
+        the version of the address as entered by the user.
+
+        Returns:
+            Union[Address, "ALAddress"]: Normalized address if geocoding is successful, otherwise
+            the original address.
         """
         try:
             self.geocode()
@@ -494,18 +570,23 @@ class ALAddress(Address):
             return self.norm_long
         return self
 
-    def state_name(self, country_code=None):
-        """
-        Return the full state name associated with the Address object's state abbreviation.
+    def state_name(self, country_code: str = None) -> str:
+        """Returns the full state name based on the state abbreviation.
 
-        If provided, the `country_code` parameter will override the country attribute of the
-        Address object. If omitted, it will use in order:
+        If a `country_code` is provided, it will override the country attribute of the Address
+        object. Otherwise, the method uses, in order:
 
         1. The country code associated with the Address object, and then
-        2. The country set in the global config for the server
+        2. The country set in the global config for the server.
 
-        `country_code` should be an ISO-3166-1 alpha-2 code
-        (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements)
+        Args:
+            country_code (str, optional): ISO-3166-1 alpha-2 code to override the country attribute of
+            the Address object. For valid codes, refer to: 
+            https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
+
+        Returns:
+            str: The full state name corresponding to the state abbreviation. If an error occurs
+            or the full name cannot be determined, returns the state abbreviation.
         """
         if country_code:
             return state_name(self.state, country_code=country_code)
@@ -524,30 +605,50 @@ class ALAddress(Address):
 
 
 class ALAddressList(DAList):
-    """Store a list of Address objects"""
+    """A class to store a list of ALAddress objects.
+
+    Extends the DAList class and specifically caters to ALAddress objects. 
+    It provides methods to initialize the list and get a string representation 
+    of the list in a formatted manner.
+    """
 
     def init(self, *pargs, **kwargs):
         super(ALAddressList, self).init(*pargs, **kwargs)
         self.object_type = ALAddress
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Provide a string representation of the ALAddressList.
+
+        This method returns the addresses in the list formatted in a 
+        comma-separated manner using the on_one_line method of ALAddress.
+
+        Returns:
+            str: Formatted string of all addresses in the list.
+        """        
         return comma_and_list([item.on_one_line() for item in self])
 
 
 class ALNameList(DAList):
-    """Store a list of IndividualNames"""
+    """A class to store a list of IndividualName objects.
 
+    Extends the DAList class and is tailored for IndividualName objects.
+    """
     def init(self, *pargs, **kwargs):
         super().init(*pargs, **kwargs)
         self.object_type = IndividualName
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Provide a string representation of the ALNameList.
+
+        Returns:
+            str: Formatted string of all names in the list.
+        """
         return comma_list(self)
 
 
 class ALPeopleList(DAList):
-    """Used to represent a list of people. E.g., defendants, plaintiffs, children"""
-
+    """Class to store a list of ALIndividual objects, representing people.
+    """
     def init(self, *pargs, **kwargs):
         super(ALPeopleList, self).init(*pargs, **kwargs)
         self.object_type = ALIndividual
@@ -555,7 +656,15 @@ class ALPeopleList(DAList):
     def names_and_addresses_on_one_line(
         self, comma_string: str = "; ", bare=False
     ) -> str:
-        """Returns the name of each person followed by their address, separated by a semicolon"""
+        """Provide names and addresses of individuals on one line.
+
+        Args:
+            comma_string (str, optional): The string to use between name-address pairs. Defaults to '; '.
+            bare (bool, optional): If True, represents the address in a minimalistic way. Defaults to False.
+
+        Returns:
+            str: Formatted string of names followed by addresses.
+        """
         return comma_and_list(
             [
                 str(person) + ", " + person.address.on_one_line(bare=bare)
@@ -565,16 +674,32 @@ class ALPeopleList(DAList):
         )
 
     def familiar(self) -> str:
+        """Provide a list of familiar forms of names of individuals.
+
+        Returns:
+            str: Formatted string of familiar names.
+        """        
         return comma_and_list([person.name.familiar() for person in self])
 
     def familiar_or(self) -> str:
+        """Provide a list of familiar forms of names of individuals separated by 'or'.
+
+        Returns:
+            str: Formatted string of familiar names separated by 'or'.
+        """        
         return comma_and_list(
             [person.name.familiar() for person in self], and_string=word("or")
         )
 
     def short_list(self, limit: int, truncate_string: str = ", et. al."):
-        """Return a subset of the list, as as string with a comma separating items, followed by 'et. al.' if the list exceeds the provided limit.
-        Otherwise just return the items in the list.
+        """Return a subset of the list, truncated with 'et. al.' if it exceeds a given limit.
+
+        Args:
+            limit (int): The maximum number of items to display before truncating.
+            truncate_string (str, optional): The string to append when truncating. Defaults to ', et. al.'.
+
+        Returns:
+            str: Formatted string of names, truncated if needed.
         """
         if len(self) > limit:
             return comma_and_list(self[:limit]) + truncate_string
@@ -582,10 +707,14 @@ class ALPeopleList(DAList):
             return comma_and_list(self)
 
     def full_names(self, comma_string=", ", and_string=word("and")):
-        """
-        Return a formatted list of names in the PeopleList, without shortening middle name to an initial.
-        Optional parameters `comma_string` and `and_string` will be passed to `comma_and_list` and allow
-        you to change the list separator and the word before the final list item, respectively.
+        """Return a formatted list of full names of individuals.
+
+        Args:
+            comma_string (str, optional): The string to use between names. Defaults to ','.
+            and_string (str, optional): The string to use before the last name in the list. Defaults to 'and'.
+
+        Returns:
+            str: Formatted string of full names.
         """
         return comma_and_list(
             [person.name.full(middle="full") for person in self],
@@ -596,8 +725,23 @@ class ALPeopleList(DAList):
 
 class ALIndividual(Individual):
     """Used to represent an Individual on the assembly line project.
-    Two custom attributes are objects and so we need to initialize: `previous_addresses`
-    and `other_addresses`
+
+    This class extends the Individual class and adds more tailored attributes and methods 
+    relevant for the assembly line project. Specifically, it has attributes for previous addresses, 
+    other addresses, mailing addresses, previous names, aliases, and a preferred name.
+
+    Attributes:
+        previous_addresses (ALAddressList): List of previous addresses.
+        other_addresses (ALAddressList): List of other addresses.
+        mailing_address (ALAddress): Current mailing address.
+        service_address (ALAddress): Service address.
+        previous_names (ALNameList): List of previous names.
+        aliases (ALNameList): List of aliases.
+        preferred_name (IndividualName): The preferred name.
+
+    Note:
+        Objects as attributes should not be passed directly to the constructor due to 
+        initialization requirements in the Docassemble framework. See the `init` method.
     """
 
     previous_addresses: ALAddressList
@@ -632,12 +776,28 @@ class ALIndividual(Individual):
             self.initializeAttribute("preferred_name", IndividualName)
 
     def signature_if_final(self, i: str) -> Union[DAFile, str]:
+        """Returns the individual's signature if a condition is met.
+
+        Args:
+            i (str): The condition which, if set to "final", returns the signature.
+
+        Returns:
+            Union[DAFile, str]: The signature if the condition is met, otherwise an empty string.
+        """        
         if i == "final":
             return self.signature
         else:
             return ""
 
-    def phone_numbers(self, country=None) -> str:
+    def phone_numbers(self, country:Optional[str]=None) -> str:
+        """Fetches and formats the phone numbers of the individual.
+
+        Args:
+            country (str, optional): The country for phone number formatting.
+
+        Returns:
+            str: Formatted string of phone numbers.
+        """        
         nums = []
         if hasattr(self, "mobile_number") and self.mobile_number:
             try:
@@ -674,12 +834,10 @@ class ALIndividual(Individual):
             return ""
 
     def contact_methods(self) -> str:
-        """Method to return a formatted string with all provided contact methods of the individual:
-            * Phone number(s)
-            * Email
-            * other method
+        """Generates a formatted string of all provided contact methods.
+
         Returns:
-            str: Formatted string
+            str: A formatted string indicating the available methods to contact the individual.
         """
         methods = []
         if self.phone_numbers():
@@ -699,6 +857,9 @@ class ALIndividual(Individual):
         )
 
     def merge_letters(self, new_letters: str):
+        """
+        Very specific to 209A package, should be removed.
+        """
         # TODO: move to 209A package
         """If the Individual has a child_letters attribute, add the new letters to the existing list"""
         if hasattr(self, "child_letters"):
@@ -707,6 +868,11 @@ class ALIndividual(Individual):
             self.child_letters = filter_letters(new_letters)
 
     def formatted_age(self) -> str:
+        """Calculates and formats the age of the individual based on their birthdate.
+
+        Returns:
+            str: Formatted age string in years, months, weeks, or days.
+        """        
         dd = date_difference(self.birthdate)
         if dd.years >= 2:
             return "%d years" % (int(dd.years),)
@@ -717,6 +883,11 @@ class ALIndividual(Individual):
         return "%d days" % (int(dd.days),)
 
     def normalized_address(self) -> Union[Address, ALAddress]:
+        """Fetches the normalized version of the address.
+
+        Returns:
+            Union[Address, ALAddress]: The normalized address object.
+        """        
         return self.address.normalized_address()
 
     # This design helps us translate the prompts for common fields just once
@@ -727,8 +898,23 @@ class ALIndividual(Individual):
         show_if: Union[str, Dict[str, str], None] = None,
     ) -> List[Dict[str, str]]:
         """
-        Return suitable field prompts for a name. If `person_or_business` is None, adds the
-        proper "show ifs" and uses both the parts and the single entry
+        Generates suitable field prompts for a name based on the type of entity (person or business)
+        and other provided parameters.
+
+        Args:
+            person_or_business (str, optional): Specifies the entity type. It can either be "person" or "business".
+                Default is "person".
+            show_suffix (bool, optional): Determines if the name's suffix (e.g., Jr., Sr.) should be included in the prompts.
+                Default is True.
+            show_if (Union[str, Dict[str, str], None], optional): Condition to determine which fields to show. 
+                It can be a string, a dictionary with conditions, or None. Default is None.
+
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries where each dictionary contains field prompt details.
+
+        Note:
+            If `person_or_business` is set to None, the method will consider both entity types (i.e., "person" and "business")
+            and will set appropriate "show ifs" conditions for each type.
         """
         if person_or_business == "person":
             fields = [
@@ -844,7 +1030,18 @@ class ALIndividual(Individual):
         allow_no_address: bool = False,
     ) -> List[Dict[str, str]]:
         """
-        Return field prompts for address.
+        Generate field prompts for capturing an address.
+        
+        Args:
+            country_code (str): The default country for the address. Defaults to "US".
+            default_state (Optional[str]): Default state if applicable. Defaults to None.
+            show_country (bool): Whether to display the country field. Defaults to False.
+            show_county (bool): Whether to display the county field. Defaults to False.
+            show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
+            allow_no_address (bool): Whether to permit entries with no address. Defaults to False.
+        
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries with field prompts for addresses.
         """
         # TODO make this more flexible to work w/ homeless individuals and
         # international addresses
@@ -861,7 +1058,15 @@ class ALIndividual(Individual):
         self, show_help=False, show_if: Union[str, Dict[str, str], None] = None
     ):
         """
-        Return a standard gender input with "self described" option.
+        Generate fields for capturing gender information, including a
+        self-described option.
+        
+        Args:
+            show_help (bool): Whether to show additional help text. Defaults to False.
+            show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
+        
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries with field prompts for gender.
         """
         choices = [
             {str(self.gender_female_label): "female"},
@@ -901,9 +1106,17 @@ class ALIndividual(Individual):
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
     ):
         """
-        Return a standard multiple choice checkbox pronouns input with a "self described" option.
-
-        Options are shuffled by default.
+        Generate fields for capturing pronoun information.
+        
+        Args:
+            show_help (bool): Whether to show additional help text. Defaults to False.
+            show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
+            required (bool): Whether the field is required. Defaults to False.
+            shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
+            show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
+        
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
         shuffled_choices = [
             {str(self.pronoun_she_label): "she/her/hers"},
@@ -946,12 +1159,12 @@ class ALIndividual(Individual):
 
     def get_pronouns(self) -> set:
         """
-        Return a set of the individual's pronouns. If the individual's
-        pronouns include self-described pronouns, display those in place of the word "self-described".
-
-        The set can be displayed in the interview or in a template. For example:
-
-        Pronouns: {{ users[0].get_pronouns() | comma_and_list }}
+        Retrieve a set of the individual's pronouns.
+        
+        If the individual has selected the "self-described" option, it will use their custom input.
+        
+        Returns:
+            set: A set of strings representing the individual's pronouns.
         """
         if self.pronouns.all_false():
             return {str(self.pronoun_prefer_not_to_say_label)}
@@ -966,7 +1179,17 @@ class ALIndividual(Individual):
         style: str = "radio",
         show_if: Union[str, Dict[str, str], None] = None,
     ):
-        """Return a standard language picker with an "other" input. Language should be specified as ISO 639-2 or -3 codes so it is compatible with the language_name() function."""
+        """
+        Generate fields for capturing language preferences.
+        
+        Args:
+            choices (Optional[List[Dict[str, str]]]): A list of language choices. Defaults to None.
+            style (str): The display style of choices. Defaults to "radio".
+            show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
+        
+        Returns:
+            List[Dict[str, str]]: A list of dictionaries with field prompts for language preferences.
+        """
         if not choices:
             choices = [
                 {"English": "en"},
@@ -993,7 +1216,14 @@ class ALIndividual(Individual):
         return fields
 
     def language_name(self):
-        """Return the human-readable version of the individual's language, handling the "other" option."""
+        """
+        Get the human-readable version of the individual's selected language.
+
+        Returns:
+            str: The human-readable version of the language. If 'other' is selected, 
+            it returns the value in `language_other`. Otherwise, it uses the 
+            `language_name` function.
+        """
         if self.language == "other":
             return self.language_other
         else:
@@ -1001,45 +1231,92 @@ class ALIndividual(Individual):
 
     @property
     def gender_male(self):
-        """Provide True/False for 'male' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
+        """
+        Check if the gender is male.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is 'male', False otherwise.
+        """
         return self.gender.lower() == "male"
 
     @property
     def gender_female(self):
-        """Provide True/False for 'female' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
-        return self.gender.lower() == "female"
+        """
+        Check if the gender is female.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is 'female', False otherwise.
+        """        return self.gender.lower() == "female"
 
     @property
     def gender_other(self):
-        """Provide True/False for 'other' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on for forms without more inclusive options.
+        """
+        Check if the gender is not male or female.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is neither 'male' or 'female', False otherwise.
         """
         return (self.gender != "male") and (self.gender != "female")
 
     @property
     def gender_nonbinary(self):
-        """Provide True/False for 'nonbinary' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
+        """
+        Check if the gender is nonbinary.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is 'nobinary', False otherwise.
+        """
         return self.gender.lower() == "nonbinary"
 
     @property
     def gender_unknown(self):
-        """Provide True/False for 'unknown' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
+        """
+        Check if the gender is unknown.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is 'unknown', False otherwise.
+        """
         return self.gender.lower() == "unknown"
 
     @property
     def gender_undisclosed(self):
-        """Provide True/False for 'prefer-not-to-say' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
+        """
+        Check if the gender is not disclosed.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is 'prefer-not-to-say', False otherwise.
+        """
         return self.gender.lower() == "prefer-not-to-say"
 
     @property
     def gender_self_described(self):
-        """Provide True/False for 'self-described' gender to assist with checkbox filling
-        in PDFs with "skip undefined" turned on."""
+        """
+        Check if the gender is self described.
+
+        Used to assist with checkbox filling in PDFs with "skip undefined" 
+        turned on.
+
+        Returns:
+            bool: True if gender is none of the Assembly Line's pre-defined choices, False otherwise.
+        """
         return not (
             self.gender
             in ["prefer-not-to-say", "male", "female", "unknown", "nonbinary"]
@@ -1053,13 +1330,31 @@ class ALIndividual(Individual):
 
     @property
     def initials(self):
-        """Return the individual's initials, like QKS for Quinten K Steenhuis"""
+        """
+        Compute the initials of the individual.
+
+        For example, "Quinten K Steenhuis" would return "QKS".
+
+        Returns:
+            str: The initials extracted from the individual's name.
+        """
         return f"{self.name.first[:1]}{self.name.middle[:1] if hasattr(self.name,'middle') else ''}{self.name.last[:1] if hasattr(self.name, 'last') else ''}"
 
     def address_block(
         self, language=None, international=False, show_country=False, bare=False
     ):
-        """Returns the person name address as a block, for use in mailings."""
+        """
+        Generate a formatted address block for mailings.
+
+        Args:
+            language (Optional): The language in which the address is written.
+            international (bool): If True, format for international mailing. Defaults to False.
+            show_country (bool): If True, include the country in the address. Defaults to False.
+            bare (bool): If True, produce the address without additional formatting. Defaults to False.
+
+        Returns:
+            str: The formatted address block.
+        """        
         if this_thread.evaluation_context == "docx":
             return (
                 self.name.full()
@@ -1271,7 +1566,8 @@ class ALIndividual(Individual):
         return output
 
 
-def section_links(nav) -> List[str]:
+# (DANav isn't in public DA API, but currently in functions.py)
+def section_links(nav) -> List[str]: #type: ignore 
     """Returns a list of clickable navigation links without animation."""
     sections = nav.get_sections()
     section_link = []
@@ -1335,7 +1631,12 @@ class PeopleList(ALPeopleList):
 
 
 def will_send_to_real_court() -> bool:
-    """Dev or root needs to be in the URL root: can change in the config file"""
+    """
+    For legacy email to court forms, this checks to see if the form
+    is being run on the dev, test, or production server.
+
+    Dev or root needs to be in the URL root: can change in the config file
+    """
     return not (
         get_config("debug")
         or "dev" in get_config("url root")
@@ -1344,6 +1645,7 @@ def will_send_to_real_court() -> bool:
     )
 
 
+# TODO: move to 209A package
 # This one is only used for 209A--should move there along with the combined_letters() method
 def filter_letters(letter_strings: Union[List[str], str]) -> str:
     """Used to take a list of letters like ["A","ABC","AB"] and filter out any duplicate letters."""
@@ -1373,6 +1675,15 @@ def fa_icon(
     Return HTML for a font-awesome icon of the specified size and color. You can reference
     a CSS variable (such as Bootstrap theme color) or a true CSS color reference, such as 'blue' or
     '#DDDDDD'. Defaults to Bootstrap theme color "primary".
+
+    Args:
+        icon (str): The name of the icon to use. See https://fontawesome.com/icons for a list of icons.
+        color (str): The color of the icon. Defaults to "primary".
+        color_css (Optional[str]): A CSS variable or color reference. Defaults to None.
+        size (str): The size of the icon. Defaults to "sm".
+
+    Returns:
+        str: HTML for the icon.
     """
     if not color and not color_css:
         return ":" + icon + ":"  # Default to letting Docassemble handle it
@@ -1403,6 +1714,15 @@ def is_phone_or_email(text: str) -> bool:
     Returns True if the string is either a valid phone number or a valid email address.
     Email validation is extremely minimal--just checks for an @ sign between two non-zero length
     strings.
+
+    Args:
+        text (str): The string to check.
+
+    Returns:
+        bool: True if the string is either a valid phone number or a valid email address.
+
+    Raises:
+        DAValidationError if the string is neither a valid phone number nor a valid email address.
     """
     if re.match("\S+@\S+", text) or phone_number_is_valid(text):
         return True
@@ -1433,6 +1753,14 @@ def github_modified_date(
 
     If no valid auth information is in the configuration, it will fall back to anonymous authentication.
     The GitHub API is rate-limited to 60 anonymous API queries/hour.
+
+    Args:
+        github_user (str): The GitHub username of the repository owner.
+        github_repo_name (str): The name of the repository.
+        auth (Optional[dict]): A dictionary containing authentication information. Defaults to None.
+
+    Returns:
+        Union[DADateTime, None]: The date that the given GitHub repository was modified or None if API call fails.
     """
     if not auth:
         issue_config = get_config("github issues")
@@ -1459,7 +1787,14 @@ def github_modified_date(
 def language_name(language_code: str) -> str:
     """Given a 2 digit language code abbreviation, returns the full
     name of the language. The language name will be passed through the `word()`
-    function."""
+    function.
+    
+    Args:
+        language_code (str): A 2 digit language code abbreviation.
+    
+    Returns:
+        str: The full name of the language.
+    """
     ensure_definition(language_code)
     try:
         if len(language_code) == 2:
@@ -1472,7 +1807,14 @@ def language_name(language_code: str) -> str:
 
 def safe_states_list(country_code: str) -> List[Dict[str, str]]:
     """Wrapper around states_list that doesn't error if passed
-    an invalid country_code (e.g., a country name spelled out)"""
+    an invalid country_code (e.g., a country name spelled out)
+    
+    Args:
+        country_code (str): A 2 digit country code abbreviation.
+    
+    Returns:
+        List[Dict[str, str]]: A list of dictionaries with field prompts for states.
+    """
     try:
         return states_list(country_code=country_code)
     except:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -80,7 +80,7 @@ def safe_subdivision_type(country_code: str) -> Optional[str]:
         country_code (str): The ISO-3166-1 alpha-2 code for the country.
 
     Returns:
-        str: The subdivision type for the country with the given country code.
+        Optional[str]: The subdivision type for the country with the given country code.
     """
     try:
         return subdivision_type(country_code)
@@ -648,7 +648,9 @@ class ALNameList(DAList):
 
 
 class ALPeopleList(DAList):
-    """Class to store a list of ALIndividual objects, representing people."""
+    """Class to store a list of ALIndividual objects, representing people.
+    
+    For example, defendants, plaintiffs, or children."""
 
     def init(self, *pargs, **kwargs):
         super(ALPeopleList, self).init(*pargs, **kwargs)
@@ -661,7 +663,7 @@ class ALPeopleList(DAList):
 
         Args:
             comma_string (str, optional): The string to use between name-address pairs. Defaults to '; '.
-            bare (bool, optional): If True, represents the address in a minimalistic way. Defaults to False.
+            bare (bool, optional): If True, prevents appending the word "Unit" to the unit attribute. Defaults to False.
 
         Returns:
             str: Formatted string of names followed by addresses.
@@ -777,7 +779,7 @@ class ALIndividual(Individual):
             self.initializeAttribute("preferred_name", IndividualName)
 
     def signature_if_final(self, i: str) -> Union[DAFile, str]:
-        """Returns the individual's signature if a condition is met.
+        """Returns the individual's signature if `i` is "final", which usually means we are assembling the final version of the document (as opposed to a preview).
 
         Args:
             i (str): The condition which, if set to "final", returns the signature.
@@ -794,7 +796,7 @@ class ALIndividual(Individual):
         """Fetches and formats the phone numbers of the individual.
 
         Args:
-            country (str, optional): The country for phone number formatting.
+            country (str, optional): The country for phone number formatting. Defaults to the country of the docassemble server.
 
         Returns:
             str: Formatted string of phone numbers.
@@ -858,9 +860,6 @@ class ALIndividual(Individual):
         )
 
     def merge_letters(self, new_letters: str):
-        """
-        Very specific to 209A package, should be removed.
-        """
         # TODO: move to 209A package
         """If the Individual has a child_letters attribute, add the new letters to the existing list"""
         if hasattr(self, "child_letters"):
@@ -872,7 +871,7 @@ class ALIndividual(Individual):
         """Calculates and formats the age of the individual based on their birthdate.
 
         Returns:
-            str: Formatted age string in years, months, weeks, or days.
+            str: Formatted age string that shows the most relevant time unit; for example, if under 2 years, it will return "X months".
         """
         dd = date_difference(self.birthdate)
         if dd.years >= 2:
@@ -914,7 +913,7 @@ class ALIndividual(Individual):
             List[Dict[str, str]]: A list of dictionaries where each dictionary contains field prompt details.
 
         Note:
-            If `person_or_business` is set to None, the method will consider both entity types (i.e., "person" and "business")
+            If `person_or_business` is set to None, the method will offer the end user a choice
             and will set appropriate "show ifs" conditions for each type.
         """
         if person_or_business == "person":

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1637,7 +1637,7 @@ def will_send_to_real_court() -> bool:
     For legacy email to court forms, this checks to see if the form
     is being run on the dev, test, or production server.
 
-    Dev or root needs to be in the URL root: can change in the config file
+    The text "dev" or "test" needs to be in the URL root in the DA config: can change in `/config`.
     """
     return not (
         get_config("debug")

--- a/docassemble/AssemblyLine/language.py
+++ b/docassemble/AssemblyLine/language.py
@@ -115,11 +115,10 @@ def get_language_list_dropdown_item(
     Args:
         language: a tuple containing the language name and language code
         link: whether to return a link or just the text
-        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml)
         event_name: the name of the event to trigger when the language is changed
 
     Returns:
-        A string containing the HTML for a dropdown menu item for language selection.
+        str: A string containing the HTML for a dropdown menu item for language selection.
     """
 
     if link:
@@ -144,11 +143,10 @@ def get_language_list(
 
     Args:
         languages: a list of tuples containing the language name and language code (deprecated)
-        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es'])
         current: the current language code
+        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es'])
         languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml)
         event_name: the name of the event to trigger when the language is changed
-
 
     Returns:
         A string containing the HTML for an unordered inline list of language selection.
@@ -173,7 +171,7 @@ def get_language_list(
     return list_start + list_end
 
 
-def get_language_list_item(language, link=True, event_name="al_change_language"):
+def get_language_list_item(language, link=True, event_name="al_change_language") -> str:
     """Given an ordered tuple, returns a link to the current interview with lang=language code and the link title
     given in the first part of the tuple.
 
@@ -183,7 +181,7 @@ def get_language_list_item(language, link=True, event_name="al_change_language")
         event_name: the name of the event to trigger when the language is changed
 
     Returns:
-        A string containing the HTML for an unordered inline list item for language selection.
+        str: A string containing the HTML for an unordered inline list item for language selection.
     """
     li_start = '<li class="list-inline-item">'
     li_end = "</li>"

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -675,7 +675,7 @@ def radial_progress(answer: Dict[str, Union[str, int]]):
         answer (Dict[str, Union[str, int]]): The answer dictionary to get the interview progress from
 
     Returns:
-        str: HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
+        str: the HTML as a string
     """
     if not answer.get("progress"):
         return f"Page {answer.get('steps') or answer.get('num_keys') or 1}"

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -196,7 +196,7 @@ system_interviews: List[Dict[str, Any]] = interview_menu()
 def _package_name(package_name: Optional[str] = None):
     """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
     docassemble.ALWeaver.advertise_capabilities
-    
+
     Args:
         package_name (str, optional): The package name to process. Defaults to None.
 
@@ -214,13 +214,13 @@ def _package_name(package_name: Optional[str] = None):
 al_session_store_default_filename = f"{_package_name()}:al_saved_sessions_store.yml"
 
 
-def is_file_like(obj:Any) -> bool:
+def is_file_like(obj: Any) -> bool:
     """
     Return True if the object is a file-like object.
 
     Args:
         obj (Any): The object to test
-    
+
     Returns:
         bool: True if the object is a file-like object.
     """
@@ -673,7 +673,7 @@ def radial_progress(answer: Dict[str, Union[str, int]]):
 
     Args:
         answer (Dict[str, Union[str, int]]): The answer dictionary to get the interview progress from
-    
+
     Returns:
         str: HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
     """
@@ -891,7 +891,7 @@ def rename_interview_answers(
 ) -> None:
     """Update the 'title' metadata of an interview, as stored in the dedicated `metadata` column, without touching other
     metadata that may be present.
-    
+
     Args:
         filename (str): The filename of the interview to rename
         session_id (int): The session ID of the interview to rename
@@ -948,7 +948,7 @@ def rename_current_session(
 ) -> None:
     """Update the "title" metadata entry for the current session without changing any other
     metadata that might be present.
-    
+
     Args:
         new_name (str): The new name to set for the interview
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
@@ -981,7 +981,7 @@ def save_interview_answers(
         original_interview_filename (str, optional): Original filename of the interview. Defaults to None.
         source_filename (str, optional): Source filename to get session variables from. Defaults to None.
         source_session (str, optional): Session ID of the source file. Defaults to None.
-    
+
     Returns:
         str: ID of the new session.
     """
@@ -1047,15 +1047,15 @@ def get_filtered_session_variables(
     variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> Dict[str, Any]:
     """
-    Retrieves a filtered subset of variables from a specified interview and session. 
-    If no filename and session ID are given, it will return a filtered list of variables 
+    Retrieves a filtered subset of variables from a specified interview and session.
+    If no filename and session ID are given, it will return a filtered list of variables
     from the current interview.
 
     Args:
         filename (Optional[str], optional): Filename of the session. Defaults to None.
         session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
         variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to exclude. Defaults to `al_sessions_variables_to_remove`.
-    
+
     Returns:
         Dict[str, Any]: A dictionary of filtered session variables.
     """
@@ -1082,14 +1082,14 @@ def get_filtered_session_variables_string(
     variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> str:
     """
-    Returns a JSON string that represents the filtered contents of a specified filename and session ID. 
+    Returns a JSON string that represents the filtered contents of a specified filename and session ID.
     If no filename and session ID are provided, the current session's variables will be used.
 
     Args:
         filename (Optional[str], optional): Filename of the session. Defaults to None.
         session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
         variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to exclude. Defaults to `al_sessions_variables_to_remove`.
-    
+
     Returns:
         str: A JSON-formatted string of filtered session variables.
     """
@@ -1107,8 +1107,8 @@ def load_interview_answers(
     variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
-    Loads answers from a specified session. If the parameter `new_session` is set to True, it will create 
-    a new session with the provided or current interview filename. Otherwise, it will load the answers into 
+    Loads answers from a specified session. If the parameter `new_session` is set to True, it will create
+    a new session with the provided or current interview filename. Otherwise, it will load the answers into
     the active session. This function is primarily used for migrating answers between sessions.
 
     Args:
@@ -1117,7 +1117,7 @@ def load_interview_answers(
         new_session (bool, optional): Determines whether to create a new session. Defaults to False.
         new_interview_filename (Optional[str], optional): Filename for the new session. Defaults to None.
         variables_to_filter (Optional[List[str]], optional): List of variables to exclude. Defaults to None.
-    
+
     Returns:
         Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
@@ -1147,8 +1147,8 @@ def load_interview_json(
     variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
-    Given a JSON string, this function loads the specified variables into a Docassemble session. 
-    JSON strings containing annotated class names will be transformed into Docassemble objects. 
+    Given a JSON string, this function loads the specified variables into a Docassemble session.
+    JSON strings containing annotated class names will be transformed into Docassemble objects.
     If the `new_session` argument is not set, the JSON answers will be loaded into the current interview.
 
     Args:
@@ -1185,8 +1185,8 @@ def export_interview_variables(
     output: DAFile = None,
 ) -> DAFile:
     """
-    Generates a DAFile containing a JSON representation of a specified session's interview answers. 
-    The resultant output is compatible with `set_session_variables(process_objects=True)` and 
+    Generates a DAFile containing a JSON representation of a specified session's interview answers.
+    The resultant output is compatible with `set_session_variables(process_objects=True)` and
     `set_variables(process_objects=True)` methods.
 
     Args:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -198,7 +198,7 @@ def _package_name(package_name: Optional[str] = None):
     docassemble.ALWeaver.advertise_capabilities
 
     Args:
-        package_name (str, optional): The package name to process. Defaults to None.
+        package_name (str, optional): The package name to process. If `None`, will use the existing package name `__name__` instead
 
     Returns:
         str: The package name without the current module name.

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1105,7 +1105,7 @@ def load_interview_answers(
     new_session: bool = False,
     new_interview_filename: Optional[str] = None,
     variables_to_filter: Optional[List[str]] = None,
-) -> Optional[int]:
+) -> Optional[Union[int, bool]]:
     """
     Loads answers from a specified session. If the parameter `new_session` is set to True, it will create
     a new session with the provided or current interview filename. Otherwise, it will load the answers into
@@ -1119,7 +1119,7 @@ def load_interview_answers(
         variables_to_filter (Optional[List[str]], optional): List of variables to exclude. Defaults to None.
 
     Returns:
-        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
+        Optional[Union[int, bool]]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
 
     old_variables = get_filtered_session_variables(
@@ -1158,7 +1158,7 @@ def load_interview_json(
         variables_to_filter (Optional[List[str]], optional): List of variables to exclude. Defaults to None.
 
     Returns:
-        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
+        Optional[Union[int, bool]]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
     json_processed = json.loads(json_string)
 
@@ -1196,7 +1196,7 @@ def export_interview_variables(
         output (DAFile, optional):
 
     Returns:
-        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
+        DAFile: DAFile with a JSON representation of the answers
     """
     if not output:
         output = DAFile()

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -642,7 +642,7 @@ def pascal_to_zwspace(text: str) -> str:
     return re_outer.sub(r"\1​\2", re_inner.sub(r"​\1\2", text))
 
 
-def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
+def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True) -> str:
     """
     Return first defined of the "title" metadata, the "auto_title" metadata, or empty string.
 
@@ -650,6 +650,7 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
 
     Args:
         answer (Dict[str, str]): The answer dictionary to get the interview subtitle from
+        exclude_identical (bool, optional): If True, excludes the subtitle if it is identical to the title. Defaults to True.
 
     Returns:
         str: The human readable interview subtitle
@@ -663,11 +664,10 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
         )
     ):
         return pascal_to_zwspace(answer["auto_title"])
-    else:
-        return ""
+    return ""
 
 
-def radial_progress(answer: Dict[str, Union[str, int]]):
+def radial_progress(answer: Dict[str, Union[str, int]]) -> str:
     """
     Return HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
 
@@ -1193,7 +1193,7 @@ def export_interview_variables(
         filename (Optional[str], optional): Filename of the session. Defaults to None.
         session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
         variables_to_filter (Union[Set, List[str], None], optional): List or set of variables to exclude. Defaults to None.
-        output (DAFile, optional):
+        output (DAFile, optional): DAFile to write the JSON output to. If None, a new DAFile is created.
 
     Returns:
         DAFile: DAFile with a JSON representation of the answers

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -195,7 +195,14 @@ system_interviews: List[Dict[str, Any]] = interview_menu()
 
 def _package_name(package_name: Optional[str] = None):
     """Get package name without the name of the current module, like: docassemble.ALWeaver instead of
-    docassemble.ALWeaver.advertise_capabilities"""
+    docassemble.ALWeaver.advertise_capabilities
+    
+    Args:
+        package_name (str, optional): The package name to process. Defaults to None.
+
+    Returns:
+        str: The package name without the current module name.
+    """
     if not package_name:
         package_name = __name__
     try:
@@ -207,7 +214,16 @@ def _package_name(package_name: Optional[str] = None):
 al_session_store_default_filename = f"{_package_name()}:al_saved_sessions_store.yml"
 
 
-def is_file_like(obj):
+def is_file_like(obj:Any) -> bool:
+    """
+    Return True if the object is a file-like object.
+
+    Args:
+        obj (Any): The object to test
+    
+    Returns:
+        bool: True if the object is a file-like object.
+    """
     return isinstance(
         obj,
         (
@@ -233,6 +249,12 @@ def set_interview_metadata(
     - subtitle
     - original_interview_filename
     - variable_count
+
+    Args:
+        filename (str): The filename of the interview to add metadata for
+        session_id (int): The session ID of the interview to add metadata for
+        data (Dict): The metadata to add
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
     """
     server.write_answer_json(
         session_id, filename, safe_json(data), tags=metadata_key_name, persistent=True
@@ -241,9 +263,17 @@ def set_interview_metadata(
 
 def get_interview_metadata(
     filename: str, session_id: int, metadata_key_name: str = "metadata"
-) -> Dict:
+) -> Dict[str, Any]:
     """Retrieve the unencrypted metadata associated with an interview.
     We implement this with the docassemble jsonstorage table and a dedicated `tag` which defaults to `metadata`.
+
+    Args:
+        filename (str): The filename of the interview to retrieve metadata for
+        session_id (int): The session ID of the interview to retrieve metadata for
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
+
+    Returns:
+        Dict[str, Any]: The metadata associated with the interview
     """
     conn = variables_snapshot_connection()
     with conn.cursor() as cur:
@@ -280,6 +310,20 @@ def get_saved_interview_list(
     and likely do not need to be resumed, it will also have the side effect of excluding all answer sets from the
     results. Answer sets generally have exactly one "step", which is the step where information was copied from
     an existing interview to the answer set.
+
+    Args:
+        filename (str, optional): The filename of the interview to retrieve sessions for. Defaults to al_session_store_default_filename.
+        user_id (Union[int, str, None], optional): The user ID to retrieve sessions for. Defaults to None.
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
+        limit (int, optional): The maximum number of results to return. Defaults to 50.
+        offset (int, optional): The offset to start returning results from. Defaults to 0.
+        filename_to_exclude (str, optional): The filename to exclude from the results. Defaults to "".
+        exclude_current_filename (bool, optional): Whether to exclude the current filename from the results. Defaults to True.
+        exclude_filenames (Optional[List[str]], optional): A list of filenames to exclude from the results. Defaults to None.
+        exclude_newly_started_sessions (bool, optional): Whether to exclude sessions that are still on "step 1". Defaults to False.
+
+    Returns:
+        List[Dict[str, Any]]: A list of saved sessions for the specified filename.
     """
     # We use an `offset` instead of a cursor because it is simpler and clearer
     # while it appears to be performant enough for real-world usage.
@@ -388,6 +432,11 @@ def delete_interview_sessions(
     Delete all sessions for the specified user, excluding the current filename
     and by default, the intentionally saved "answer sets". Created because
     interview_list(action="delete_all") is both quite slow and because it deletes answer sets.
+
+    Args:
+        user_id (Optional[int], optional): The user ID to delete sessions for. Defaults to None.
+        filename_to_exclude (str, optional): The filename to exclude from the results. Defaults to al_session_store_default_filename.
+        exclude_current_filename (bool, optional): Whether to exclude the current filename from the results. Defaults to True.
     """
     if not user_logged_in():
         log(
@@ -460,6 +509,26 @@ def interview_list_html(
     `exclude_newly_started_sessions` should almost always be set to False, because most answer sets
     are on "page 1" (exactly 1 step was taken to copy the answers and the user isn't able to interact with the answer set
     itself in a way that adds additional steps)
+
+    Args:
+        filename (str, optional): Name of the file. Defaults to `al_session_store_default_filename`.
+        user_id (Union[int, str, None], optional): User's ID. Defaults to None.
+        metadata_key_name (str, optional): Name of the metadata key. Defaults to "metadata".
+        exclude_newly_started_sessions (bool, optional): If True, newly started sessions are excluded. Defaults to False.
+        date_label (str, optional): Label for the date column. Defaults to translated word "Date".
+        details_label (str, optional): Label for the details column. Defaults to translated word "Details".
+        actions_label (str, optional): Label for the actions column. Defaults to translated word "Actions".
+        delete_label (str, optional): Label for the delete action. Defaults to translated word "Delete".
+        view_label (str, optional): Label for the view action. Defaults to translated word "View".
+        load_action (str, optional): Name of the load action. Defaults to "al_sessions_fast_forward_session".
+        delete_action (str, optional): Name of the delete action. Defaults to "al_sessions_delete_session".
+        view_only (bool, optional): If True, only view is allowed. Defaults to False.
+        limit (int, optional): Limit for the number of sessions returned. Defaults to 50.
+        offset (int, optional): Offset for the session list. Defaults to 0.
+        display_interview_title (bool, optional): If True, displays the title of the interview. Defaults to True.
+
+    Returns:
+        str: HTML-formatted table containing the list of saved answers.
     """
     # TODO: Currently, using the `word()` function for translation, but templates
     # might be more flexible
@@ -536,6 +605,12 @@ def nice_interview_title(
     1. Try looking up the interview title from the `dispatch` directive
     1. Try removing the package and path from the filename and replace _ with spaces.
     4. Finally, return "Untitled interview" or translated phrase from system-wide words.yml
+
+    Args:
+        answer (Dict[str, str]): The answer dictionary to get the interview title from
+
+    Returns:
+        str: The human readable interview title
     """
     if answer.get("filename"):
         for interview in system_interviews:
@@ -555,6 +630,12 @@ def pascal_to_zwspace(text: str) -> str:
     """
     Insert a zero-width space into words that are PascalCased to help
     with word breaks on small viewports.
+
+    Args:
+        text (str): The text to insert zero-width spaces into
+
+    Returns:
+        str: The text with zero-width spaces inserted
     """
     re_outer = re.compile(r"([^A-Z ])([A-Z])")
     re_inner = re.compile(r"(?<!^)([A-Z])([^A-Z])")
@@ -566,6 +647,12 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
     Return first defined of the "title" metadata, the "auto_title" metadata, or empty string.
 
     If exclude_identical, return empty string when title is the same as the subtitle.
+
+    Args:
+        answer (Dict[str, str]): The answer dictionary to get the interview subtitle from
+
+    Returns:
+        str: The human readable interview subtitle
     """
     if answer.get("title"):
         return pascal_to_zwspace(answer["title"])
@@ -583,6 +670,12 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True):
 def radial_progress(answer: Dict[str, Union[str, int]]):
     """
     Return HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
+
+    Args:
+        answer (Dict[str, Union[str, int]]): The answer dictionary to get the interview progress from
+    
+    Returns:
+        str: HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
     """
     if not answer.get("progress"):
         return f"Page {answer.get('steps') or answer.get('num_keys') or 1}"
@@ -604,6 +697,15 @@ def radial_progress(answer: Dict[str, Union[str, int]]):
 
 
 def local_date(utcstring: Optional[str]) -> DADateTime:
+    """
+    Return a localized date from a UTC string.
+
+    Args:
+        utcstring (Optional[str]): The UTC string to convert to a localized date
+
+    Returns:
+        DADateTime: The localized date
+    """
     if not utcstring:
         return DADateTime()
     return (
@@ -638,6 +740,31 @@ def session_list_html(
     """Return a string containing an HTML-formatted table with the list of user sessions.
     While interview_list_html() is for answer sets, this feature is for standard
     user sessions. The results exclude the answer set filename by default.
+
+    Args:
+        filename (Optional[str], optional): Name of the file. Defaults to None.
+        user_id (Union[int, str, None], optional): User's ID. Defaults to None.
+        metadata_key_name (str, optional): Name of the metadata key. Defaults to "metadata".
+        filename_to_exclude (str, optional): Name of the file to exclude. Defaults to `al_session_store_default_filename`.
+        exclude_current_filename (bool, optional): If True, excludes the current filename. Defaults to True.
+        exclude_filenames (Optional[List[str]], optional): List of filenames to exclude. Defaults to None.
+        exclude_newly_started_sessions (bool, optional): If True, excludes newly started sessions. Defaults to False.
+        name_label (str, optional): Label for the session name/title. Defaults to translated word "Title".
+        date_label (str, optional): Label for the date column. Defaults to translated word "Date modified".
+        details_label (str, optional): Label describing the progress of the session. Defaults to translated word "Progress".
+        actions_label (str, optional): Label for actions applicable to the session. Defaults to translated word "Actions".
+        delete_label (str, optional): Label for the delete action. Defaults to translated word "Delete".
+        rename_label (str, optional): Label for the rename action. Defaults to translated word "Rename".
+        rename_action (str, optional): Name of the rename action. Defaults to "interview_list_rename_action".
+        delete_action (str, optional): Name of the delete action. Defaults to "interview_list_delete_session".
+        copy_action (str, optional): Name of the copy action. Defaults to "interview_list_copy_action".
+        clone_label (str, optional): Label for the action to copy as an answer set. Defaults to translated word "Copy as answer set".
+        show_title (bool, optional): If True, shows the title of the session. Defaults to True.
+        limit (int, optional): Limit for the number of sessions returned. Defaults to 50.
+        offset (int, optional): Offset for the session list. Defaults to 0.
+
+    Returns:
+        str: HTML-formatted table containing the list of user sessions.
     """
 
     # TODO: think through how to translate this function. Templates probably work best but aren't
@@ -763,7 +890,16 @@ def rename_interview_answers(
     metadata_key_name: str = "metadata",
 ) -> None:
     """Update the 'title' metadata of an interview, as stored in the dedicated `metadata` column, without touching other
-    metadata that may be present."""
+    metadata that may be present.
+    
+    Args:
+        filename (str): The filename of the interview to rename
+        session_id (int): The session ID of the interview to rename
+        new_name (str): The new name to set for the interview
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
+
+    If exception is raised in set_session_variables, this will silently fail but log the error.
+    """
     existing_metadata = get_interview_metadata(
         filename, session_id, metadata_key_name=metadata_key_name
     )
@@ -793,7 +929,10 @@ def set_current_session_metadata(
 ) -> None:
     """
     Set metadata for the current session, such as the title, in an unencrypted database entry.
-    This may be helpful for faster SQL queries and reports, such as listing interview answers.
+
+    Args:
+        data (Dict[str, Any]): The metadata to set
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
     """
     return set_interview_metadata(
         user_info().filename,
@@ -808,7 +947,12 @@ def rename_current_session(
     metadata_key_name: str = "metadata",
 ) -> None:
     """Update the "title" metadata entry for the current session without changing any other
-    metadata that might be present."""
+    metadata that might be present.
+    
+    Args:
+        new_name (str): The new name to set for the interview
+        metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
+    """
     return rename_interview_answers(
         user_info().filename,
         user_info().session,
@@ -826,8 +970,21 @@ def save_interview_answers(
     source_filename=None,
     source_session=None,
 ) -> str:
-    """Copy the answers from the specified session into a new session with the given
-    interview filename. Typically used to create an answer set."""
+    """
+    Copies the answers from a given session into a new session with a specified interview filename.
+
+    Args:
+        filename (str, optional): The desired filename for the new session. Defaults to `al_session_store_default_filename`.
+        variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to filter out. Defaults to `al_sessions_variables_to_remove`.
+        metadata (Optional[Dict], optional): Dictionary containing metadata. Defaults to an empty dictionary.
+        metadata_key_name (str, optional): Key name for metadata storage. Defaults to "metadata".
+        original_interview_filename (str, optional): Original filename of the interview. Defaults to None.
+        source_filename (str, optional): Source filename to get session variables from. Defaults to None.
+        source_session (str, optional): Session ID of the source file. Defaults to None.
+    
+    Returns:
+        str: ID of the new session.
+    """
     # Avoid using mutable default parameter
     if not variables_to_filter:
         variables_to_filter = al_sessions_variables_to_remove
@@ -890,9 +1047,17 @@ def get_filtered_session_variables(
     variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> Dict[str, Any]:
     """
-    Get a filtered subset of the variables from the specified interview filename and session.
+    Retrieves a filtered subset of variables from a specified interview and session. 
+    If no filename and session ID are given, it will return a filtered list of variables 
+    from the current interview.
 
-    If no filename and session ID are specified, return filtered list of variables from the current interview.
+    Args:
+        filename (Optional[str], optional): Filename of the session. Defaults to None.
+        session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
+        variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to exclude. Defaults to `al_sessions_variables_to_remove`.
+    
+    Returns:
+        Dict[str, Any]: A dictionary of filtered session variables.
     """
     if not variables_to_filter:
         variables_to_filter = al_sessions_variables_to_remove
@@ -917,8 +1082,16 @@ def get_filtered_session_variables_string(
     variables_to_filter: Union[Set[str], List[str], None] = None,
 ) -> str:
     """
-    Get a JSON string representing the filtered contents of the specified filename and session_id. If no filename and session_id
-    are provided, the output will contain the variables from the current session.
+    Returns a JSON string that represents the filtered contents of a specified filename and session ID. 
+    If no filename and session ID are provided, the current session's variables will be used.
+
+    Args:
+        filename (Optional[str], optional): Filename of the session. Defaults to None.
+        session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
+        variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to exclude. Defaults to `al_sessions_variables_to_remove`.
+    
+    Returns:
+        str: A JSON-formatted string of filtered session variables.
     """
     simple_vars = serializable_dict(
         get_filtered_session_variables(filename, session_id, variables_to_filter)
@@ -934,12 +1107,21 @@ def load_interview_answers(
     variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
-    Load answers from the specified session. If the parameter new_session = True, create a new session of
-    the specified or current interview filename. Otherwise, load the answers into the active session.
-    Returns the ID of the newly created session
-    Create a new session with the variables from the specified session ID. Returns the ID of the newly
-    created and "filled" session.
+    Loads answers from a specified session. If the parameter `new_session` is set to True, it will create 
+    a new session with the provided or current interview filename. Otherwise, it will load the answers into 
+    the active session. This function is primarily used for migrating answers between sessions.
+
+    Args:
+        old_interview_filename (str): Filename of the old interview.
+        old_session_id (int): Session ID of the old interview.
+        new_session (bool, optional): Determines whether to create a new session. Defaults to False.
+        new_interview_filename (Optional[str], optional): Filename for the new session. Defaults to None.
+        variables_to_filter (Optional[List[str]], optional): List of variables to exclude. Defaults to None.
+    
+    Returns:
+        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
+
     old_variables = get_filtered_session_variables(
         old_interview_filename, old_session_id, variables_to_filter
     )
@@ -965,10 +1147,18 @@ def load_interview_json(
     variables_to_filter: Optional[List[str]] = None,
 ) -> Optional[int]:
     """
-    Provided a JSON string, load the specified variables into a Docassemble session. JSON with annotated class names
-    will be processed into Docassemble objects.
+    Given a JSON string, this function loads the specified variables into a Docassemble session. 
+    JSON strings containing annotated class names will be transformed into Docassemble objects. 
+    If the `new_session` argument is not set, the JSON answers will be loaded into the current interview.
 
-    If new_session is not provided, the JSON answers will be loaded into the current interview.
+    Args:
+        json_string (str): A JSON-formatted string containing session variables.
+        new_session (bool, optional): Specifies whether to create a new session or load into the current one. Defaults to False.
+        new_interview_filename (Optional[str], optional): Filename for the new session. Defaults to None.
+        variables_to_filter (Optional[List[str]], optional): List of variables to exclude. Defaults to None.
+
+    Returns:
+        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
     json_processed = json.loads(json_string)
 
@@ -995,8 +1185,18 @@ def export_interview_variables(
     output: DAFile = None,
 ) -> DAFile:
     """
-    Get a DAFile with the JSON representation of the specified session's interview answers. The output is compatible with
-    set_session_variables(process_objects=True) and set_variables(process_objects=True)
+    Generates a DAFile containing a JSON representation of a specified session's interview answers. 
+    The resultant output is compatible with `set_session_variables(process_objects=True)` and 
+    `set_variables(process_objects=True)` methods.
+
+    Args:
+        filename (Optional[str], optional): Filename of the session. Defaults to None.
+        session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
+        variables_to_filter (Union[Set, List[str], None], optional): List or set of variables to exclude. Defaults to None.
+        output (DAFile, optional):
+
+    Returns:
+        Optional[int]: ID of the newly created session if `new_session` is True, otherwise True or False based on success.
     """
     if not output:
         output = DAFile()
@@ -1013,6 +1213,15 @@ def export_interview_variables(
 
 
 def is_valid_json(json_string: str) -> bool:
+    """
+    Checks if the provided string is a valid JSON-formatted string.
+
+    Args:
+        json_string (str): The string to be checked for JSON validity.
+
+    Returns:
+        bool: True if the string is a valid JSON, otherwise it raises a validation error and returns False.
+    """
     try:
         json.loads(json_string)
     except:


### PR DESCRIPTION
Fix #178 

This just adds google-style docstrings for every class, method and function so we can improve our auto-generated documentation pages. Used GitHub copilot as an assistant but I've checked these all for correctness and minor tone/style changes from the CoPilot first drafts.

Also added some types that were missing.

I added one new method `geocode` because we were using the legacy phrasing `geolocate` (a misnomer that was in the Docassemble code base for several years). Otherwise, this should have no functional changes, only new documentation and change of documentation style to Google. Feel free to do a light review--any egregious documentation error should be corrected but we're mostly filling in missing information.