### PR TITLE
Check SMS is enabled before showing texting opts

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1812,10 +1812,13 @@ def fa_icon(
         )
 
 
-def is_sms_enabled():
+def is_sms_enabled() -> bool:
     """Checks if SMS (Twilio) is enabled on the server. Does not verify that it works.
 
     See https://docassemble.org/docs/config.html#twilio for more info.
+
+    Returns:
+        bool: True if there is a non-empty Twilio config on the server, False otherwise
     """
     twilio_config = get_config("twilio")
     if isinstance(twilio_config, list):

--- a/docassemble/AssemblyLine/data/questions/al_reminders.yml
+++ b/docassemble/AssemblyLine/data/questions/al_reminders.yml
@@ -65,14 +65,13 @@ fields:
     datatype: yesnoradio
   - I want to get reminders by: al_user_preferred_reminder_formats
     datatype: checkboxes
-    choices:
-      - SMS (text message): sms
-      - Email: email
+    code: |
+      al_reminder_delivery_options
     minlength: 1
     validation messages:
       minlength: |
         You need to choose to get reminders by either email or SMS, or both.
-    show if: al_user_wants_reminders    
+    show if: al_user_wants_reminders
   - Email: al_user_reminder_email
     datatype: email
     default: |
@@ -92,6 +91,13 @@ fields:
     validate: |
       lambda y: phone_number_is_valid(y) or validation_error("Enter a valid phone number")
     show if: al_user_preferred_reminder_formats["sms"]
+---
+code: |
+  al_reminder_delivery_options = [
+    {"email": word("Email")},
+  ]
+  if is_sms_enabled():
+    al_reminder_delivery_options.append({"sms": word("SMS (text message)")})
 ---
 variable name: al_reminders
 use objects: True

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -195,14 +195,20 @@ fields:
     datatype: radio
     code: |
       sharing_choices
-  -  How do you want to share the link?: al_how_share_link
-     datatype: radio
-     choices:
-       - Email${ " or text message" if is_sms_enabled() else ""}: email_or_sms
-       - Just show me the link. I will share it myself.: link_only
-       - Export my answers to a file: download_json
-     js show if: |
-       val("al_sharing_type") === "tell_friend" || val("al_sharing_type") === "share_answers" 
+  - How do you want to share the link?: al_how_share_link
+    datatype: radio
+    choices:
+      - label: |
+          % if is_sms_enabled():
+          Email or text message
+          % else:
+          Email
+          % endif
+        value: email_or_sms
+      - Just show me the link. I will share it myself.: link_only
+      - Export my answers to a file: download_json
+    js show if: |
+      val("al_sharing_type") === "tell_friend" || val("al_sharing_type") === "share_answers"
   - note: |
       **Note**: the person you share this link with will be able to see and
       edit your answers on this form.
@@ -219,7 +225,13 @@ fields:
       ${ copy_button_html( interview_url(temporary=48), label=al_copy_button_label.show(), tooltip_inert_text=al_copy_button_tooltip_inert_text.show(), tooltip_copied_text = al_copy_button_tooltip_copied_text.show()) }
     js show if: |
       val("al_sharing_type") === "share_answers" && val("al_how_share_link") === "link_only"
-  - Email ${ "or phone number " if is_sms_enabled() else ""}you want to send this to: share_interview_contact_method
+  - label: |
+      % if is_sms_enabled():
+      Email or phone number you want to send this to
+      % else:
+      Email you want to send this to
+      % endif
+    field: share_interview_contact_method
     validate: is_phone_or_email
     show if:
       variable: al_how_share_link
@@ -317,7 +329,7 @@ template: al_share_answers_message_template
 subject: |
   ${ AL_ORGANIZATION_TITLE } form from ${ al_share_form_from_name }
 content: |
-  ${ share_interview_answers_message.replace("\n", "<br>") }
+  ${ share_interview_answers_message.replace("\n", "<br/>") }
   Click the link below to view and edit ${ al_share_form_from_name }'s
   progress so far:
   
@@ -327,7 +339,7 @@ template: al_tell_a_friend_message_template
 subject: |
   ${ al_share_form_from_name } wants to tell you about ${ AL_ORGANIZATION_TITLE }
 content: |
-  ${ tell_a_friend_message.replace("\n", "<br>") }
+  ${ tell_a_friend_message.replace("\n", "<br/>") }
   ${ interview_url(i=user_info().filename, style="short", new_session=1) }
 ---
 code: |

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -193,13 +193,12 @@ question: |
 fields:
   - What do you want to do?: al_sharing_type
     datatype: radio
-    choices:
-      - Tell a friend about this website: tell_friend
-      - Share my answers and progress with someone: share_answers
+    code: |
+      sharing_choices
   -  How do you want to share the link?: al_how_share_link
      datatype: radio
      choices:
