### PR TITLE
Don't pass 'bare' parameter unless it's an ALAddress

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1456,7 +1456,6 @@ class ALIndividual(Individual):
                     language=language,
                     international=international,
                     show_country=show_country,
-                    show_impounded=show_impounded,
                 )
         else:
             if isinstance(self.address, ALAddress):
@@ -1481,7 +1480,6 @@ class ALIndividual(Individual):
                         language=language,
                         international=international,
                         show_country=show_country,
-                        show_impounded=show_impounded,
                     )
                 )
 

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -712,7 +712,7 @@ class ALPeopleList(DAList):
         """
         return comma_and_list(
             [
-                str(person) + ", " + person.address.on_one_line(bare=bare)
+                str(person) + ", " + (person.address.on_one_line(bare=bare) if isinstance(person.address, ALAddress) else str(person.address.on_one_line()))
                 for person in self
             ],
             comma_string=comma_string,
@@ -1436,29 +1436,48 @@ class ALIndividual(Individual):
             str: The formatted address block.
         """
         if this_thread.evaluation_context == "docx":
-            return (
-                self.name.full()
-                + '</w:t><w:br/><w:t xml:space="preserve">'
-                + self.address.block(
+            if isinstance(self.address, ALAddress):
+                return self.address.block(
                     language=language,
                     international=international,
                     show_country=show_country,
                     bare=bare,
                     show_impounded=show_impounded,
                 )
-            )
-        return (
-            "[FLUSHLEFT] "
-            + self.name.full()
-            + " [NEWLINE] "
-            + self.address.block(
-                language=language,
-                international=international,
-                show_country=show_country,
-                bare=bare,
-                show_impounded=show_impounded,
-            )
-        )
+            else:
+                # bare parameter is ignored for plain Address objects
+                return self.address.block(
+                    language=language,
+                    international=international,
+                    show_country=show_country,
+                    show_impounded=show_impounded,
+                )
+        else:
+            if isinstance(self.address, ALAddress):
+                return (
+                    "[FLUSHLEFT] "
+                    + self.name.full()
+                    + " [NEWLINE] "
+                    + self.address.block(
+                        language=language,
+                        international=international,
+                        show_country=show_country,
+                        bare=bare,
+                        show_impounded=show_impounded,
+                    )
+                )
+            else:
+                return (
+                    "[FLUSHLEFT] "
+                    + self.name.full()
+                    + " [NEWLINE] "
+                    + self.address.block(
+                        language=language,
+                        international=international,
+                        show_country=show_country,
+                        show_impounded=show_impounded,
+                    )
+                )
 
     def pronoun(self, **kwargs) -> str:
         """Returns an objective pronoun as appropriate, based on attributes.

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -712,7 +712,13 @@ class ALPeopleList(DAList):
         """
         return comma_and_list(
             [
-                str(person) + ", " + (person.address.on_one_line(bare=bare) if isinstance(person.address, ALAddress) else str(person.address.on_one_line()))
+                str(person)
+                + ", "
+                + (
+                    person.address.on_one_line(bare=bare)
+                    if isinstance(person.address, ALAddress)
+                    else str(person.address.on_one_line())
+                )
                 for person in self
             ],
             comma_string=comma_string,


### PR DESCRIPTION
Also don't pass `show_impounded`

Fix  #816

Test YAML that only works after this change:

```yaml
---
include:
  - assembly_line.yml
---
objects:
  - the_address: Address
---
id: your address
question: |
  What is your address?
subquestion: |
  Where do you live?
fields:
  - Street address: the_address.address
    address autocomplete: True
  - Unit: the_address.unit
    required: False
  - City: the_address.city
  - State: the_address.state
    code: |
      states_list()
    default: MA      
  - Zip: the_address.zip
    required: False
---
mandatory: True
code: |
  users.gather()
  users[0].address = the_address
  message(users[0].address_block())
```