### PR TITLE
Use `al_international_phone` datatype for all phone number fields

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -599,8 +599,10 @@ subquestion: |
 fields:  
   - Mobile number: users[0].mobile_number
     required: False
+    datatype: al_international_phone
   - Other phone number: users[0].phone_number
     required: False
+    datatype: al_international_phone
   - Email address: users[0].email    
     datatype: email
     required: False
@@ -1141,12 +1143,21 @@ fields:
     field: users[i].previous_addresses.there_is_another  
     datatype: yesnoradio
 ---
-id: persons contact information
+id: persons phone number
 generic object: ALIndividual
 question: |
   What is ${x}'s phone number?
 fields:
   - Phone: x.phone_number
+    datatype: al_international_phone
+---
+id: persons mobile number
+generic object: ALIndividual
+question: |
+  What is ${x}'s mobile number?
+fields:
+  - Phone: x.mobile_number
+    datatype: al_international_phone
 ---
 id: persons fax number
 generic object: ALIndividual
@@ -1154,6 +1165,7 @@ question: |
   What is ${x}'s fax number?
 fields:
   - Fax number: x.fax_number
+    datatype: al_international_phone  
 ---
 id: email
 generic object: ALIndividual

--- a/docassemble/AssemblyLine/data/sources/test_question_library.feature
+++ b/docassemble/AssemblyLine/data/sources/test_question_library.feature
@@ -38,6 +38,6 @@ Scenario: Can enter all parts of contact info
   And I tap to continue
   And I tap to continue
   Then I should see the phrase "You need to provide at least one contact method"
-  And I set the variable "users[0].mobile_number" to "123-456-7890"
+  And I set the variable "users[0].mobile_number" to "617-555-5555"
   And I tap to continue
   Then I should see the phrase "All done!"


### PR DESCRIPTION
This shouldn't affect e-filing screens as they are already customized.

Fix #552