### PR TITLE
Undo deprecation declaration for "trigger" HTML

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_code.yml
+++ b/docassemble/AssemblyLine/data/questions/al_code.yml
@@ -186,13 +186,16 @@ code: |
     # If the user role was set to "unknown" at the time wizard run
     user_role = user_ask_role
 ---
-# Old HTML for ALKiln deprecated 3-column Story Tables.
+# HTML for interviews using ALKiln tests at ALKiln
+# Necessary for servers that set their `restrict input variables` config value to `True`
+# If you are using al_package_unstyled.yml, copy it into your `default screen parts: post`
 template: alkiln_trigger_html
 content: |
   <div data-variable="${ encode_name(str( user_info().variable )) }" id="trigger" aria-hidden="true" style="display: none;"></div>
 ---
 # HTML for interviews using ALKiln tests at ALKiln versions 5.9.0 and above.
-# If you are using al_package_unstyled.yml, include it in your `default screen parts: post`
+# Necessary for interviews that use docassemble generic objects or index variables
+# If you are using al_package_unstyled.yml, copy it into your `default screen parts: post`
 template: alkiln_proxy_html
 content: |
   <div id="alkiln_proxy_var_values"


### PR DESCRIPTION
As the comments now describe, some servers still need the HTML code to add the trigger variable name to the DOM.

As this is just a comment and doesn't change any functional code, I'm just going to merge it.