### PR TITLE
Speed up next screen after uploading Exhibit page

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1728,6 +1728,7 @@ validation code: |
       pdf_concatenate(x[0].pages)
     except:
       validation_error("Unable to convert this file. Please upload a new one.")
+    x[0].pages.complete_attribute = 'ok'
     x[0].pages.reset_gathered()  # docassemble sets this attribute but we want to force gathering additional pages
 ---
 generic object: ALExhibitList


### PR DESCRIPTION
By calling `reset_gathered()` and `gather()` on the ALExhibitList, we force DA to call `str` on each document we upload. We can avoid this by setting the `complete_attribute` to `ok`, which is always defined for a DAFile.

Thumbnails are still generated when the PDF is uploaded, but it happens in the background, and won't cause the 504 sometimes seen.

Partially fix #752.