### PR TITLE
remove icon from intro screen that was never displayed

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -185,15 +185,6 @@ default screen parts:
     [:info-circle: About](${ url_action('about_this_interview') })
     [:comment-dots: Feedback](${ feedback_link(user_info(), i=feedback_form, github_repo=github_repo_name, github_user=github_user, package_version=package_version_number) } ){:target="_blank"}
 ---
-image sets:
-  smashicons:
-    attribution: |
-      Icon made by
-      [Smashicons](https://www.flaticon.com/authors/smashicons)
-    images:
-      form: sign-form.svg
-      form-lineal: sign-form-lineal.svg
----
 continue button field: al_share_form_screen
 id: al share form screen
 question: |

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -34,7 +34,6 @@ objects:
   - x.service_address: ALAddress
 ---
 id: basic questions intro screen
-decoration: form-lineal
 question: |
   ${interview_short_title}: ${ AL_ORGANIZATION_TITLE}
 subquestion: |


### PR DESCRIPTION
Fix #736

Looks like this was meant to be a decoration for the main intro page. I found the icon w/ the attribution, but it's now behind a paywall so we can't easily just add it back in anyway.

It's not a bad idea to have some visual here, but given #461 and the fact that this decoration appears to have *never* been visible, going to just remove it for now as the safest choice.

We can decide to add more graphics later, probably shouldn't do it in the default theme without notice though.