### PR TITLE
Support dynamically provided options in the DOCX template file

### DIFF
--- a/docassemble/AssemblyLine/custom_jinja_filters.py
+++ b/docassemble/AssemblyLine/custom_jinja_filters.py
@@ -86,4 +86,34 @@ def catchall_options(value: Any, *raw_items: Any) -> DACatchAll:
     return value
 
 
+def catchall_label(value: Any, label:str) -> DACatchAll:
+    """Jinja2 filter to allow you to define a label for a DACatchAll field inside a DOCX template.
+
+    This filter takes a label string and assigns it to the `label` attribute of the
+    DACatchAll object. This label can be used to provide a more descriptive name for the
+    catchall field in the user interface.
+
+    Example usage in a DOCX template:
+    ```
+    {{ my_catchall_field | catchall_label("My Custom Label") }}
+    ```
+    Example in an interview with `features: use catchall: True` turned on:
+    ```
+    ---
+    generic object: DACatchAll
+    question: |
+        ${ x.label if hasattr(x, "label") else x.object_name() }?
+    fields:
+        - ${ x.label if hasattr(x, "label") else x.object_name() }: x.value
+    ```
+    Args:
+        value (DACatchAll): The DACatchAll object to which the label will be assigned.
+        label (str): The label string to assign to the DACatchAll object.
+
+    """
+    if isinstance(value, DACatchAll):
+        value.label = label
+    return value
+
 register_jinja_filter("catchall_options", catchall_options)
+register_jinja_filter("catchall_label", catchall_label)

--- a/docassemble/AssemblyLine/custom_jinja_filters.py
+++ b/docassemble/AssemblyLine/custom_jinja_filters.py
@@ -86,7 +86,7 @@ def catchall_options(value: Any, *raw_items: Any) -> DACatchAll:
     return value
 
 
-def catchall_label(value: Any, label:str) -> DACatchAll:
+def catchall_label(value: Any, label: str) -> DACatchAll:
     """Jinja2 filter to allow you to define a label for a DACatchAll field inside a DOCX template.
 
     This filter takes a label string and assigns it to the `label` attribute of the
@@ -110,10 +110,14 @@ def catchall_label(value: Any, label:str) -> DACatchAll:
         value (DACatchAll): The DACatchAll object to which the label will be assigned.
         label (str): The label string to assign to the DACatchAll object.
 
+    Returns:
+        DACatchAll: The modified DACatchAll object with the assigned label.
+
     """
     if isinstance(value, DACatchAll):
         value.label = label
     return value
+
 
 register_jinja_filter("catchall_options", catchall_options)
 register_jinja_filter("catchall_label", catchall_label)

--- a/docassemble/AssemblyLine/custom_jinja_filters.py
+++ b/docassemble/AssemblyLine/custom_jinja_filters.py
@@ -1,0 +1,89 @@
+# pre-load
+
+# Because this has the pre-load preamble, this code runs automatically each time the
+# server reloads. you do not need to import this module in your code.
+
+# See: https://docassemble.org/docs/documents.html#register_jinja_filter
+
+from typing import Any
+from docassemble.base.util import register_jinja_filter, DACatchAll
+
+
+def catchall_options(value: Any, *raw_items: Any) -> DACatchAll:
+    """Jinja2 filter to support defining options for DACatchAll fields inside a DOCX template.
+
+    This filter takes a list of items, which can be strings, dictionaries, or tuples,
+    and converts them into a list of tuples containing the code and label for each option.
+
+    The items can be in various formats:
+
+    - String: `"code: label"`
+    - Dictionary: `{"code": "label"}`
+    - Tuple: `("code", "label")`
+    - List of any of the above types
+
+    The resulting list of tuples is assigned to the `_catchall_options` attribute of the
+    DACatchAll object, which can then be used to populate the options in the catchall field.
+
+    Example usage in a DOCX template:
+
+    ```
+    {{ my_catchall_field | catchall_options("code1: label1", "code2: label2") }}
+
+    {{ my_catchall_field_2 | catchall_options({"code1": "label1"}, {"code2": "label2"}) }}
+    ```
+
+    Example in an interview with `features: use catchall: True` turned on:
+
+    ```
+    ---
+    if: |
+        hasattr(x, "_catchall_options")
+    generic object: DACatchAll
+    question: |
+        ${ x.object_name() }?
+    fields:
+        - ${ x.object_name() }: x.value
+          code: x._catchall_options
+    ```
+
+    Args:
+        value (DACatchAll): The DACatchAll object to which the options will be assigned.
+        *raw_items: A variable number of arguments representing the options to be added.
+    Returns:
+        DACatchAll: The modified DACatchAll object with the assigned options.
+    """
+    if isinstance(value, DACatchAll):
+        pairs = []
+        for item in raw_items:
+            if isinstance(item, str):
+                if ":" in item:
+                    code, label = item.split(":", 1)
+                else:
+                    code = label = item
+                pairs.append((code.strip(), label.strip()))
+            elif isinstance(item, dict):
+                for code, label in item.items():
+                    pairs.append((code.strip(), label.strip()))
+            elif isinstance(item, tuple) and len(item) == 2:
+                code, label = item
+                pairs.append((code.strip(), label.strip()))
+            elif isinstance(item, list):
+                for subitem in item:
+                    if isinstance(subitem, str):
+                        if ":" in subitem:
+                            code, label = subitem.split(":", 1)
+                        else:
+                            code = label = subitem
+                        pairs.append((code.strip(), label.strip()))
+                    elif isinstance(subitem, dict):
+                        for code, label in subitem.items():
+                            pairs.append((code.strip(), label.strip()))
+                    elif isinstance(subitem, tuple) and len(subitem) == 2:
+                        code, label = subitem
+                        pairs.append((code.strip(), label.strip()))
+        value._catchall_options = pairs
+    return value
+
+
+register_jinja_filter("catchall_options", catchall_options)

