### PR TITLE
Allow pronoun functions to work when .pronouns is defined as a string rather than DADict

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1239,7 +1239,7 @@ class ALIndividual(Individual):
             final_choices.append({str(self.pronoun_unknown_label): "unknown"})
         self_described_input = {
             "label": str(self.pronoun_self_described_label),
-            "field": self.attr_name("pronouns_self_described"),
+            "field": self.attr_name("self.pronouns_self_described"),
             "show if": self.attr_name("pronouns['self-described']"),
         }
         fields = [
@@ -1280,7 +1280,7 @@ class ALIndividual(Individual):
         if self.pronouns.get("self-described"):
             pronouns = pronouns.union(self.pronouns_self_described.splitlines())
         return pronouns
-    
+
     def list_pronouns(self) -> str:
         """
         Retrieve a formatted string of the individual's pronouns, arranged with
@@ -1533,7 +1533,7 @@ class ALIndividual(Individual):
                 )
                 or (
                     pronouns.get("self-described")
-                    and has_parsable_pronouns(pronouns_self_described)
+                    and has_parsable_pronouns(self.pronouns_self_described)
                 )
             )
         ):
@@ -1546,7 +1546,7 @@ class ALIndividual(Individual):
             elif pronouns["ze/zir/zirs"]:
                 output = word("zir", **kwargs)
             elif pronouns.get("self-described"):
-                output = parse_custom_pronouns(pronouns_self_described)["o"]
+                output = parse_custom_pronouns(self.pronouns_self_described)["o"]
         elif hasattr(self, "person_type") and self.person_type in [
             "business",
             "organization",
@@ -1607,7 +1607,7 @@ class ALIndividual(Individual):
                 )
                 or (
                     pronouns.get("self-described")
-                    and has_parsable_pronouns(pronouns_self_described)
+                    and has_parsable_pronouns(self.pronouns_self_described)
                 )
             )
         ):
@@ -1621,7 +1621,7 @@ class ALIndividual(Individual):
                 output = word("zir", **kwargs) + " " + target
             elif pronouns.get("self-described"):
                 output = (
-                    parse_custom_pronouns(pronouns_self_described)["p"]
+                    parse_custom_pronouns(self.pronouns_self_described)["p"]
                     + " "
                     + target
                 )
@@ -1673,7 +1673,7 @@ class ALIndividual(Individual):
                 )
                 or (
                     pronouns.get("self-described")
-                    and has_parsable_pronouns(pronouns_self_described)
+                    and has_parsable_pronouns(self.pronouns_self_described)
                 )
             )
         ):
@@ -1686,7 +1686,7 @@ class ALIndividual(Individual):
             elif pronouns["ze/zir/zirs"]:
                 output = word("ze", **kwargs)
             elif pronouns.get("self-described"):
-                output = parse_custom_pronouns(pronouns_self_described)["s"]
+                output = parse_custom_pronouns(self.pronouns_self_described)["s"]
         elif hasattr(self, "person_type") and self.person_type in [
             "business",
             "organization",

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1267,15 +1267,29 @@ class ALIndividual(Individual):
 
         If the individual has selected the "self-described" option, it will use their custom input.
 
+        Can be formatted however the author likes.
+
         Returns:
             set: A set of strings representing the individual's pronouns.
         """
+        if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
+            return {self.pronouns}
         if self.pronouns.all_false():
             return {str(self.pronoun_prefer_not_to_say_label)}
         pronouns = set(self.pronouns.true_values()) - {"self-described"}
         if self.pronouns.get("self-described"):
             pronouns = pronouns.union(self.pronouns_self_described.splitlines())
         return pronouns
+    
+    def list_pronouns(self) -> str:
+        """
+        Retrieve a formatted string of the individual's pronouns, arranged with
+        the comma_list() function.
+
+        Returns:
+            str: A formatted string of the individual's pronouns.
+        """
+        return comma_list(sorted(self.get_pronouns()))
 
     def language_fields(
         self,
@@ -1500,33 +1514,39 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate pronoun.
         """
+        # Developers can do funky things; be a little flexible
+        if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
+            pronouns = DADict(elements={self.pronouns.lower(): True})
+        else:
+            pronouns = self.pronouns
+
         if self == this_thread.global_vars.user:
             output = word("you", **kwargs)
         elif (
             hasattr(self, "pronouns")
-            and isinstance(self.pronouns, DADict)
-            and len(self.pronouns.true_values()) == 1
+            and isinstance(pronouns, DADict)
+            and len(pronouns.true_values()) == 1
             and (
                 (
-                    self.pronouns.true_values()[0]
+                    pronouns.true_values()[0]
                     in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]
                 )
                 or (
-                    self.pronouns.get("self-described")
-                    and has_parsable_pronouns(self.pronouns_self_described)
+                    pronouns.get("self-described")
+                    and has_parsable_pronouns(pronouns_self_described)
                 )
             )
         ):
-            if self.pronouns["she/her/hers"]:
+            if pronouns["she/her/hers"]:
                 output = word("her", **kwargs)
-            elif self.pronouns["he/him/his"]:
+            elif pronouns["he/him/his"]:
                 output = word("him", **kwargs)
-            elif self.pronouns["they/them/theirs"]:
+            elif pronouns["they/them/theirs"]:
                 output = word("them", **kwargs)
-            elif self.pronouns["ze/zir/zirs"]:
+            elif pronouns["ze/zir/zirs"]:
                 output = word("zir", **kwargs)
-            elif self.pronouns.get("self-described"):
-                output = parse_custom_pronouns(self.pronouns_self_described)["o"]
+            elif pronouns.get("self-described"):
+                output = parse_custom_pronouns(pronouns_self_described)["o"]
         elif hasattr(self, "person_type") and self.person_type in [
             "business",
             "organization",
@@ -1567,36 +1587,41 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate possessive phrase.
         """
+        if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
+            pronouns = DADict(elements={self.pronouns.lower(): True})
+        else:
+            pronouns = self.pronouns
+
         if self == this_thread.global_vars.user and (
             "thirdperson" not in kwargs or not kwargs["thirdperson"]
         ):
             output = your(target, **kwargs)
         elif (
             hasattr(self, "pronouns")
-            and isinstance(self.pronouns, DADict)
-            and len(self.pronouns.true_values()) == 1
+            and isinstance(pronouns, DADict)
+            and len(pronouns.true_values()) == 1
             and (
                 (
-                    self.pronouns.true_values()[0]
+                    pronouns.true_values()[0]
                     in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]
                 )
                 or (
-                    self.pronouns.get("self-described")
-                    and has_parsable_pronouns(self.pronouns_self_described)
+                    pronouns.get("self-described")
+                    and has_parsable_pronouns(pronouns_self_described)
                 )
             )
         ):
-            if self.pronouns["she/her/hers"]:
+            if pronouns["she/her/hers"]:
                 output = her(target, **kwargs)
-            elif self.pronouns["he/him/his"]:
+            elif pronouns["he/him/his"]:
                 output = his(target, **kwargs)
-            elif self.pronouns["they/them/theirs"]:
+            elif pronouns["they/them/theirs"]:
                 output = their(target, **kwargs)
-            elif self.pronouns["ze/zir/zirs"]:
+            elif pronouns["ze/zir/zirs"]:
                 output = word("zir", **kwargs) + " " + target
-            elif self.pronouns.get("self-described"):
+            elif pronouns.get("self-described"):
                 output = (
-                    parse_custom_pronouns(self.pronouns_self_described)["p"]
+                    parse_custom_pronouns(pronouns_self_described)["p"]
                     + " "
                     + target
                 )
@@ -1628,35 +1653,40 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate subjective pronoun.
         """
+        if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
+            pronouns = DADict(elements={self.pronouns.lower(): True})
+        else:
+            pronouns = self.pronouns
+
         if self == this_thread.global_vars.user and (
             "thirdperson" not in kwargs or not kwargs["thirdperson"]
         ):
             output = word("you", **kwargs)
         elif (
             hasattr(self, "pronouns")
-            and isinstance(self.pronouns, DADict)
-            and len(self.pronouns.true_values()) == 1
+            and isinstance(pronouns, DADict)
+            and len(pronouns.true_values()) == 1
             and (
                 (
-                    self.pronouns.true_values()[0]
+                    pronouns.true_values()[0]
                     in ["she/her/hers", "he/him/his", "they/them/theirs", "ze/zir/zirs"]
                 )
                 or (
-                    self.pronouns.get("self-described")
-                    and has_parsable_pronouns(self.pronouns_self_described)
+                    pronouns.get("self-described")
+                    and has_parsable_pronouns(pronouns_self_described)
                 )
             )
         ):
-            if self.pronouns["she/her/hers"]:
+            if pronouns["she/her/hers"]:
                 output = word("she", **kwargs)
-            elif self.pronouns["he/him/his"]:
+            elif pronouns["he/him/his"]:
                 output = word("he", **kwargs)
-            elif self.pronouns["they/them/theirs"]:
+            elif pronouns["they/them/theirs"]:
                 output = word("they", **kwargs)
-            elif self.pronouns["ze/zir/zirs"]:
+            elif pronouns["ze/zir/zirs"]:
                 output = word("ze", **kwargs)
-            elif self.pronouns.get("self-described"):
-                output = parse_custom_pronouns(self.pronouns_self_described)["s"]
+            elif pronouns.get("self-described"):
+                output = parse_custom_pronouns(pronouns_self_described)["s"]
         elif hasattr(self, "person_type") and self.person_type in [
             "business",
             "organization",

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1239,7 +1239,7 @@ class ALIndividual(Individual):
             final_choices.append({str(self.pronoun_unknown_label): "unknown"})
         self_described_input = {
             "label": str(self.pronoun_self_described_label),
-            "field": self.attr_name("self.pronouns_self_described"),
+            "field": self.attr_name("pronouns_self_described"),
             "show if": self.attr_name("pronouns['self-described']"),
         }
         fields = [


### PR DESCRIPTION
Fix #845