### PR TITLE
Add session search feature to interview list page; allow limiting session searching by arbitrary metadata column

### DIFF
--- a/docassemble/AssemblyLine/data/questions/demo_search_sessions.yml
+++ b/docassemble/AssemblyLine/data/questions/demo_search_sessions.yml
@@ -25,9 +25,20 @@ subquestion: |
   Searching is not case sensitive.
 fields:
   - Keyword: search_keyword
+  - Limit metadata column: limit_column_name
+    required: False
+  - To value: limit_column_value
+    required: False  
 ---
 code: |
-  matching_results = find_matching_sessions(search_keyword, user_id="all")
+  if limit_column_name:
+    matching_results = find_matching_sessions(
+      search_keyword, user_id="all", metadata_filters = {
+        limit_column_name: (limit_column_value, "ILIKE")
+      }
+      )
+  else:
+    matching_results = find_matching_sessions(search_keyword, user_id="all")
 ---
 event: no_matches
 question: |

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -132,6 +132,7 @@ code: |
 sections:
   - section_in_progress_forms: In progress forms
   - section_answer_sets: Answer sets
+  - section_search: Search
 progressive: False
 ---
 # A code block is the only way to show navigation with custom labels (mako isn't allowed in `sections`)
@@ -144,7 +145,10 @@ code: |
         },
         {
           "section_answer_sets": ANSWER_SETS_TITLE or word("Answer sets")
-        }
+        },
+        {
+          "section_search": word("Search")
+        },
         ]
   )
 ---
@@ -261,6 +265,10 @@ subquestion: |
   documents.
   % endif
 
+  % if showifdef("limit_filename") or showifdef("search_keyword"):
+  ${ session_list_html(results_to_format = find_matching_sessions(filenames={limit_filename} if limit_filename else None, keyword=search_keyword), filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }
+
+  % else:
   ${ session_list_html(filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }
 
   <nav aria-label="Page navigation">
@@ -273,8 +281,12 @@ subquestion: |
   % endif
     </ul>
   </nav>  
-  % else:
-  You do not have any current forms in progress
+  % endif
+
+  % endif
+
+  % if showifdef("limit_filename") or showifdef("search_keyword"):
+  ${ action_button_html(url_action("delete_results_action"), label=word("Clear search results"), size="md", color="secondary", icon="times-circle", id_tag="al-clear-search-results") }
   % endif
 # TODO: might be able to save some DB queries here but performance is good
 section: section_in_progress_forms
@@ -303,6 +315,24 @@ script:
         return false;
       });
   </script>
+---
+continue button field: section_search
+question: |
+  Search
+  % if PAGE_QUESTION:
+  ${ PAGE_QUESTION }
+  % else:
+  In progress forms 
+  % endif
+subquestion: |
+  Use a keyword to find results that match the title or description of the session.
+fields:
+  - Limit by form title (optional): limit_filename
+    required: False
+    code: |
+      get_combined_filename_list()
+  - Search term (optional): search_keyword
+    required: False
 ---
 event: section_answer_sets
 id: answer set list
@@ -441,3 +471,8 @@ code: |
           ),
       )
   )
+---
+event: delete_results_action
+code: |
+  undefine("limit_filename")
+  undefine("search_keyword")

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -317,12 +317,13 @@ script:
   </script>
 ---
 continue button field: section_search
+section: section_search
 question: |
   Search
   % if PAGE_QUESTION:
-  ${ PAGE_QUESTION }
+  ${ str(PAGE_QUESTION).lower() }
   % else:
-  In progress forms 
+  in progress forms 
   % endif
 subquestion: |
   Use a keyword to find results that match the title or description of the session.

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -266,7 +266,7 @@ subquestion: |
   % endif
 
   % if showifdef("limit_filename") or showifdef("search_keyword"):
