### PR TITLE
When using the as_pdf() method of a bundle, add parameter to ensure an odd or even number of pages

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1479,6 +1479,7 @@ class ALDocumentBundle(DAList):
         enabled (bool, optional): Determines if the bundle is active. Defaults to True.
         auto_gather (bool, optional): Automatically gathers attributes. Defaults to False.
         gathered (bool, optional): Specifies if attributes have been gathered. Defaults to True.
+        default_parity (Optional[Literal["even", "odd"]]): Default parity to enforce on the PDF. Defaults to None.
 
     Examples:
         Given three documents: `Cover page`, `Main motion form`, and `Notice of Interpreter Request`,
@@ -1575,7 +1576,13 @@ class ALDocumentBundle(DAList):
         pdf.title = self.title
         setattr(self.cache, safe_key, pdf)
         
-        if ensure_parity:
+        if hasattr(self, "default_parity") and not ensure_parity:
+            ensure_parity = self.default_parity
+
+        if ensure_parity not in [None, "even", "odd"]:
+            raise ValueError("ensure_parity must be either 'even', 'odd' or None")
+        
+        if ensure_parity: # Check for odd/even requirement
             if pdf_page_parity(pdf.path()) == ensure_parity:
                 return pdf
             else:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -181,7 +181,7 @@ def table_row(title: str, button_htmls: List[str] = []) -> str:
     return html
 
 
-def pdf_page_parity(pdf_path:str) -> Literal["even", "odd"]:
+def pdf_page_parity(pdf_path: str) -> Literal["even", "odd"]:
     """
     Count the number of pages in the PDF and
     return "even" if it is divisible by 2 and "odd"
@@ -189,34 +189,41 @@ def pdf_page_parity(pdf_path:str) -> Literal["even", "odd"]:
 
     Args:
         pdf_path (str): Path to the PDF in the filesystem
+
+    Returns:
+        Literal["even", "odd"]: The parity of the number of pages in the PDF
     """
     with pikepdf.open(pdf_path) as pdf:
         num_pages = len(pdf.pages)
         if num_pages % 2 == 0:
             return "even"
         return "odd"
-    
 
-def add_blank_page(pdf_path:str):
+
+def add_blank_page(pdf_path: str) -> None:
+    """
+    Add a blank page to the end of a PDF.
+
+    Args:
+        pdf_path (str): Path to the PDF in the filesystem
+    """
     # Load the PDF
     with pikepdf.open(pdf_path, allow_overwriting_input=True) as pdf:
         # Retrieve the last page
         last_page = pdf.pages[-1]
-        
+
         # Extract the size of the last page
         media_box = last_page.MediaBox
-        
+
         # Create a new blank page with the same dimensions as the last page
-        blank_page = pikepdf.Page(pikepdf.Dictionary(
-            MediaBox=media_box
-        ))
-        
+        blank_page = pikepdf.Page(pikepdf.Dictionary(MediaBox=media_box))
+
         # Add the blank page to the end of the PDF
         pdf.pages.append(blank_page)
-        
+
         # Overwrite the original PDF with the modified version
         pdf.save(pdf_path)
- 
+
 
 class ALAddendumField(DAObject):
     """
@@ -1575,14 +1582,14 @@ class ALDocumentBundle(DAList):
             )
         pdf.title = self.title
         setattr(self.cache, safe_key, pdf)
-        
+
         if hasattr(self, "default_parity") and not ensure_parity:
             ensure_parity = self.default_parity
 
         if ensure_parity not in [None, "even", "odd"]:
             raise ValueError("ensure_parity must be either 'even', 'odd' or None")
-        
-        if ensure_parity: # Check for odd/even requirement
+
+        if ensure_parity:  # Check for odd/even requirement
             if pdf_page_parity(pdf.path()) == ensure_parity:
                 return pdf
             else:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -185,7 +185,7 @@ def pdf_page_parity(pdf_path: str) -> Literal["even", "odd"]:
     """
     Count the number of pages in the PDF and
     return "even" if it is divisible by 2 and "odd"
