### PR TITLE
Moved ALKiln HTML to a template in al_code

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -185,3 +185,9 @@ code: |
   else:
     # If the user role was set to "unknown" at the time wizard run
     user_role = user_ask_role
+---
+# A bit of HTML required for ALKiln to be used in interviews.
+# To add to your unstyled alkiln interviews, include it in your `default screen parts: post`
+template: alkiln_trigger_html
+content: |
+    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -48,8 +48,9 @@ default screen parts:
     <div data-variable="${ encode_name(str( user_info().variable )) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
     % endif
   # We need both pre and post until old interviews are updated to v2 of the testing framework or v1 of the testing framework is updated. In future, we will need this in `post` so that it will work on signature pages.
+  # Uses `alkiln_trigger_html` template in al_code.yml
   post: |
-    <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+    ${ alkiln_trigger_html }
 ---
 features:
   small screen navigation: dropdown


### PR DESCRIPTION
Makes it easier to be reused in unstyled interviews, while keeping all styled and unstyled interviews the same.

Fixes #355.

I think the Assembly Line Kiln tests should be good enough to test this fully, but I might manually check what the trigger variable looks like in a few different question screens.