-  ${ session_list_html(results_to_format = find_matching_sessions(filenames={limit_filename} if limit_filename else None, keyword=search_keyword), filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }
+  ${ session_list_html(answers = find_matching_sessions(filenames={limit_filename} if limit_filename else None, keyword=search_keyword), filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }
 
   % else:
   ${ session_list_html(filename=None, limit=20, offset=session_page*20, exclude_filenames=al_sessions_to_exclude_from_interview_list, exclude_newly_started_sessions=True) }

--- a/docassemble/AssemblyLine/requirements.txt
+++ b/docassemble/AssemblyLine/requirements.txt
@@ -6,3 +6,4 @@ sqlalchemy[mypy]
 types-PyYAML
 PyGithub
 types-requests
+types-psycopg2

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1593,11 +1593,7 @@ def config_with_language_fallback(
 def get_filenames_having_sessions(
     user_id: Optional[Union[int, str]] = None,
     global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
-<<<<<<< Updated upstream
-):
-=======
 ) -> List[str]:
->>>>>>> Stashed changes
     """Get a list of all filenames that have sessions saved for a given user, in order
     to help show the user a good list of interviews to filter search results.
 

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1591,15 +1591,17 @@ def config_with_language_fallback(
         return get_config(top_level_config_key or config_key)
 
 
-
-def get_filenames_having_sessions(user_id: Optional[Union[int, str]] = None, global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None):
+def get_filenames_having_sessions(
+    user_id: Optional[Union[int, str]] = None,
+    global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
+):
     """Get a list of all filenames that have sessions saved for a given user, in order
     to help show the user a good list of interviews to filter search results.
 
     Args:
         user_id (Optional[Union[int, str]], optional): User ID to get the list of filenames for. Defaults to current logged-in user. Use "all" to get all filenames.
         global_search_allowed_roles (Optional[Union[Set[str], List[str]]], optional): Roles that are allowed to search for all sessions. Defaults to admin, developer, and advocate.
-    
+
     Returns:
         List[str]: List of filenames that have sessions saved for the user.
     """
@@ -1644,13 +1646,18 @@ def get_filenames_having_sessions(user_id: Optional[Union[int, str]] = None, glo
                     WHERE (%(user_id)s is null OR user_id = %(user_id)s)
                 """
                 cur.execute(query, {"user_id": user_id})
-            
-            results = [record['filename'] for record in cur]
+
+            results = [record["filename"] for record in cur]
     finally:
         conn.close()
 
     return results
-def get_combined_filename_list(user_id: Optional[Union[int, str]] = None, global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None) -> List[Dict[str, str]]:
+
+
+def get_combined_filename_list(
+    user_id: Optional[Union[int, str]] = None,
+    global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
+) -> List[Dict[str, str]]:
     """
     Get a list of all filenames that have sessions saved for a given user. If it is possible
     to show a descriptive name for the filename (from the main dispatch area of the configuration),
@@ -1679,7 +1686,13 @@ def get_combined_filename_list(user_id: Optional[Union[int, str]] = None, global
         found_match = False
         for interview in interview_filenames:
             if interview["filename"] == user_interview:
-                combined_interviews.append({interview["filename"]: interview.get("title", interview["filename"]) })
+                combined_interviews.append(
+                    {
+                        interview["filename"]: interview.get(
+                            "title", interview["filename"]
+                        )
+                    }
+                )
                 found_match = True
                 continue
         if not found_match:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1593,11 +1593,7 @@ def config_with_language_fallback(
 def get_filenames_having_sessions(
     user_id: Optional[Union[int, str]] = None,
     global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
-<<<<<<< Updated upstream
 ) -> List[str]:
-=======
-):
->>>>>>> Stashed changes
     """Get a list of all filenames that have sessions saved for a given user, in order
     to help show the user a good list of interviews to filter search results.
 

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -991,7 +991,7 @@ def session_list_html(
     show_copy_button: bool = True,
     limit: int = 50,
     offset: int = 0,
-    results_to_format: Optional[List[Dict[str, Any]]] = None,
+    answers: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Return a string containing an HTML-formatted table with the list of user sessions.
     While interview_list_html() is for answer sets, this feature is for standard
@@ -1019,12 +1019,13 @@ def session_list_html(
         show_copy_button (bool, optional): If True, show a copy button for answer sets. Defaults to True.
         limit (int, optional): Limit for the number of sessions returned. Defaults to 50.
         offset (int, optional): Offset for the session list. Defaults to 0.
+        answers (Optional[List[Dict[str, Any]], optional): A list of answers to format and display. Defaults to showing all sessions for the current user.
 
 
     Returns:
         str: HTML-formatted table containing the list of user sessions.
     """
-    if not results_to_format:
+    if not answers:
         answers = get_saved_interview_list(
             filename=filename,
             user_id=user_id,
@@ -1036,8 +1037,6 @@ def session_list_html(
             exclude_filenames=exclude_filenames,
             exclude_newly_started_sessions=exclude_newly_started_sessions,
         )
-    else:
-        answers = results_to_format
 
     if not answers:
         return ""
@@ -1594,7 +1593,11 @@ def config_with_language_fallback(
 def get_filenames_having_sessions(
     user_id: Optional[Union[int, str]] = None,
     global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
+<<<<<<< Updated upstream
 ):
+=======
+) -> List[str]:
+>>>>>>> Stashed changes
     """Get a list of all filenames that have sessions saved for a given user, in order
     to help show the user a good list of interviews to filter search results.
 

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1593,7 +1593,11 @@ def config_with_language_fallback(
 def get_filenames_having_sessions(
     user_id: Optional[Union[int, str]] = None,
     global_search_allowed_roles: Optional[Union[Set[str], List[str]]] = None,
+<<<<<<< Updated upstream
 ) -> List[str]:
+=======
+):
+>>>>>>> Stashed changes
     """Get a list of all filenames that have sessions saved for a given user, in order
     to help show the user a good list of interviews to filter search results.
 


### PR DESCRIPTION
This PR adds the ability to search through existing sessions to the interview list page.

![image](https://github.com/user-attachments/assets/7ec57846-6420-470a-b085-ecd9557ae117)

When searching through sessions, it is also now possible to limit the search results by a particular metadata column. This can be used for access control or other arbitrary ways to limit search results across a server.

This will also be used to support more ways to troubleshoot session searching in the ALDasbhoard