### PR TITLE
Add a hide_hud parameter to enable hiding the id/variable/package number

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -41,10 +41,10 @@ default screen parts:
   corner back button label: |
     Undo
   pre: |
-    % if get_config('debug'):
-    `id: ${ user_info().question_id }`  
-    `Variable triggering this screen: ${ user_info().variable }`  
-    `Package: ${ user_info().package } ${ package_version_number }; ${ al_version }`
+    % if get_config('debug') and not url_args.get("hide_hud", "").lower() in ["1", "on", "true", "yes"]:
+    `id: ${ user_info().question_id }`[BR]
+    `Variable: ${ user_info().variable }`[BR]
+    `Version: ${ user_info().package.replace("docassemble.", "") + " " if not user_info().package.startswith("docassemble.playground") else "" }${ package_version_number }; ${ al_version }`
     <div data-variable="${ encode_name(str( user_info().variable )) }" id="sought_variable" aria-hidden="true" style="display: none;"></div>
     % endif
   # We need both pre and post until old interviews are updated to v2 of the testing framework or v1 of the testing framework is updated. In future, we will need this in `post` so that it will work on signature pages.


### PR DESCRIPTION
Fix #771 

Adds an optional URL parameter, `hide_hud`, that can be used to hide the "red" text that displays when the server
is in debug mode. This can be helpful if you want to share a link to the interview on a development server and the red text will distract the recipient.