--- a/docassemble/AssemblyLine/data/questions/ql_catchall.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_catchall.yml
@@ -4,13 +4,17 @@ features:
 ---
 ###################### Catchall questions ###########################################
 ---
+code: |
+  # If you intentionally want to use catchall questions, you can set this value to False
+  al_warn_catchall_questions = True
+---
 generic object: DACatchAll
 question: |
-  ${ x.object_name() }?
+  ${ x.label if hasattr(x, "label") else x.object_name() }?
 fields:
-  - ${ x.object_name() }: x.value
+  - ${ x.label if hasattr(x, "label") else x.object_name() }: x.value
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 validation code: |
@@ -22,9 +26,9 @@ if: |
   x.context == 'float' or (x.data_type_guess() == 'float')
 generic object: DACatchAll
 question: |
-  How much is ${ x.object_name() }?
+  How much is ${ x.label if hasattr(x, "label") else x.object_name() }?
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 fields:
@@ -39,9 +43,9 @@ if: |
   x.data_type_guess() == 'int'
 generic object: DACatchAll
 question: |
-  ${ x.object_name() }?
+  ${ x.label if hasattr(x, "label") else x.object_name() }?
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 fields:
@@ -56,13 +60,13 @@ if: |
   x.data_type_guess() == 'bool'
 generic object: DACatchAll
 question: |
-  ${x.object_name()}?
+  ${ x.label if hasattr(x, "label") else x.object_name() }
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 fields:
-  - ${x.object_name()}?: x.value
+  - ${ x.label if hasattr(x, "label") else x.object_name() }: x.value
     datatype: yesnoradio
 validation code: |
   define(x.instanceName, x.value)
@@ -73,9 +77,9 @@ if: |
   x.object_name().endswith('date')
 generic object: DACatchAll
 question: |
-  ${x.object_name()}?
+  ${ x.label if hasattr(x, "label") else x.object_name() }
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 fields:
@@ -102,9 +106,9 @@ content: |
   ---
   id: amount of ${ x.instanceName }
   question: |
-    How much is ${ x.object_name() }?
+    How much is ${ x.label if hasattr(x, "label") else x.object_name() }?
   fields:
-    - ${ x.object_name() }: ${ x.instanceName }
+    - ${ x.label if hasattr(x, "label") else x.object_name() }: ${ x.instanceName }
       datatype: currency
   </pre>
   % else:
@@ -112,9 +116,9 @@ content: |
   ---
   id: ${ x.instanceName }
   question: |
-    What is ${ x.object_name() }?
+    What is ${ x.label if hasattr(x, "label") else x.object_name() }?
   fields:
-    - ${ x.object_name() }: ${ x.instanceName }
+    - ${ x.label if hasattr(x, "label") else x.object_name() }: ${ x.instanceName }
   </pre>
   % endif
 
@@ -128,19 +132,21 @@ if: |
   hasattr(x, "_catchall_options")
 generic object: DACatchAll
 question: |
-  ${ x.object_name() }?
+  ${ x.label if hasattr(x, "label") else x.object_name() }?
 subquestion: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   ${ collapse_template(x.catchall_question_explanation) }
   % endif
 fields:
-  - ${ x.object_name() }: x.value
+  - ${ x.label if hasattr(x, "label") else x.object_name() }: x.value
     code: |
       x._catchall_options
+validation code: |
+  define(x.instanceName, x.value)
 ---
 template: dacatchall_css_template
 content: |
-  % if get_config("debug"):
+  % if get_config("debug") and al_warn_catchall_questions:
   <style>
   #daquestion {
     border-style: solid;

--- a/docassemble/AssemblyLine/data/questions/ql_catchall.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_catchall.yml
@@ -124,6 +124,20 @@ content: |
   This warning message will not appear when this interview is installed on a production
   server.
 ---
+if: |
+  hasattr(x, "_catchall_options")
+generic object: DACatchAll
+question: |
+  ${ x.object_name() }?
+subquestion: |
+  % if get_config("debug"):
+  ${ collapse_template(x.catchall_question_explanation) }
+  % endif
+fields:
+  - ${ x.object_name() }: x.value
+    code: |
+      x._catchall_options
+---
 template: dacatchall_css_template
 content: |
   % if get_config("debug"):


### PR DESCRIPTION
If you are using a DOCX template, this adds a new Jinja2 filter, `catchall_options(value [implicit], *items)`, that lets you define the options in the template itself. The options will be presented as a drop down menu in the interview.

Template options would typically be provided with a syntax like either of the below examples:

```
    {{ my_catchall_field | catchall_options("code1: label1", "code2: label2") }}
    {{ my_catchall_field_2 | catchall_options({"code1": "label1"}, {"code2": "label2"}) }}
```

This is useful for situations when you have a very simple interview that you would like to allow an end-user to edit and upload and you have DACatchAll enabled to flag undefined variables. E.g., some legal aid programs use this to request client signatures.

This also adds a filter `catchall_label` with similar functionality, but this allows you to define the `label` of a catchall question in the template.

Together, these new functions allow much of the functionality of the interview to be driven by the template author, requiring less work inside the interview YAML. This is helpful for a lot of kinds of templates that are used by attorneys rather than end-users.

Note that this special syntax only works with DACatchall objects. You cannot use it, for example, to override the options if there is an existing question in the YAML with the same variable name.