### PR TITLE
Remove redundant alt-text on logos

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,9 +1,9 @@
 ---
 objects:
-  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Assembly Line Logo")
+  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
 ---
 code: |
-  al_logo.alt_text = "Home - Assembly Line"
+  al_logo.alt_text = ""
 ---
 default screen parts:
   title: |

--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -3,7 +3,7 @@ objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
 ---
 code: |
-  al_logo.alt_text = ""
+  al_logo.alt_text = "" # Per accessibility recommendations, best to leave alt text off a logo
 ---
 default screen parts:
   title: |

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -123,10 +123,10 @@ modules:
   - docassemble.ALToolbox.misc
 ---
 objects:
-  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="Logo")
+  - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
 ---
 code: |
-  al_logo.alt_text = "Logo" # Patch for old sessions
+  al_logo.alt_text = "" # Patch for old sessions
 ---
 # This block is a placeholder and will be replaced by the definition below
 sections:


### PR DESCRIPTION
Fix #795