### PR TITLE
International addresses

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -176,17 +176,6 @@ class ALAddress(Address):
             ]
         else:
             fields = []
-        if show_country:
-            fields.append(
-                {
-                    "label": str(self.country_label),
-                    "field": self.attr_name("country"),
-                    "required": False,
-                    "code": "countries_list()",
-                    "default": country_code,
-                }
-            )
-
         fields.extend(
             [
                 {
@@ -252,6 +241,16 @@ class ALAddress(Address):
                     "label": str(self.county_label),
                     "field": self.attr_name("county"),
                     "required": False,
+                }
+            )
+        if show_country:
+            fields.append(
+                {
+                    "label": str(self.country_label),
+                    "field": self.attr_name("country"),
+                    "required": False,
+                    "code": "countries_list()",
+                    "default": country_code,
                 }
             )
             # NOTE: using , "datatype": "combobox" might be nice but does not play together well w/ address autocomplete

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -21,9 +21,11 @@ from docassemble.base.util import (
     Individual,
     IndividualName,
     its,
+    log,
     name_suffix,
     phone_number_formatted,
     phone_number_is_valid,
+    showifdef,
     state_name,
     states_list,
     subdivision_type,
@@ -150,6 +152,10 @@ class ALAddress(Address):
         # differs from the server's country.
         if country_code and country_code != get_country() and not show_country:
             self.country = country_code
+        # Priority order for country: already answered country, passed in country_code, then get_country
+        prev_selected_country = showifdef(self.attr_name("country"), None, prior=True)
+        if prev_selected_country:
+            country_code = prev_selected_country
         if not country_code:
             country_code = get_country()
         if allow_no_address:
@@ -171,6 +177,17 @@ class ALAddress(Address):
             ]
         else:
             fields = []
+        if show_country:
+            fields.append(
+                {
+                    "label": str(self.country_label),
+                    "field": self.attr_name("country"),
+                    "required": False,
+                    "code": "countries_list()",
+                    "default": country_code,
+                }
+            )
+
         fields.extend(
             [
                 {
@@ -210,7 +227,7 @@ class ALAddress(Address):
                     "default": default_state if default_state else "",
                 }
             )
-        if country_code == "US":
+        if country_code == "US" and not show_country:
             fields.append(
                 {
                     "label": str(self.zip_label),
@@ -236,16 +253,6 @@ class ALAddress(Address):
                     "label": str(self.county_label),
                     "field": self.attr_name("county"),
                     "required": False,
-                }
-            )
-        if show_country:
-            fields.append(
-                {
-                    "label": str(self.country_label),
-                    "field": self.attr_name("country"),
-                    "required": False,
-                    "code": "countries_list()",
-                    "default": country_code,
                 }
             )
             # NOTE: using , "datatype": "combobox" might be nice but does not play together well w/ address autocomplete

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -21,7 +21,6 @@ from docassemble.base.util import (
     Individual,
     IndividualName,
     its,
-    log,
     name_suffix,
     phone_number_formatted,
     phone_number_is_valid,
@@ -210,7 +209,7 @@ class ALAddress(Address):
 
         fields.append({"label": str(self.city_label), "field": self.attr_name("city")})
 
-        if country_code:
+        if country_code and not show_country:
             fields.append(
                 {
                     "label": str(self.state_label),
@@ -219,10 +218,10 @@ class ALAddress(Address):
                     "default": default_state if default_state else "",
                 }
             )
-        else:  # not showing country and not showing country code
+        else:  # when you are allowed to change country
             fields.append(
                 {
-                    "label": str(self.state_label),
+                    "label": str(self.state_or_province_label),
                     "field": self.attr_name("state"),
                     "default": default_state if default_state else "",
                 }
@@ -528,7 +527,7 @@ class ALAddress(Address):
 
         Args:
             include_unit (bool): If True, includes the unit in the formatted address. Defaults to True.
-            omit_default_country (bool): If True, omits the default country from the formatted address. Defaults to True.
+            omit_default_country (bool): If True, doesn't show the Docassemble default country in the formatted address. Defaults to True.
             language (str, optional): Language for the address format.
             show_country (bool, optional): If True, includes the country in the formatted address.
                 If None, decides based on the country attribute.

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -472,6 +472,7 @@ subquestion: |
 fields:
   - code: |
       users[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
+check in: update_states_list
 ---
 id: your mailing address
 question: |
@@ -503,6 +504,7 @@ fields:
   - ${ users[0].address.country_label}: users[0].mailing_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
+check in: update_states_list
 ---
 id: user i's address
 question: |
@@ -534,6 +536,7 @@ fields:
 #  - ${ users[i].address.country_label}: users[i].address.country
 #    code: countries_list()
 #    default: ${ AL_DEFAULT_COUNTRY }
+check in: update_states_list
 ---
 generic object: ALIndividual
 id: any mailing address
@@ -563,6 +566,7 @@ fields:
   - ${ x.address.country_label }: x.mailing_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
+check in: update_states_list
 ---
 generic object: ALIndividual
 id: any service address
@@ -593,6 +597,20 @@ fields:
   - ${ x.service_address.country_label }: x.service_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
+check in: update_states_list
+---
+event: update_states_list
+code: |
+  log(f"{action_argument('_changed')}")
+  changed_var = action_argument("_changed")
+  if changed_var and changed_var.endswith('.country'):
+    base_var = changed_var[:-len(".country")]
+    background_response({
+      f"{base_var}.state": {
+        "choices": states_list(country_code=action_argument(changed_var)) or ["N/A"]
+      }
+    }, 'fields')
+  background_response()
 ---
 generic object: ALIndividual
 id: service method

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -362,6 +362,11 @@ content: |
   % endif
 ---
 generic object: ALAddress
+template: x.state_or_province_label
+content: |
+  State / Province
+---
+generic object: ALAddress
 template: x.zip_label
 content: |
   Zip or postal code
@@ -472,7 +477,6 @@ subquestion: |
 fields:
   - code: |
       users[0].address_fields(country_code=AL_DEFAULT_COUNTRY, default_state=AL_DEFAULT_STATE)
-check in: update_states_list
 ---
 id: your mailing address
 question: |
@@ -504,7 +508,6 @@ fields:
   - ${ users[0].address.country_label}: users[0].mailing_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
-check in: update_states_list
 ---
 id: user i's address
 question: |
@@ -536,7 +539,6 @@ fields:
 #  - ${ users[i].address.country_label}: users[i].address.country
 #    code: countries_list()
 #    default: ${ AL_DEFAULT_COUNTRY }
-check in: update_states_list
 ---
 generic object: ALIndividual
 id: any mailing address
@@ -566,7 +568,6 @@ fields:
   - ${ x.address.country_label }: x.mailing_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
-check in: update_states_list
 ---
 generic object: ALIndividual
 id: any service address
@@ -597,20 +598,6 @@ fields:
   - ${ x.service_address.country_label }: x.service_address.country
     code: countries_list()
     default: ${ AL_DEFAULT_COUNTRY }
-check in: update_states_list
----
-event: update_states_list
-code: |
-  log(f"{action_argument('_changed')}")
-  changed_var = action_argument("_changed")
-  if changed_var and changed_var.endswith('.country'):
-    base_var = changed_var[:-len(".country")]
-    background_response({
-      f"{base_var}.state": {
-        "choices": states_list(country_code=action_argument(changed_var)) or ["N/A"]
-      }
-    }, 'fields')
-  background_response()
 ---
 generic object: ALIndividual
 id: service method


### PR DESCRIPTION
Minor changes that address #281. More details in that issue, but I don't think it's possible to get the full state dropdown for each country without messing up Google autocomplete, so when the country is an input, we turn the state list into a text box (I tried swapping out a dropdown for just the US and text input for other countries, but Google autocomplete also has a problem with that).

Only other changes were to change the "State" label to "State / Province" when the country is an input, and a few comments / docs, for accuracy.

Also relevant to https://github.com/mplp/docassemble-MLHMotionRegardingChildSupport/issues/6. 