### PR TITLE
Un-hypenate sign-in

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -179,7 +179,7 @@ code: |
 default screen parts:
   under: |
     % if not user_logged_in():
-    [:sign-in-alt: Sign-in](${url_of('login', next=interview_url())}) or [register](${url_of('register', next=interview_url())}) to save your progress (optional).
+    [:sign-in-alt: Sign in](${url_of('login', next=interview_url())}) or [register](${url_of('register', next=interview_url())}) to save your progress (optional).
     % endif
   footer: |
     [:share-alt-square: Share](${ url_ask([{'undefine': ['al_sharing_type','al_how_share_link']}, 'al_share_form_screen', {'recompute': ['al_did_share_form']}, 'al_share_results']) })


### PR DESCRIPTION
Very minor note that someone noticed when doing feedback of our interviews. Assembly Line doesn't hypenate it elsewhere: https://github.com/SuffolkLITLab/docassemble-AssemblyLine/blob/3d0181df9f2c78a87db86e018825cffaf8ce27c4/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml#L60, so this makes us consistent with other text on the screen and ourselves.