### PR TITLE
Impounded address feature

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -101,6 +101,7 @@ class ALAddress(Address):
         state (str): The state where the person lives.
         zip (str): The zip code where the person lives.
         country (str): The country where the person lives.
+        impounded (Optional[bool]): Whether the address is impounded.
     """
 
     def address_fields(
@@ -111,6 +112,7 @@ class ALAddress(Address):
         show_county: bool = False,
         show_if: Union[str, Dict[str, str], None] = None,
         allow_no_address: bool = False,
+        ask_if_impounded: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         """
         Return a YAML structure representing the list of fields for the object's address.
@@ -129,6 +131,7 @@ class ALAddress(Address):
             show_county (bool): Whether to display the county field. Defaults to False.
             show_if (Union[str, Dict[str, str], None]): Condition to display each field. Defaults to None.
             allow_no_address (bool): Allow users to specify they don't have an address. Defaults to False.
+            ask_if_impounded (Optional[bool]): Whether to ask if the address is impounded. Defaults to False.
 
         Returns:
             list: A list of YAML structure representing address fields.
@@ -251,6 +254,15 @@ class ALAddress(Address):
             if show_if:
                 for field in fields:
                     field["show if"] = show_if
+        
+        if ask_if_impounded:
+            fields.append(
+                {
+                    "label": str(self.impounded_label),
+                    "field": self.attr_name("impounded"),
+                    "datatype": "yesno",
+                }
+            )
 
         return fields
 
@@ -322,6 +334,7 @@ class ALAddress(Address):
         show_country: Optional[bool] = None,
         bare: bool = False,
         long_state: bool = False,
+        show_impounded_address: bool = False,
     ) -> str:
         """Returns a one-line formatted address, primarily for geocoding.
 
@@ -332,6 +345,7 @@ class ALAddress(Address):
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
+            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The one-line formatted address.
@@ -341,6 +355,11 @@ class ALAddress(Address):
         else:
             line_breaker = " [NEWLINE] "
 
+        if not show_impounded_address and (
+            hasattr(self, "impounded")
+            and self.impounded
+        ):
+                return str(self.impounded_output_label)
         if (
             hasattr(self, "has_no_address")
             and self.has_no_address
@@ -417,16 +436,22 @@ class ALAddress(Address):
             output += line_breaker + country_name(self._get_country())
         return output
 
-    def line_one(self, language: Optional[str] = None, bare: bool = False) -> str:
+    def line_one(self, language: Optional[str] = None, bare: bool = False, show_impounded_address: bool = False) -> str:
         """Returns the first line of the address, including the unit number if it exists.
 
         Args:
             language (str, optional): Language for the address format.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
+            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The first line of the address.
         """
+        if not show_impounded_address and (
+            hasattr(self, "impounded")
+            and self.impounded
+        ):
+                return str(self.impounded_output_label)        
         if (
             hasattr(self, "has_no_address")
             and self.has_no_address
@@ -448,16 +473,22 @@ class ALAddress(Address):
             output += ", " + the_unit
         return output
 
-    def line_two(self, language: Optional[str] = None, long_state: bool = False) -> str:
+    def line_two(self, language: Optional[str] = None, long_state: bool = False, show_impounded_address: bool = False) -> str:
         """Returns the second line of the address, including city, state, and postal code.
 
         Args:
             language (str, optional): Language for the address format.
             long_state (bool): If True, uses the full state name. Defaults to False.
+            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The second line of the address.
         """
+        if not show_impounded_address and (
+            hasattr(self, "impounded")
+            and self.impounded
+        ):
+                return str(self.impounded_output_label)        
         output = ""
         # if hasattr(self, 'sublocality') and self.sublocality:
         #    output += str(self.sublocality) + ", "
@@ -483,6 +514,7 @@ class ALAddress(Address):
         show_country: Optional[bool] = None,
         bare: bool = False,
         long_state: bool = False,
+        show_impounded_address: bool = False,
     ) -> str:
         """Returns a one-line formatted address.
 
@@ -494,10 +526,16 @@ class ALAddress(Address):
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
+            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The one-line formatted address.
         """
+        if not show_impounded_address and (
+            hasattr(self, "impounded")
+            and self.impounded
+        ):
+                return str(self.impounded_output_label)        
         if (
             hasattr(self, "has_no_address")
             and self.has_no_address
@@ -557,8 +595,9 @@ class ALAddress(Address):
         be a standard Address object, not an ALAddress object. If geocoding fails, it returns
         the version of the address as entered by the user.
 
-        Returns:
-            Union[Address, "ALAddress"]: Normalized address if geocoding is successful, otherwise
+        Warning: currently the normalized address will not be redacted if the address is impounded.
+
+        Returns: (Union[Address, "ALAddress"]): Normalized address if geocoding is successful, otherwise
             the original address.
         """
         try:
