### PR TITLE
Pad .zip attribute with 0 and ensure proper loading from court list

### DIFF
--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -435,15 +435,17 @@ class ALCourtLoader(DAObject):
         def convert_zip(z: Any) -> str:
             return str(z).zfill(5)
 
-        merged_converters: Dict[str, Callable[[object], object]] = {"address_zip": convert_zip}
+        merged_converters: Dict[str, Callable[[object], object]] = {
+            "address_zip": convert_zip
+        }
         if hasattr(self, "converters") and self.converters:
-            assert(isinstance(self.converters, dict))
+            assert isinstance(self.converters, dict)
             merged_converters.update(self.converters)
         to_load = path_and_mimetype(load_path)[0]
         if self.filename.lower().endswith(".xlsx"):
-            df = pd.read_excel(to_load, converters=merged_converters) # type: ignore
+            df = pd.read_excel(to_load, converters=merged_converters)  # type: ignore
         elif self.filename.lower().endswith(".csv"):
-            df = pd.read_csv(to_load, converters=merged_converters) # type: ignore
+            df = pd.read_csv(to_load, converters=merged_converters)  # type: ignore
         elif self.filename.lower().endswith(".json"):
             # TODO: we may need to normalize a JSON file
             df = pd.read_json(to_load)

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -3,7 +3,7 @@ Package for a very simple / MVP list of courts that is mostly signature compatib
 """
 
 import os
-from typing import Any, Callable, Dict, List, Optional, Union, Set
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union, Set
 import pandas as pd
 import docassemble.base.functions
 from docassemble.base.util import (
@@ -435,17 +435,18 @@ class ALCourtLoader(DAObject):
         def convert_zip(z: Any) -> str:
             return str(z).zfill(5)
 
-        merged_converters = {'address_zip': convert_zip}
+        merged_converters: Dict[str, Callable[[object], object]] = {"address_zip": convert_zip}
         if hasattr(self, "converters") and self.converters:
+            assert(isinstance(self.converters, dict))
             merged_converters.update(self.converters)
         to_load = path_and_mimetype(load_path)[0]
         if self.filename.lower().endswith(".xlsx"):
-            df = pd.read_excel(to_load, converters=merged_converters)
+            df = pd.read_excel(to_load, converters=merged_converters) # type: ignore
         elif self.filename.lower().endswith(".csv"):
-            df = pd.read_csv(to_load, converters=merged_converters)
+            df = pd.read_csv(to_load, converters=merged_converters) # type: ignore
         elif self.filename.lower().endswith(".json"):
             # TODO: we may need to normalize a JSON file
-            df = pd.read_json(to_load, converters=merged_converters)
+            df = pd.read_json(to_load)
         else:
             raise Exception(
                 "The datafile must be a CSV, XLSX, or JSON file. Unknown file type: "

--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -3,7 +3,7 @@ Package for a very simple / MVP list of courts that is mostly signature compatib
 """
 
 import os