-    if it is even.
+    if it is not divisible by 2.
 
     Args:
         pdf_path (str): Path to the PDF in the filesystem

--- a/docassemble/AssemblyLine/data/questions/test_bundle_parity.yml
+++ b/docassemble/AssemblyLine/data/questions/test_bundle_parity.yml
@@ -1,0 +1,47 @@
+---
+include:
+  - assembly_line.yml
+---
+objects:
+  - the_doc: ALDocument.using(
+        title="The document", 
+        filename="the_document", 
+        enabled=True, 
+        has_addendum=False
+      )
+---
+objects:
+  - even_bundle: ALDocumentBundle.using(
+          title="Even bundle",
+          filename="the_bundle",
+          elements=[
+            the_doc
+          ]
+      )
+  - odd_bundle: ALDocumentBundle.using(
+          title="Even bundle",
+          filename="the_bundle",
+          elements=[
+            the_doc,
+            the_doc
+          ]
+      )
+
+---
+attachment:
+  variable name: the_doc[i]
+  content: |
+    Test content
+---
+mandatory: True
+question: |
+  About to make a PDF
+continue button field: the_field
+---
+mandatory: True
+question: |
+  Download
+subquestion: |
+  ${ even_bundle.as_pdf(ensure_parity="even") }
+
+  ${ odd_bundle.as_pdf(ensure_parity="odd") }

--- a/docassemble/AssemblyLine/data/questions/test_bundle_parity.yml
+++ b/docassemble/AssemblyLine/data/questions/test_bundle_parity.yml
@@ -16,7 +16,9 @@ objects:
           filename="the_bundle",
           elements=[
             the_doc
-          ]
+          ],
+          default_parity="even",
+          enabled=True
       )
   - odd_bundle: ALDocumentBundle.using(
           title="Even bundle",
@@ -24,7 +26,29 @@ objects:
           elements=[
             the_doc,
             the_doc
-          ]
+          ],
+          enabled=True
+      )
+  - bundle_with_default: ALDocumentBundle.using(
+          title="Even bundle",
+          filename="the_bundle",
+          elements=[
+            the_doc
+          ],
+          default_parity="even",
+          enabled=True 
+      )
+
+---
+objects:
+  - bundle_of_bundles: ALDocumentBundle.using(
+          title="Bundle of bundles",
+          filename="the_bundle",
+          elements=[
+            even_bundle,
+            bundle_with_default
+          ],
+          enabled=True
       )
 
 ---
@@ -42,6 +66,14 @@ mandatory: True
 question: |
   Download
 subquestion: |
+  # Should be even
   ${ even_bundle.as_pdf(ensure_parity="even") }
 
+  # should be odd
   ${ odd_bundle.as_pdf(ensure_parity="odd") }
+
+  # should be even
+  ${ bundle_with_default.as_pdf() }
+
+  # Should be even
+  ${ bundle_of_bundles.as_pdf() }


### PR DESCRIPTION
Adds a parameter `ensure_parity` to the `ALDocumentBundle.as_pdf()`, and `default_parity` as an attribute of the bundle.

parity means odd or even number of pages. When either parameter or attribute is set, the as_pdf() method of the bundle may pad the output with an additional page, if needed to match the desired parity.

The purpose is primarily to assist with double-sided printing.

- `ALDocumentBundle.default_parity`: can be "odd", "even", or `None`.
- `ALDocumentBundle.as_pdf(ensure_parity)` can be "odd", "even", or `None`. Overrides `default_parity`.

Test document: `test_bundle_parity.yml`.

Example usage:

```
---
objects:
  - even_bundle: ALDocumentBundle.using(
          title="Even bundle",
          filename="the_bundle",
          elements=[
            the_doc
          ],
          default_parity="even",
          enabled=True
      )
```

Fix #828 