### PR TITLE
Slightly more efficient and simplified metadata update method

### DIFF
--- a/docassemble/AssemblyLine/custom_jinja_filters.py
+++ b/docassemble/AssemblyLine/custom_jinja_filters.py
@@ -119,5 +119,126 @@ def catchall_label(value: Any, label: str) -> DACatchAll:
     return value
 
 
+def catchall_subquestion(value: Any, subquestion: str) -> DACatchAll:
+    """Jinja2 filter to allow you to define a subquestion for a DACatchAll field inside a DOCX template.
+
+    This filter takes a subquestion string and assigns it to the `subquestion` attribute of the
+    DACatchAll object. This can be useful for providing additional context or instructions
+    related to the catchall field.
+
+    Example usage in a DOCX template:
+    ```
+    {{ my_catchall_field | catchall_subquestion("Please select an option from the list.") }}
+    ```
+
+    Args:
+        value (DACatchAll): The DACatchAll object to which the subquestion will be assigned.
+        subquestion (str): The subquestion string to assign to the DACatchAll object.
+
+    Returns:
+        DACatchAll: The modified DACatchAll object with the assigned subquestion.
+    """
+    if isinstance(value, DACatchAll):
+        value.subquestion = subquestion
+    return value
+
+
+def catchall_datatype(value: Any, datatype: str) -> DACatchAll:
+    """Jinja2 filter to allow you to define a datatype for a DACatchAll field inside a DOCX template.
+
+    This filter takes a datatype string and assigns it to the `datatype` attribute of the
+    DACatchAll object. This can be useful for specifying the type of data that the catchall
+    field should accept.
+
+    You can use any valid Docassemble datatatype, but note that some datatypes might
+    also require additional filters, such as catchall_options, to work correctly.
+
+    Example usage in a DOCX template:
+    ```
+    {{ my_catchall_field | catchall_datatype("radio") | catchall_options("code1: label1", "code2: label2") }}
+    ```
+
+    Args:
+        value (DACatchAll): The DACatchAll object to which the datatype will be assigned.
+        datatype (str): The datatype string to assign to the DACatchAll object.
+
+    Returns:
+        DACatchAll: The modified DACatchAll object with the assigned datatype.
+    """
+    if isinstance(value, DACatchAll):
+        value.datatype = datatype
+    return value
+
+
+def catchall_question_code(obj: DACatchAll) -> dict:
+    """
+    Given a DACatchAll object, return a dictionary representing the Docassemble
+    code for an appropriate field that can be used in a question.
+
+    If used as filters, the returned question field will include:
+
+    * `catchall_label`: The label for the catchall field.
+    * `catchall_datatype`: The datatype for the catchall field.
+    * `catchall_options`: The options for the catchall field, if any.
+
+    Because Docassemble datatypes might change over time, there is no validation of
+    the datatype or options. It is up to the user to ensure that the datatype
+    and options are provided in the correct combination.
+
+    Example usage in a DOCX template:
+
+    ```jinja2
+    {{ my_catchall_field | catchall_label("Which branch do you work at?") | catchall_options("Scranton", "Nashua", "Buffalo") | catchall_datatype("radio") }}
+    ```
+
+    Example in the interview YAML:
+
+    ```yaml
+    ---
+    if: |
+        hasattr(x, "_catchall_options") or hasattr(x, "datatype") or hasattr(x, "label")
+    generic object: DACatchAll
+    question: |
+        ${ x.label if hasattr(x, "label") else x.object_name() }?
+    subquestion: |
+        % if get_config("debug") and al_warn_catchall_questions:
+        ${ collapse_template(x.catchall_question_explanation) }
+        % endif
+    fields:
+        - code: |
+            catchall_question_code(x)
+    validation code: |
+        define(x.instanceName, x.value)
+    ```
+
+    Which results in a question with the equivalent of YAML like this:
+
+
+    ```yaml
+    ---
+    generic object: DACatchAll
+    question: |
+        At which Dunder Mifflin branch do you work?
+    fields:
+        - At which Dunder Mifflin branch do you work?: x.value
+          datatype: radio
+          choices:
+            - Scranton
+            - Nashua
+            - Buffalo
+    """
+    if isinstance(obj, DACatchAll):
+        question_field = {
+            "datatype": obj.datatype if hasattr(obj, "datatype") else "text",
+            "label": obj.label if hasattr(obj, "label") else obj.object_name(),
+            "field": "x.value",
+        }
+        if hasattr(obj, "_catchall_options") and obj._catchall_options:
+            question_field["choices"] = obj._catchall_options
+        return question_field
+    return {}
+
+
+register_jinja_filter("catchall_datatype", catchall_datatype)
 register_jinja_filter("catchall_options", catchall_options)
 register_jinja_filter("catchall_label", catchall_label)

--- a/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
+++ b/docassemble/AssemblyLine/data/questions/al_saved_sessions.yml
@@ -8,13 +8,10 @@ initial: True
 code: |
   ########### Save title and progress to session list ##################
   if get_config("assembly line",{}).get("update session metadata", True):
-    al_temp_metadata = get_interview_metadata(
-      current_context().filename, current_context().session
-    )
-    al_temp_metadata["auto_title"] = str(al_sessions_interview_title)
-    al_temp_metadata["progress"] = get_progress()
-    set_current_session_metadata(al_temp_metadata)
-    del(al_temp_metadata)
+    update_current_session_metadata({
+      "auto_title": str(al_sessions_interview_title),
+      "progress": get_progress(),
+    })
 ---
 template: al_sessions_interview_title
 content: |


### PR DESCRIPTION
This doesn't seem to have a huge impact, but it might shave about 0.02s from a typical page load?

I tested this on the test_question_library.yml file and that's the difference I was seeing.

Completed processing at 0.15401s the old way, vs 0.13143s the new way. I probably didn't do enough passes to be positive, but I like the API a bit better anyway. It's not likely to be a huge impact either way.

This is part of the solution to #773 . Want to test @jpagh's idea also. But this seems safe and helpful.