-       - Email or text message: email_or_sms
+       - Email${ " or text message" if is_sms_enabled() else ""}: email_or_sms
        - Just show me the link. I will share it myself.: link_only
        - Export my answers to a file: download_json
      js show if: |
@@ -220,7 +219,7 @@ fields:
       ${ copy_button_html( interview_url(temporary=48), label=al_copy_button_label.show(), tooltip_inert_text=al_copy_button_tooltip_inert_text.show(), tooltip_copied_text = al_copy_button_tooltip_copied_text.show()) }
     js show if: |
       val("al_sharing_type") === "share_answers" && val("al_how_share_link") === "link_only"
-  - Email or phone number you want to send this to: share_interview_contact_method
+  - Email ${ "or phone number " if is_sms_enabled() else ""}you want to send this to: share_interview_contact_method
     validate: is_phone_or_email
     show if:
       variable: al_how_share_link
@@ -252,6 +251,13 @@ fields:
       is: download_json
 back button label: |
   Back to your form
+---
+code: |
+  sharing_choices = [
+      {"tell_friend": word("Tell a friend about this website")},
+  ]
+  if showifdef("multi_user", False):
+      sharing_choices.append({"share_answers": word("Share my answers and progress with someone")})
 ---
 id: Results of sharing
 continue button field: al_share_results
@@ -311,7 +317,7 @@ template: al_share_answers_message_template
 subject: |
   ${ AL_ORGANIZATION_TITLE } form from ${ al_share_form_from_name }
 content: |
-  ${ share_interview_answers_message }
+  ${ share_interview_answers_message.replace("\n", "<br>") }
   Click the link below to view and edit ${ al_share_form_from_name }'s
   progress so far:
   
@@ -321,7 +327,7 @@ template: al_tell_a_friend_message_template
 subject: |
   ${ al_share_form_from_name } wants to tell you about ${ AL_ORGANIZATION_TITLE }
 content: |
-  ${ tell_a_friend_message }
+  ${ tell_a_friend_message.replace("\n", "<br>") }
   ${ interview_url(i=user_info().filename, style="short", new_session=1) }
 ---
 code: |

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1385,7 +1385,11 @@ fields:
     choices:
       - On a phone with my finger: phone
         help: |
+          % if is_sms_enabled():
           We can text or share a link with your phone on the next screen
+          % else:
+          We can share a link with your phone on the next screen
+          % endif
       - On a computer with my mouse: this_device
     show if:
       code: |
@@ -1395,7 +1399,11 @@ fields:
     choices:
       - On a phone with my finger: phone
         help: |
+          % if is_sms_enabled():
           We can text or share a link with your phone on the next screen
+          % else:
+          We can share a link with your phone on the next screen
+          % endif
       - On a computer with my mouse: this_device
       - On the paper with a pen after I print the documents: sign_after_printing
     show if:
@@ -1440,7 +1448,7 @@ fields:
       4. Click ${word("next")} on your phone.
       
       <center>
-      ${interview_url_as_qr()}
+      ${interview_url_as_qr(style="short")}
       </center>
 
       ${ collapse_template(help_using_qr_code_template) }
@@ -1451,7 +1459,7 @@ fields:
     datatype: yesnowide
     show if: 
       code: |
-        device() and device().is_pc
+        device() and device().is_pc and is_sms_enabled()
   - label: Cell phone number
     field: link_cell
     show if: text_link
@@ -1460,17 +1468,24 @@ fields:
       Click ${word("next")} to add your signature.
     show if: 
       code: |
-        device() and not device().is_pc
+        device() and not device().is_pc and is_sms_enabled()
 continue button field: saw_signature_qrcode
 ---
 template: help_using_qr_code_template
 subject: |
   How do I use this screen?
-content: |          
+content: |
   Many smartphones will automatically find the link on this screen when you use
   the camera app. The link
   may "float" up from the screen into a small icon you can tap.
-  If your phone does not do this, use the text option instead.
+  % if is_sms_enabled():
+  If your phone does not do this, use the text option instead, or
+  % else:
+  If your phone does not do this
+  % endif
+  you can enter this link manually into your phone's browser:
+
+  [${ interview_url(style="short") }](${ interview_url(style="short") })
 ---
 id: signature phone followup
 question: |


### PR DESCRIPTION
* `is_sms_enabled()`, sees if the `twilio` config in the settings are non-empty (doesn't check that they work)
* Turns off mentions of texting in the "Share" page
* Turns off option to get texts from the reminder system
* Turns off options to text the link to yourself when signing

The only change I could see being suggested is to move `is_sms_enabled()` (and `is_phone_or_email()`, even thought it's been in AL for a while) to the Toolbox. IMO, it's not worth splitting highly coupled functions between two different packages, but will happily do it if suggested.

Fixes #411 for texting, not for email, but as mentioned in the meeting this morning, most of our users have some sort of email enabled on their server.