### PR TITLE
Allow to handle 1st/2nd person pronouns with pronoun methods

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1577,7 +1577,12 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate pronoun.
         """
-        # Developers can do funky things; be a little flexible
+        person = str(kwargs.get("person", self.get_point_of_view()))
+
+        if person in ("1", "1p", "2", "2p"):
+            # Use the parent version of pronoun
+            return super().pronoun(**kwargs)
+
         if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
             pronouns = DADict(elements={self.pronouns.lower(): True})
         else:
@@ -1650,6 +1655,12 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate possessive phrase.
         """
+        person = str(kwargs.get("person", self.get_point_of_view()))
+
+        if person in ("1", "1p", "2", "2p"):
+            # Use the parent version of pronoun
+            return super().pronoun_possessive(target, **kwargs)
+
         if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
             pronouns = DADict(elements={self.pronouns.lower(): True})
         else:
@@ -1716,6 +1727,12 @@ class ALIndividual(Individual):
         Returns:
             str: The appropriate subjective pronoun.
         """
+        person = str(kwargs.get("person", self.get_point_of_view()))
+
+        if person in ("1", "1p", "2", "2p"):
+            # Use the parent version of pronoun
+            return super().pronoun_subjective(**kwargs)
+
         if hasattr(self, "pronouns") and isinstance(self.pronouns, str):
             pronouns = DADict(elements={self.pronouns.lower(): True})
         else:


### PR DESCRIPTION
Fix #870, updating the pronoun capability to match DA 1.4.103 and higher.

This allows making text in a template responsive to the number of people in a list, for words like "I" "we" "us" "our" "my"

Test interview:

```yaml
---
include:
  - assembly_line.yml
---
mandatory: True
question: |
subquestion: |
  ${ users.pronoun(person=1) }
  
  ${ users.pronoun_subjective(person=1, capitalize=True) }
  
  ${ users.pronoun_possessive("elephant", person=1) }
```