@@ -791,11 +830,12 @@ class ALIndividual(Individual):
         else:
             return ""
 
-    def phone_numbers(self, country: Optional[str] = None) -> str:
+    def phone_numbers(self, country: Optional[str] = None, show_impounded_numbers:bool = False) -> str:
         """Fetches and formats the phone numbers of the individual.
 
         Args:
             country (str, optional): The country for phone number formatting. Defaults to the country of the docassemble server.
+            show_impounded_numbers (bool): If True, shows the phone numbers even if impounded. Defaults to False.
 
         Returns:
             str: Formatted string of phone numbers.
@@ -823,7 +863,15 @@ class ALIndividual(Individual):
                 )
             except:
                 nums.append({self.phone_number: "other"})
-        if len(nums) > 1:
+        if len(nums) < 1:
+            return ""
+        # Check for impounded phone number
+        elif not show_impounded_numbers and (
+            hasattr(self, "phone_impounded")
+            and self.phone_impounded
+        ):
+            return str(self.impounded_phone_label)
+        elif len(nums) > 1:
             return comma_list(
                 [
                     list(num.keys())[0] + " (" + list(num.values())[0] + ")"
@@ -832,8 +880,8 @@ class ALIndividual(Individual):
             )
         elif len(nums):
             return list(nums[0].keys())[0]
-        else:
-            return ""
+        
+        assert False # We should never get here, no default return is necessary
 
     def contact_methods(self) -> str:
         """Generates a formatted string of all provided contact methods.
@@ -1323,7 +1371,7 @@ class ALIndividual(Individual):
         return f"{self.name.first[:1]}{self.name.middle[:1] if hasattr(self.name,'middle') else ''}{self.name.last[:1] if hasattr(self.name, 'last') else ''}"
 
     def address_block(
-        self, language=None, international=False, show_country=False, bare=False
+        self, language=None, international=False, show_country=False, bare=False, show_impounded_address=False
     ) -> str:
         """
         Generate a formatted address block for mailings.
@@ -1333,6 +1381,7 @@ class ALIndividual(Individual):
             international (bool): If True, format for international mailing. Defaults to False.
             show_country (bool): If True, include the country in the address. Defaults to False.
             bare (bool): If True, produce the address without additional formatting. Defaults to False.
+            show_impounded_address (bool): If True, show the address even if it is impounded. Defaults to False.
 
         Returns:
             str: The formatted address block.
@@ -1345,6 +1394,8 @@ class ALIndividual(Individual):
                     language=language,
                     international=international,
                     show_country=show_country,
+                    bare=bare,
+                    show_impounded_address=show_impounded_address,
                 )
             )
         return (
@@ -1356,6 +1407,7 @@ class ALIndividual(Individual):
                 international=international,
                 show_country=show_country,
                 bare=bare,
+                show_impounded_address=show_impounded_address,                
             )
         )
 

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -334,7 +334,7 @@ class ALAddress(Address):
         show_country: Optional[bool] = None,
         bare: bool = False,
         long_state: bool = False,
-        show_impounded_address: bool = False,
+        show_impounded: bool = False,
     ) -> str:
         """Returns a one-line formatted address, primarily for geocoding.
 
