### PR TITLE
Make a simpler API for customizing list of filtered variables

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -191,3 +191,6 @@ code: |
 template: alkiln_trigger_html
 content: |
     <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
+---
+code: |
+  al_sessions_additional_variables_to_filter = []

--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
@@ -180,13 +180,18 @@ code: |
 event: al_sessions_fast_forward_session
 code: |
   # set_save_status('ignore')
-  al_sessions_snapshot_results = load_interview_answers(action_argument("i"), action_argument("session"), new_session=False)
+  al_sessions_snapshot_results = load_interview_answers(
+        action_argument("i"), 
+        action_argument("session"), 
+        new_session=False, 
+        additional_variables_to_filter=al_sessions_additional_variables_to_filter)
   force_ask('al_sessions_load_status')
 ---
 code: |
   if user_logged_in():
     new_session_id = save_interview_answers(
-          metadata = { "title": al_sessions_snapshot_label }
+          metadata = { "title": al_sessions_snapshot_label },
+          additional_variables_to_filter=al_sessions_additional_variables_to_filter,
         )
     log(f"Saved interview {al_sessions_snapshot_label} with id {new_session_id}")
   else:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1076,7 +1076,7 @@ def get_filtered_session_variables(
     filename: Optional[str] = None,
     session_id: Optional[int] = None,
     variables_to_filter: Optional[Union[Set[str], List[str]]] = None,
-    additional_variables_to_filter: Optional[Union[Set[str], List[str]]]=None,
+    additional_variables_to_filter: Optional[Union[Set[str], List[str]]] = None,
 ) -> Dict[str, Any]:
     """
     Retrieves a filtered subset of variables from a specified interview and session.
@@ -1098,7 +1098,7 @@ def get_filtered_session_variables(
         additional_variables_to_filter = []
     variables_to_filter = set(variables_to_filter).union(
         set(additional_variables_to_filter)
-    )        
+    )
 
     if filename and session_id:
         all_vars = get_session_variables(filename, session_id, simplify=False)
@@ -1150,7 +1150,7 @@ def get_filtered_session_variables_string(
     filename: Optional[str] = None,
     session_id: Optional[int] = None,
     variables_to_filter: Union[Set[str], List[str], None] = None,
-    additional_variables_to_filter: Optional[Union[Set[str], List[str]]]=None,
+    additional_variables_to_filter: Optional[Union[Set[str], List[str]]] = None,
 ) -> str:
     """
     Returns a JSON string that represents the filtered contents of a specified filename and session ID.
@@ -1165,7 +1165,12 @@ def get_filtered_session_variables_string(
         str: A JSON-formatted string of filtered session variables.
     """
     simple_vars = serializable_dict(
-        get_filtered_session_variables(filename=filename, session_id=session_id, variables_to_filter=variables_to_filter, additional_variables_to_filter=additional_variables_to_filter)
+        get_filtered_session_variables(
+            filename=filename,
+            session_id=session_id,
+            variables_to_filter=variables_to_filter,
+            additional_variables_to_filter=additional_variables_to_filter,
+        )
     )
     return json.dumps(simple_vars)
 
@@ -1196,7 +1201,10 @@ def load_interview_answers(
     """
 
     old_variables = get_filtered_session_variables(
-        filename=old_interview_filename, session_id=old_session_id, variables_to_filter=variables_to_filter, additional_variables_to_filter=additional_variables_to_filter
+        filename=old_interview_filename,
+        session_id=old_session_id,
+        variables_to_filter=variables_to_filter,
+        additional_variables_to_filter=additional_variables_to_filter,
     )
 
     if new_session:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1160,6 +1160,7 @@ def get_filtered_session_variables_string(
         filename (Optional[str], optional): Filename of the session. Defaults to None.
         session_id (Optional[int], optional): Session ID to retrieve variables from. Defaults to None.
         variables_to_filter (Union[Set[str], List[str], None], optional): List or set of variables to exclude. Defaults to `al_sessions_variables_to_remove`.
+        additional_variables_to_filter (Union[Set[str], List[str], None], optional): List or set of additional variables to exclude. Defaults to None.
 
     Returns:
         str: A JSON-formatted string of filtered session variables.


### PR DESCRIPTION
Fix #825

You can now customize the list of filtered variables when saving or loading a snapshot by adding a new definition of `al_sessions_additional_variables_to_filter`, without having to manually add all of the Docassemble and AssemblyLine variables that should always be filtered.

Tested manually by loading and saving some sessions.