-from typing import Any, Dict, List, Optional, Union, Set
+from typing import Any, Callable, Dict, List, Optional, Union, Set
 import pandas as pd
 import docassemble.base.functions
 from docassemble.base.util import (
@@ -205,6 +205,7 @@ class ALCourtLoader(DAObject):
 
     Attributes:
         filename (str): Path to the file containing court information.
+        converters (Dict[str, Callable]): A dictionary of functions to apply to columns in the dataframe.
     """
 
     def init(self, *pargs, **kwargs):
@@ -413,6 +414,8 @@ class ALCourtLoader(DAObject):
 
         The method determines the file type (.csv, .xlsx, or .json) based on its extension and reads it accordingly.
 
+        If the "callable" attribute is defined on the instance, it will be used to convert the data in the dataframe.
+
         Returns:
             pd.DataFrame: A dataframe containing the list of courts.
 
@@ -429,14 +432,20 @@ class ALCourtLoader(DAObject):
         else:
             load_path = str(self.filename)
 
+        def convert_zip(z: Any) -> str:
+            return str(z).zfill(5)
+
+        merged_converters = {'address_zip': convert_zip}
+        if hasattr(self, "converters") and self.converters:
+            merged_converters.update(self.converters)
         to_load = path_and_mimetype(load_path)[0]
         if self.filename.lower().endswith(".xlsx"):
-            df = pd.read_excel(to_load)
+            df = pd.read_excel(to_load, converters=merged_converters)
         elif self.filename.lower().endswith(".csv"):
-            df = pd.read_csv(to_load)
+            df = pd.read_csv(to_load, converters=merged_converters)
         elif self.filename.lower().endswith(".json"):
             # TODO: we may need to normalize a JSON file
-            df = pd.read_json(to_load)
+            df = pd.read_json(to_load, converters=merged_converters)
         else:
             raise Exception(
                 "The datafile must be a CSV, XLSX, or JSON file. Unknown file type: "

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -425,7 +425,11 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip).zfill(5)
+            current_country = self.country if hasattr(self, "country") else get_country()
+            if current_country == "US":
+                output += " " + str(self.zip).zfill(5)
+            else:
+                output += " " + str(self.zip)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         if (
@@ -508,7 +512,11 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip).zfill(5)
+            current_country = self.country if hasattr(self, "country") else get_country()
+            if current_country == "US":
+                output += " " + str(self.zip).zfill(5)
+            else:
+                output += " " + str(self.zip)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         return output
@@ -576,7 +584,11 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip).zfill(5)
+            current_country = self.country if hasattr(self, "country") else get_country()
+            if current_country == "US":
+                output += " " + str(self.zip).zfill(5)
+            else:
+                output += " " + str(self.zip)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         if (

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -425,7 +425,7 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip)
+            output += " " + str(self.zip).zfill(5)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         if (
@@ -508,7 +508,7 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip)
+            output += " " + str(self.zip).zfill(5)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         return output
@@ -576,7 +576,7 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            output += " " + str(self.zip)
+            output += " " + str(self.zip).zfill(5)
         elif hasattr(self, "postal_code") and self.postal_code:
             output += " " + str(self.postal_code)
         if (

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -425,7 +425,9 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            current_country = self.country if hasattr(self, "country") else get_country()
+            current_country = (
+                self.country if hasattr(self, "country") else get_country()
+            )
             if current_country == "US":
                 output += " " + str(self.zip).zfill(5)
             else:
@@ -512,7 +514,9 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            current_country = self.country if hasattr(self, "country") else get_country()
+            current_country = (
+                self.country if hasattr(self, "country") else get_country()
+            )
             if current_country == "US":
                 output += " " + str(self.zip).zfill(5)
             else:
@@ -584,7 +588,9 @@ class ALAddress(Address):
             else:
                 output += ", " + str(self.state)
         if hasattr(self, "zip") and self.zip:
-            current_country = self.country if hasattr(self, "country") else get_country()
+            current_country = (
+                self.country if hasattr(self, "country") else get_country()
+            )
             if current_country == "US":
                 output += " " + str(self.zip).zfill(5)
             else:


### PR DESCRIPTION
Fix #840

Currently, when you use the court_loader class in al_courts.py, there's a chance that a column that has a zip code with leading zeros will be interpreted incorrectly.

This fixes it in 2 ways:

1. transforms the `address_zip` column inside the dataframe when it is loaded to zerofill it to at least 5 digits
2. when printing a zip code (.zip attribute) as part of an address, zerofill to 5 digits.

It also adds an API to define a transformation for arbitrary columns of the Excel spreadsheet: defining the `.converters` attribute of the `ALCourtLoader` will now automatically run the converters when the dataframe is loaded. This honors the standard Pandas syntax, where `converters` should be a mapping between the column name and a callable with one parameter.

Ex:

```
---
objects:
  - all_courts: |
      ALCourtLoader.using(file_name='courts_list.xlsx', converters={"address_zip": float})
```