### PR TITLE
Shorter way to specify name.full(middle='full')

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1683,7 +1683,8 @@ class ALIndividual(Individual):
     def name_initials(self) -> str:
         """
         Returns the individual's name with the middle name as an initial.
-        Equivalent to `name.full(middle="initial")`.
+        Equivalent to `name.full(middle="initial")`, which is also the default.
+        Defined only to make it possible to be explicit about the name form.
 
         Returns:
             str: The individual's name with the middle name as an initial.
@@ -1700,6 +1701,7 @@ class ALIndividual(Individual):
             str: The individual'
         """
         return self.name.firstlast()
+
 
 # (DANav isn't in public DA API, but currently in functions.py)
 def section_links(nav) -> List[str]:  # type: ignore

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1672,6 +1672,34 @@ class ALIndividual(Individual):
             return capitalize(output)
         return output
 
+    def name_full(self) -> str:
+        """Returns the individual's full name.
+
+        Returns:
+            str: The individual's full name.
+        """
+        return self.name.full(middle="full")
+
+    def name_initials(self) -> str:
+        """
+        Returns the individual's name with the middle name as an initial.
+        Equivalent to `name.full(middle="initial")`.
+
+        Returns:
+            str: The individual's name with the middle name as an initial.
+        """
+        return self.name.full(middle="initial")
+
+    def name_short(self) -> str:
+        """
+        Returns the individual's name without any middle name.
+
+        Equivalent to self.name.firstlast()
+
+        Returns:
+            str: The individual'
+        """
+        return self.name.firstlast()
 
 # (DANav isn't in public DA API, but currently in functions.py)
 def section_links(nav) -> List[str]:  # type: ignore

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -426,6 +426,15 @@ class TestALIndividual(unittest.TestCase):
         # Should raise an exception
         with self.assertRaises(DAAttributeError):
             self.individual.pronoun_objective()
+    
+    def test_name_methods(self):
+        self.individual.name.first = "John"
+        self.individual.name.middle = "Jacob"
+        self.individual.name.last = "Jingleheimer"
+
+        self.assertEqual(self.individual.name_full(), "John Jacob Jingleheimer")
+        self.assertEqual(self.individual.name_initials(), "John J. Jingleheimer")
+        self.assertEqual(self.individual.name_short(), "John Jingleheimer")
 
 
 class test_get_visible_al_nav_items(unittest.TestCase):

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -426,7 +426,7 @@ class TestALIndividual(unittest.TestCase):
         # Should raise an exception
         with self.assertRaises(DAAttributeError):
             self.individual.pronoun_objective()
-    
+
     def test_name_methods(self):
         self.individual.name.first = "John"
         self.individual.name.middle = "Jacob"


### PR DESCRIPTION
Fix #818

Adds 3 new methods directly on ALIndividual to shorten various methods of IndividualName:

* ALIndividual.name_full() = ALIndividual.name.full(middle="full")
* ALIndividual.name_short() = ALIndividual.name.firstlast()
* ALIndividual.name_initials() = ALIndividual.name.full(middle="initial")