@@ -345,7 +345,7 @@ class ALAddress(Address):
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
-            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
+            show_impounded (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The one-line formatted address.
@@ -355,7 +355,7 @@ class ALAddress(Address):
         else:
             line_breaker = " [NEWLINE] "
 
-        if not show_impounded_address and (
+        if not show_impounded and (
             hasattr(self, "impounded")
             and self.impounded
         ):
@@ -436,18 +436,18 @@ class ALAddress(Address):
             output += line_breaker + country_name(self._get_country())
         return output
 
-    def line_one(self, language: Optional[str] = None, bare: bool = False, show_impounded_address: bool = False) -> str:
+    def line_one(self, language: Optional[str] = None, bare: bool = False, show_impounded: bool = False) -> str:
         """Returns the first line of the address, including the unit number if it exists.
 
         Args:
             language (str, optional): Language for the address format.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
-            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
+            show_impounded (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The first line of the address.
         """
-        if not show_impounded_address and (
+        if not show_impounded and (
             hasattr(self, "impounded")
             and self.impounded
         ):
@@ -473,18 +473,18 @@ class ALAddress(Address):
             output += ", " + the_unit
         return output
 
-    def line_two(self, language: Optional[str] = None, long_state: bool = False, show_impounded_address: bool = False) -> str:
+    def line_two(self, language: Optional[str] = None, long_state: bool = False, show_impounded: bool = False) -> str:
         """Returns the second line of the address, including city, state, and postal code.
 
         Args:
             language (str, optional): Language for the address format.
             long_state (bool): If True, uses the full state name. Defaults to False.
-            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
+            show_impounded (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The second line of the address.
         """
-        if not show_impounded_address and (
+        if not show_impounded and (
             hasattr(self, "impounded")
             and self.impounded
         ):
@@ -514,7 +514,7 @@ class ALAddress(Address):
         show_country: Optional[bool] = None,
         bare: bool = False,
         long_state: bool = False,
-        show_impounded_address: bool = False,
+        show_impounded: bool = False,
     ) -> str:
         """Returns a one-line formatted address.
 
@@ -526,12 +526,12 @@ class ALAddress(Address):
                 If None, decides based on the country attribute.
             bare (bool): If True, excludes certain formatting elements. Defaults to False.
             long_state (bool): If True, uses the full state name. Defaults to False.
-            show_impounded_address (bool): If True, shows the address even if impounded. Defaults to False.
+            show_impounded (bool): If True, shows the address even if impounded. Defaults to False.
 
         Returns:
             str: The one-line formatted address.
         """
-        if not show_impounded_address and (
+        if not show_impounded and (
             hasattr(self, "impounded")
             and self.impounded
         ):
@@ -830,12 +830,12 @@ class ALIndividual(Individual):
         else:
             return ""
 
-    def phone_numbers(self, country: Optional[str] = None, show_impounded_numbers:bool = False) -> str:
+    def phone_numbers(self, country: Optional[str] = None, show_impounded:bool = False) -> str:
         """Fetches and formats the phone numbers of the individual.
 
         Args:
             country (str, optional): The country for phone number formatting. Defaults to the country of the docassemble server.
-            show_impounded_numbers (bool): If True, shows the phone numbers even if impounded. Defaults to False.
+            show_impounded (bool): If True, shows the phone numbers even if impounded. Defaults to False.
 
         Returns:
             str: Formatted string of phone numbers.
@@ -866,7 +866,7 @@ class ALIndividual(Individual):
         if len(nums) < 1:
             return ""
         # Check for impounded phone number
-        elif not show_impounded_numbers and (
+        elif not show_impounded and (
             hasattr(self, "phone_impounded")
             and self.phone_impounded
         ):
@@ -1081,6 +1081,7 @@ class ALIndividual(Individual):
         show_county: bool = False,
         show_if: Union[str, Dict[str, str], None] = None,
         allow_no_address: bool = False,
+        ask_if_impounded: bool = False,
     ) -> List[Dict[str, str]]:
         """
         Generate field prompts for capturing an address.
@@ -1092,6 +1093,7 @@ class ALIndividual(Individual):
             show_county (bool): Whether to display the county field. Defaults to False.
             show_if (Union[str, Dict[str, str], None]): Condition to determine if the field should be shown. Defaults to None.
             allow_no_address (bool): Whether to permit entries with no address. Defaults to False.
+            ask_if_impounded (bool): Whether to ask if the address is impounded. Defaults to False.
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for addresses.
@@ -1105,6 +1107,7 @@ class ALIndividual(Individual):
             show_county=show_county,
             show_if=show_if,
             allow_no_address=allow_no_address,
+            ask_if_impounded=ask_if_impounded,
         )
 
     def gender_fields(
@@ -1371,7 +1374,7 @@ class ALIndividual(Individual):
         return f"{self.name.first[:1]}{self.name.middle[:1] if hasattr(self.name,'middle') else ''}{self.name.last[:1] if hasattr(self.name, 'last') else ''}"
 
     def address_block(
-        self, language=None, international=False, show_country=False, bare=False, show_impounded_address=False
+        self, language=None, international=False, show_country=False, bare=False, show_impounded=False
     ) -> str:
         """
         Generate a formatted address block for mailings.
@@ -1381,7 +1384,7 @@ class ALIndividual(Individual):
             international (bool): If True, format for international mailing. Defaults to False.
             show_country (bool): If True, include the country in the address. Defaults to False.
             bare (bool): If True, produce the address without additional formatting. Defaults to False.
-            show_impounded_address (bool): If True, show the address even if it is impounded. Defaults to False.
+            show_impounded (bool): If True, show the address even if it is impounded. Defaults to False.
 
         Returns:
             str: The formatted address block.
@@ -1395,7 +1398,7 @@ class ALIndividual(Individual):
                     international=international,
                     show_country=show_country,
                     bare=bare,
-                    show_impounded_address=show_impounded_address,
+                    show_impounded=show_impounded,
                 )
             )
         return (
@@ -1407,7 +1410,7 @@ class ALIndividual(Individual):
                 international=international,
                 show_country=show_country,
                 bare=bare,
-                show_impounded_address=show_impounded_address,                
+                show_impounded=show_impounded,                
             )
         )
 

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -870,7 +870,7 @@ class ALIndividual(Individual):
             hasattr(self, "phone_impounded")
             and self.phone_impounded
         ):
-            return str(self.impounded_phone_label)
+            return str(self.impounded_phone_output_label)
         elif len(nums) > 1:
             return comma_list(
                 [

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -382,7 +382,7 @@ content: |
   **IMPOUNDED**
 ---
 generic object: ALIndividual
-template: x.impounded_phone_label
+template: x.impounded_phone_output_label
 content: |
   **IMPOUNDED**
 ---

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -372,6 +372,21 @@ content: |
   Country
 ---
 generic object: ALAddress
+template: x.impounded_label
+content: |
+  This address is impounded
+---
+generic object: ALAddress
+template: x.impounded_output_label
+content: |
+  **IMPOUNDED**
+---
+generic object: ALIndividual
+template: x.impounded_phone_label
+content: |
+  **IMPOUNDED**
+---
+generic object: ALAddress
 template: x.county_label
 content: |
   County


### PR DESCRIPTION
This adds a new feature that allows the interview author to control asking if an address or phone number is impounded. 

New attributes:

* ALAddress.impounded (bool)
* ALIndividual.phone_impounded (bool)

There is a new keyword parameter for `ALAddress.address_fields()` and `ALIndividual.address_fields()`: `ask_if_impounded (bool)`

There is a new keyword parameter for all methods that display an address or part of an address, `show_impounded`. The same keyword can be used with the `phone_numbers()` method.

Finally, we add some new templates to allow translation of phrases related to impounded addresses:

* `ALAddress.impounded_label`
* `ALAddress.impounded_output_label`
* `ALIndividual.impounded_phone_output_label`

Here's a short demo interview:

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
code: |
  users[0].phone_number
  users[0].address.address
  ending_screen
---
sets:
  - users[0].address.address
question: |
  Your address
fields:
  - code: |
      users[0].address_fields(ask_if_impounded=True)
---
id: your contact information
question: |
  What is your contact information?
subquestion: |
  Include at least **one** way to reach you other than by mail.

  ${ collapse_template(why_contact_info_needed_template) }
fields:  
  - Mobile number: users[0].mobile_number
    required: False
  - Other phone number: users[0].phone_number
    required: False
  - My phone number is impounded: users[0].phone_impounded
    datatype: yesno
  - Email address: users[0].email    
    datatype: email
    required: False
  - Other ways to reach you: users[0].other_contact_method
    input type: area
    required: False
    help: |
      If you do not have a phone number or email, provide
      specific contact instructions. For example, use a friend's phone number.
      But the friend must be someone you can rely on to give you a
      message.
validation code: |
  if (not showifdef('users[0].phone_number') and \
      (not showifdef('users[0].mobile_number')) and \
      (not showifdef('users[0].email')) and \
      (not showifdef('users[0].other_contact_method'))):
    validation_error(word("You need to provide at least one contact method."), field="users[0].other_contact_method")
      
---
event: ending_screen
question: |
subquestion: |
  If impounded:
  
  Address: ${ users[0].address_block() }
  
  Phone: ${ users[0].phone_numbers() }
  
  For impounded information sheet:
  
  ${ users[0].address_block(show_impounded=True) }
  
  ${ users[0].phone_numbers(show_impounded=True) }
```

I think this is fairly safe and I'm happy with the API, but happy to let this get some feedback from our grant partners before merging.
