### PR TITLE
Handle False boolean overflow triggers, not just True

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -282,8 +282,10 @@ class ALAddendumField(DAObject):
             Any: The portion of the variable exceeding the content safe for display, considered as overflow.
         """
         # Handle a Boolean overflow first
-        if isinstance(self.overflow_trigger, bool) and self.overflow_trigger:
-            return self.value()
+        if isinstance(self.overflow_trigger, bool):
+            if self.overflow_trigger:
+                return self.value()
+            return ""
 
         # If trigger is not a boolean value, overflow value is the value that starts at the end of the safe value.
         original_value = self.value_if_defined()


### PR DESCRIPTION
It's possible to set a `boolean` as the `overflow_trigger` for an ALAddendumField when the conditions for triggering the addendum don't depend on the length of a list or string. But we weren't properly handling the condition where the `boolean` was `False`.

This handles the `False` condition in the overflow trigger by returning an empty string, which will result in `has_overflow()` returning `False`.

This situation may be a bit unusual, but it might be worth using this pattern when the conditional text is required to be added to the same addendum as other overflow text. In other situations, it would make more sense to create a standard ALDocument with the `enabled` value set.

This also fixes a production bug in the Vermont Divorce package.