### PR TITLE
Allow using 'data' rather than 'data from code' for al_nav_sections

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2244,8 +2244,12 @@ class ALDocumentBundle(DAList):
             return send_email(
                 to=to,
                 template=template,
-                attachments=set(
-                    self.as_editable_list(key=key) + self.as_pdf_list(key=key)
+                # Add both DOCX and PDF versions, but if it's not possible to be a DOCX don't add the PDF
+                # twice
+                attachments=list(
+                    dict.fromkeys(
+                        self.as_editable_list(key=key) + self.as_pdf_list(key=key)
+                    )
                 ),
                 **kwargs,
             )

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -2078,7 +2078,7 @@ def get_visible_al_nav_items(
 
         # For dictionaries at top level
         item_copy = deepcopy(item)
-        if not item_copy.pop("hidden", False):  # if not hidden
+        if not str(item_copy.pop("hidden", "False")).lower() == "true":  # if not hidden
             for key, val in item_copy.items():
                 if isinstance(val, list):  # if value of a key is a list
                     new_sublist: List[Union[str, dict]] = []
@@ -2087,8 +2087,10 @@ def get_visible_al_nav_items(
                         if isinstance(subitem, str):
                             new_sublist.append(subitem)
                         # Add dictionaries if not hidden
-                        elif isinstance(subitem, dict) and not subitem.pop(
-                            "hidden", False
+                        elif (
+                            isinstance(subitem, dict)
+                            and not str(subitem.pop("hidden", "False")).lower()
+                            == "true"
                         ):
                             new_sublist.append(subitem)
                     item_copy[key] = new_sublist


### PR DESCRIPTION
Currently, when you use the `al_nav_sections` method to declaratively define navigation, you need the longer and more verbose `data from code` because the `hidden` dictionary key is evaluated as a `str`.

For example:

```yaml
---
reconsider: True
variable name: al_nav_sections
data from code:
  - section_intro: |
      "Introduction"
  - section_about_you: |
      "About you"
  - section_about_spouse: |
      "About your spouse"
    hidden: not is_married
```

works but

```yaml
reconsider: True
variable name: al_nav_sections
variable name: al_nav_sections
data:
  - section_intro: Introduction
  - section_about_you: About you
  - section_about_spouse: About your spouse
    hidden: ${ not showifdef("is_married") }
```

does not.