### PR TITLE
Move Metadata over to metadatablock

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -366,10 +366,18 @@ content: |
       MAIN_METADATA = next(iter(interview_metadata.values())) 
     %>
   % else:
-    <% MAIN_METADATA = {} %>
+    <% MAIN_METADATA = all_variables(special='metadata') %>
   % endif
-  % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form", "").strip() == "None" and MAIN_METADATA.get("original_form").startswith("http"):
-  [View the original version of this form](${ MAIN_METADATA.get("original_form") }).
+  <% ORIGINAL_FORMS = MAIN_METADATA.get("original_form", []) if isinstance(MAIN_METADATA.get("original_form"), list) else ([MAIN_METADATA.get("original_form", "")] if MAIN_METADATA.get("original_form") else []) %>
+
+  % if len(ORIGINAL_FORMS) > 1:
+  View the original version of this form at the links below:
+
+  % for url in [url for url in ORIGINAL_FORMS if url.strip() != "None" and url.startswith("http")]:
+  * [${ url }](${ url })
+  % endfor
+  % elif len(ORIGINAL_FORMS) == 1:
+  [View the original version of this form](${ ORIGINAL_FORMS[0] }).
   % endif
   
   % if package_updated_on:
@@ -445,8 +453,9 @@ subquestion: |
       MAIN_METADATA = next(iter(interview_metadata.values())) 
     %>
   % else:
-    <% MAIN_METADATA = {} %>
+    <% MAIN_METADATA = all_variables(special='metadata') %>
   % endif
+  <% ORIGINAL_FORMS = MAIN_METADATA.get("original_form", []) if isinstance(MAIN_METADATA.get("original_form"), list) else ([MAIN_METADATA.get("original_form", "")] if MAIN_METADATA.get("original_form") else []) %>
 
   We ran into an error when we tried to load this screen.
 
@@ -459,8 +468,13 @@ subquestion: |
   % if al_enable_incomplete_downloads:
   * Try to [download your work in progress](${ url_action("al_error_action_download_screen") })
   % endif
-  % if MAIN_METADATA.get("original_form") and not MAIN_METADATA.get("original_form", "").strip() == "None":
-  * [Download a blank "${ all_variables(special='metadata').get("title", "").strip() }"](${ MAIN_METADATA.get("original_form") } )
+  % if len(ORIGINAL_FORMS) > 1:
+  * Download a blank "${ all_variables(special='metadata').get("title", "").strip() }":
+  % for url in ORIGINAL_FORMS:
+      * [${ url }](${ url } )
+  % endfor
+  % elif len(ORIGINAL_FORMS) == 1:
+  * [Download a blank "${ all_variables(special='metadata').get("title", "").strip() }"]( ${ ORIGINAL_FORMS[0] })
   % endif
   * Visit the [${ AL_ORGANIZATION_TITLE } home page](${ AL_ORGANIZATION_HOMEPAGE }) and try another interview
   % if al_show_email_to_user_on_errors and get_config("error notification email"):

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -434,8 +434,10 @@ continue button field: al_exit_logout_confirmation
 metadata:
   error action: al_custom_error_action
 ---
+# Only necessary to ignore playground "undefined names" warning
 objects:
   - MAIN_METADATA: DAEmpty()
+  - ORIGINAL_FORMS: DAEmpty()
 ---
 id: custom error action
 event: al_custom_error_action


### PR DESCRIPTION
In https://github.com/SuffolkLITLab/docassemble-ALWeaver/pull/835, we moved a lot of the metadata from the `interview_metadata` variable to the `metadata` block. This PR finishes the job, and allows AssemblyLine to look in the `metadata` block, if there isn't an `interview_metadata` at all. This works for newly weaved forms, and I've confirmed that it works great for interviews with and without `interview_metadata` as well.

The only tricky part was that `original_forms` in the metadata block has become a list of URLs, instead of just one. IMO that's fine, but I had to refactor some things and define one more mako variable to make the code clean. When there's only one original form, it'll still show as normal, and if there are more than one, it'll show raw URLs for each. Which is fine, not great, but I'm not sure if it's better to just list "original form 1", "original form 2", etc. Open to feedback here. 