### PR TITLE
Fixed failing mock functions in language test

### DIFF
--- a/docassemble/AssemblyLine/test_language.py
+++ b/docassemble/AssemblyLine/test_language.py
@@ -7,27 +7,22 @@ from .language import (
     get_language_list,
     get_language_list_item,
 )
+#from docassemble.base.util import (
+#    this_thread
+#)
 import pycountry
 import yaml
 import os
 
-
 class TestLanguage(unittest.TestCase):
     def setUp(self):
         self.language_codes = ["en", "fr"]
-        self.mock_url_action = patch(
-            "docassemble.AssemblyLine.language.url_action", return_value="mocked_url"
-        )
-        self.mocked_url_action = self.mock_url_action.start()
 
         # Define relative directory
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.relative_path = os.path.join(
             current_dir, "data", "sources", "languages.yml"
         )
-
-    def tearDown(self):
-        self.mock_url_action.stop()
 
     def test_get_tuples(self):
         result = get_tuples(self.language_codes, languages_path=self.relative_path)
@@ -36,26 +31,34 @@ class TestLanguage(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
-    def test_get_language_list_dropdown(self):
+    @patch("docassemble.AssemblyLine.language.url_action", return_value="mocked_url")
+    @patch("AssemblyLine.language.url_action", return_value="mocked_url")
+    def test_get_language_list_dropdown(self, url_action1, url_action2):
         result = get_language_list_dropdown(
             self.language_codes, languages_path=self.relative_path
         )
         self.assertIn('<li class="nav-item dropdown">', result)
         self.assertIn('<a class="dropdown-item" href="mocked_url">Français</a>', result)
 
-    def test_get_language_list_dropdown_item(self):
+    @patch("docassemble.AssemblyLine.language.url_action", return_value="mocked_url")
+    @patch("AssemblyLine.language.url_action", return_value="mocked_url")
+    def test_get_language_list_dropdown_item(self, url_action1, url_action2):
         language_tuple = ("English", "en")
         result = get_language_list_dropdown_item(language_tuple)
         self.assertIn('<a class="dropdown-item" href="mocked_url">English</a>', result)
 
-    def test_get_language_list(self):
+    @patch("docassemble.AssemblyLine.language.url_action", return_value="mocked_url")
+    @patch("AssemblyLine.language.url_action", return_value="mocked_url")
+    def test_get_language_list(self, url_action1, url_action2):
         result = get_language_list(
             lang_codes=self.language_codes, languages_path=self.relative_path
         )
         self.assertIn('<ul class="list-inline">', result)
         self.assertIn('<a target="_self" href="mocked_url">Français</a>', result)
 
-    def test_get_language_list_item(self):
+    @patch("docassemble.AssemblyLine.language.url_action", return_value="mocked_url")
+    @patch("AssemblyLine.language.url_action", return_value="mocked_url")
+    def test_get_language_list_item(self, url_action1, url_action2):
         language_tuple = ("English", "en")
         result = get_language_list_item(language_tuple)
         self.assertIn(

--- a/docassemble/AssemblyLine/test_language.py
+++ b/docassemble/AssemblyLine/test_language.py
@@ -7,12 +7,8 @@ from .language import (
     get_language_list,
     get_language_list_item,
 )
-#from docassemble.base.util import (
-#    this_thread
-#)
-import pycountry
-import yaml
 import os
+
 
 class TestLanguage(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Because `unittest` [no longer works with PEP-420 implicit namespaces](https://github.com/SuffolkLITLab/ALActions/commit/b2f68e2d077764a8256cb747e15fba7a97f19787) (which we are required to use because of docassemble and other python tooling deprecating the old way of using namespaces), we run unit tests with `python -m unittest discover docassemble`.

Starting at the `docassemble` folder changes what `unittest` thinks the namespace is, so the `patch` call needs to patch the `AssemblyLine.language.url_action` function instead. We keep the original patched function (`docassemble.AssemblyLine...`) to make it clear what we are trying to override and for the tests to work when run without the discover feature.

We also change to using `patch` as a decorator, which is it's documented use, and more common to find examples using, even though it has to be repeated for each test function.

This will fix the failing test in #935.