### PR TITLE
Handle unexpected interview_metadata

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -356,7 +356,7 @@ content: |
   "${all_variables(special='metadata').get('title','').rstrip()}" version 
   `${ package_version_number }`; AssemblyLine version `${ al_version }`.
 
-  % if interview_metadata.get("main_interview_key"):
+  % if interview_metadata.get("main_interview_key") and isinstance(interview_metadata.get("main_interview_key"), str):
     <%
       MAIN_METADATA = interview_metadata[interview_metadata["main_interview_key"]]
     %>
@@ -435,7 +435,7 @@ decoration: bug
 question: |
   Something went wrong
 subquestion: |
-  % if interview_metadata.get("main_interview_key"):
+  % if interview_metadata.get("main_interview_key") and isinstance(interview_metadata.get("main_interview_key"), str):
     <%
       MAIN_METADATA = interview_metadata[interview_metadata["main_interview_key"]]
     %>


### PR DESCRIPTION
Ran into an error when `interview_metadata["main_interview_key"}` was set to a dictionary. Definitely not expected use for us, but it shouldn't error out if that's the case.

This PR adds a check to make sure the interview key is a string like we expect it to be. If it's not, we fallback to the other methods (just checking the only entry in `interview_metadata` like we do in the next check works in this case).