### PR TITLE
Don't trigger gender, better handling of non-disclosed pronouns

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1572,8 +1572,8 @@ class ALIndividual(Individual):
 
         Args:
             **kwargs: Additional keyword arguments that are defined [upstream](https://docassemble.org/docs/objects.html#language%20methods).
-            person (Optional[[Union[str,int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream](https://docassemble.org/docs/objects.html#language%20methods) documentation for more information.
-            default (Optional[str]): The default word to use if the pronoun is not defined, e.g. "the agent". If not defined, the default term is the user's name.
+                    - person (Optional[[Union[str,int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream](https://docassemble.org/docs/objects.html#language%20methods) documentation for more information.
+                    - default (Optional[str]): The default word to use if the pronoun is not defined, e.g. "the agent". If not defined, the default term is the user's name.
         Returns:
             str: The appropriate pronoun.
         """
@@ -1657,7 +1657,8 @@ class ALIndividual(Individual):
         return self.pronoun(**kwargs)
 
     def pronoun_possessive(self, target, **kwargs) -> str:
-        """Returns a possessive pronoun and a target word, based on attributes.
+        """
+        Returns a possessive pronoun and a target word, based on attributes.
 
         This method will not trigger the definition of `gender` or `pronouns`, but it will use them if they are defined,
         with `pronouns` taking precedence. As a default, it will either use the value of `default` or the individual's full name.
@@ -1668,11 +1669,12 @@ class ALIndividual(Individual):
 
         Args:
             target (str): The target word to follow the pronoun.
-            person (Optional[[Union[str,int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream](https://docassemble.org/docs/objects.html#language%20methods) documentation for more information.
-            default (Optional[str]): The default word to use if the pronoun is not defined, e.g. "the agent". If not defined, the default term is the user's name.
-            **kwargs: Additional keyword arguments that are defined [upstream](https://docassemble.org/docs/objects.html#language%20methods).
+            **kwargs: Additional keyword arguments that can be passed to modify the behavior. These might include:
+                - `default` (Optional[str]): The default word to use if the pronoun is not defined, e.g., "the agent". If not defined, the default term is the user's name.
+                - `person` (Optional[Union[str, int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream documentation](https://docassemble.org/docs/objects.html#language%20methods) for more information.
+
         Returns:
-            str: The appropriate possessive phrase.
+            str: The appropriate possessive phrase, e.g., "her book", "their document".
         """
         person = str(kwargs.get("person", self.get_point_of_view()))
 
@@ -1756,8 +1758,8 @@ class ALIndividual(Individual):
 
         Args:
             **kwargs: Additional keyword arguments that are defined [upstream](https://docassemble.org/docs/objects.html#language%20methods).
-            person (Optional[[Union[str,int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream](https://docassemble.org/docs/objects.html#language%20methods) documentation for more information.
-            default (Optional[str]): The default word to use if the pronoun is not defined, e.g. "the agent". If not defined, the default term is the user's name.
+                    - person (Optional[[Union[str,int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream](https://docassemble.org/docs/objects.html#language%20methods) documentation for more information.
+                    - default (Optional[str]): The default word to use if the pronoun is not defined, e.g. "the agent". If not defined, the default term is the user's name.
         Returns:
             str: The appropriate subjective pronoun.
         """

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1588,7 +1588,7 @@ class ALIndividual(Individual):
         else:
             default = self.name_full()
 
-        if hasattr(self, "pronouns"):
+        if hasattr(self, "pronouns") and self.pronouns:
             if isinstance(self.pronouns, str):
                 pronouns = DADict(elements={self.pronouns.lower(): True})
             else:
@@ -1596,9 +1596,9 @@ class ALIndividual(Individual):
 
         if self == this_thread.global_vars.user:
             output = word("you", **kwargs)
-        elif hasattr(self, "pronouns"):
+        elif hasattr(self, "pronouns") and self.pronouns:
+            pronouns_to_use = []
             if isinstance(pronouns, DADict):
-                pronouns_to_use = []
                 for pronoun in pronouns.true_values():
                     if pronoun in [
                         "she/her/hers",
@@ -1696,9 +1696,9 @@ class ALIndividual(Individual):
             "thirdperson" not in kwargs or not kwargs["thirdperson"]
         ):
             output = your(target, **kwargs)
-        elif hasattr(self, "pronouns"):
-            if isinstance(pronouns, DADict):
-                pronouns_to_use = []
+        elif hasattr(self, "pronouns") and self.pronouns:
+            pronouns_to_use = []
+            if isinstance(pronouns, DADict):                
                 for pronoun in pronouns.true_values():
                     if pronoun in [
                         "she/her/hers",
@@ -1773,7 +1773,7 @@ class ALIndividual(Individual):
         else:
             default = self.name_full()
 
-        if hasattr(self, "pronouns"):
+        if hasattr(self, "pronouns") and self.pronouns:
             if isinstance(self.pronouns, str):
                 pronouns = DADict(elements={self.pronouns.lower(): True})
             else:
@@ -1781,9 +1781,9 @@ class ALIndividual(Individual):
 
         if self == this_thread.global_vars.user:
             output = word("you", **kwargs)
-        elif hasattr(self, "pronouns"):
+        elif hasattr(self, "pronouns") and self.pronouns:
+            pronouns_to_use = []
             if isinstance(pronouns, DADict):
-                pronouns_to_use = []
                 for pronoun in pronouns.true_values():
                     if pronoun in [
                         "she/her/hers",

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1621,9 +1621,7 @@ class ALIndividual(Individual):
                             parse_custom_pronouns(self.pronouns_self_described)["o"]
                         )
                     elif has_parsable_pronouns(pronoun):
-                        pronouns_to_use.append(
-                            parse_custom_pronouns(pronoun)["o"]
-                        )
+                        pronouns_to_use.append(parse_custom_pronouns(pronoun)["o"])
             if len(pronouns_to_use) > 0:
                 output = "/".join(pronouns_to_use)
             else:
@@ -1698,7 +1696,7 @@ class ALIndividual(Individual):
             output = your(target, **kwargs)
         elif hasattr(self, "pronouns") and self.pronouns:
             pronouns_to_use = []
-            if isinstance(pronouns, DADict):                
+            if isinstance(pronouns, DADict):
                 for pronoun in pronouns.true_values():
                     if pronoun in [
                         "she/her/hers",
@@ -1806,9 +1804,7 @@ class ALIndividual(Individual):
                             parse_custom_pronouns(self.pronouns_self_described)["s"]
                         )
                     elif has_parsable_pronouns(pronoun):
-                        pronouns_to_use.append(
-                            parse_custom_pronouns(pronoun)["s"]
-                        )
+                        pronouns_to_use.append(parse_custom_pronouns(pronoun)["s"])
             if len(pronouns_to_use) > 0:
                 output = "/".join(pronouns_to_use)
             else:

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -61,6 +61,8 @@ class TestALIndividual(unittest.TestCase):
         # Assigning this_thread to self.individual
         self.individual.this_thread = self.this_thread
 
+        self.individual.name.first = "John"
+
     def test_phone_numbers(self):
         self.assertEqual(self.individual.phone_numbers(), "")
         self.individual.phone_number = ""
@@ -423,9 +425,7 @@ class TestALIndividual(unittest.TestCase):
         self.assertEqual(self.individual.pronoun_possessive("fish"), "xem fish")
 
         self.individual.pronouns_self_described = "Xe/Xir/Xirs/xem/xirself"
-        # Should raise an exception
-        with self.assertRaises(DAAttributeError):
-            self.individual.pronoun_objective()
+        self.assertEqual(self.individual.pronoun_objective(), "John")
 
     def test_name_methods(self):
         self.individual.name.first = "John"


### PR DESCRIPTION
Fix #874 

This PR updates the pronoun, pronoun_possessive, and pronoun_subjective methods in the al_general.py module to provide more robust handling of pronouns, including support for multiple pronouns and custom user-provided pronouns. Key changes include:

* Enhanced Pronoun Flexibility: The methods now support the use of multiple pronouns (e.g., "he/they")
* Parse custom pronouns in .pronouns as a DADict, not just in `pronouns_self_described`
* Don't trigger gender or pronouns: if the pronouns or gender attributes are not defined or can't be parsed, fall back on either a user-provided default (like "the agent") or the person's full name

This may change behavior of some interviews that don't currently, explicitly, trigger a question about pronouns or gender.