### PR TITLE
Update send_button_html docs

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2091,7 +2091,8 @@ class ALDocumentBundle(DAList):
             show_editable_checkbox (bool, optional): Flag indicating if the checkbox
                 for deciding the inclusion of an editable (Word) copy should be displayed.
                 Defaults to True.
-            template_name (str, optional): The name of the template to be used. Defaults to an empty string.
+            template_name (str, optional): Name of the template variable that is used to fill
+                the email contents. By default, the `x.send_email_template` template will be used.
 
         Returns:
             str: The generated HTML string for the input box and button.


### PR DESCRIPTION
I tend to "follow the code", and it took be a little bit to figure out what the default template was actually used here. Figured I'd put it in the documentation to make it clearer to folks who might look at the API documentation.