### PR TITLE
Limit maximum height of logo

### DIFF
--- a/docassemble/AssemblyLine/data/static/styles.css
+++ b/docassemble/AssemblyLine/data/static/styles.css
@@ -12,7 +12,12 @@
   justify-items: start; 
   align-items: center; 
 }
-.al-logo { grid-area: logo; }
+.al-logo { 
+  grid-area: logo; 
+}
+.al-logo img {
+  max-height: 40px;
+}
 .al-title {
   display: grid; 
   grid-template-columns: min-content; 


### PR DESCRIPTION
fix #748

This just mirrors the defaults in various production repos so more projects will work out of the box:

https://github.com/SuffolkLITLab/docassemble-ALWeaver/blob/fef677dd2daa9dd65d04b5621841f8e464910e86/docassemble/ALWeaver/data/static/styles.css#L25

https://github.com/SuffolkLITLab/docassemble-ALThemeTemplate/blob/2b0a0140a816c12f366a93feea1cdc7cdb95eb4e/docassemble/ALThemeTemplate/data/static/colors.css#L7