### PR TITLE
Include AssemblyLine through interview list

### DIFF
--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -2,19 +2,14 @@
 # Provide a replacement for the /interviews endpoint in Docassemble
 ---
 include: 
-  - docassemble.ALToolbox:display_template.yml
-  - al_settings.yml
+  - assembly_line.yml
 ---
 features:
   small screen navigation: dropdown
   navigation: True
   navigation back button: False
-  javascript:
-    - al_audio.js
   css:
-    - styles.css
-    - al_audio.css
-    - interview_list.css    
+    - interview_list.css
   question help button: True
   question back button: False
 ---
@@ -79,6 +74,9 @@ default screen parts:
         <span class="title-row-2">${ all_variables(special='metadata').get('short title','').rstrip() }</span>
       </span>
     </span>
+  # These two were originally blank before including all of AssemblyLine.
+  pre: ""
+  footer: ""
 ---
 mandatory: True
 code: |


### PR DESCRIPTION
At MLH, we make a `interview_list` wrapper recently, that just included our interview framework YAML and `interview_list.yml`.

However, in doing so, `al_audio.js` is added twice to the page twice, and runs twice, so there are two Voice RSS widgets that show up, and one of them doesn't properly work (since it has the same id as the first).

IMO, `interview_list.yml` should just use AssemblyLine fully, instead of the awkward half-includes that it currently does. The only changes that happen when you do so are the red `pre` debug text and the footer, both of which I manually set to empty. People are welcome to re-enable those on `interview_list` if they wish.

I'm working an a PR to stop the JS stuff from running twice, even if it's on the page twice, still in progress there.

Downstream issue: https://github.com/mplp/docassemble-mlhframework/issues/15