### PR TITLE
Allow customizing pronoun list and disabling the neopronoun ze/zir/zirs both case-by-case and globally

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1342,7 +1342,7 @@ class ALIndividual(Individual):
         shuffle: bool = False,
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
         maxlengths: Optional[Dict[str, int]] = None,
-        choices: Optional[List[Dict[str, str]]] = None,
+        options: Optional[List[Dict[str, str]]] = None,
     ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing pronoun information.
@@ -1354,13 +1354,13 @@ class ALIndividual(Individual):
             shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
             show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
             maxlengths (Dict[str, int], optional): A dictionary of field names and their maximum lengths. Default is None.
-            choices (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. If not provided, global magic variable `al_pronoun_choices` will be used.
+            options (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. If not provided, global magic variable `al_pronoun_choices` will be used.
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
-        if choices:
-            shuffled_choices = choices
+        if options:
+            shuffled_choices = options
         else:
             shuffled_choices = value("al_pronoun_choices")
         if shuffle:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1341,6 +1341,8 @@ class ALIndividual(Individual):
         shuffle: bool = False,
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
         maxlengths: Optional[Dict[str, int]] = None,
+        exclude_ze: Optional[bool] = None,
+        choices: Optional[List[Dict[str, str]]] = None,
     ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing pronoun information.
@@ -1352,16 +1354,27 @@ class ALIndividual(Individual):
             shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
             show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
             maxlengths (Dict[str, int], optional): A dictionary of field names and their maximum lengths. Default is None.
+            exclude_ze (bool): Whether to include the "ze/zir/zirs" pronoun option. Respects a custom value. if omitted defaults to global configuration option "assembly line: include ze pronouns", and defaults to True for backwards compatibility.
+            choices (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. Overrides `include_ze`
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
-        shuffled_choices = [
-            {str(self.pronoun_she_label): "she/her/hers"},
-            {str(self.pronoun_he_label): "he/him/his"},
-            {str(self.pronoun_they_label): "they/them/theirs"},
-            {str(self.pronoun_zir_label): "ze/zir/zirs"},
-        ]
+        if exclude_ze is None:
+            include_ze = get_config("assembly line", {}).get("include ze pronouns", True)
+        else:
+            include_ze = not exclude_ze
+
+        if choices:
+            shuffled_choices = choices
+        else:
+            shuffled_choices = [
+                {str(self.pronoun_she_label): "she/her/hers"},
+                {str(self.pronoun_he_label): "he/him/his"},
+                {str(self.pronoun_they_label): "they/them/theirs"},
+            ]
+            if include_ze:
+                shuffled_choices.append({str(self.pronoun_zir_label): "ze/zir/zirs"})
         if shuffle:
             random.shuffle(shuffled_choices)
         final_choices = [

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1342,7 +1342,7 @@ class ALIndividual(Individual):
         shuffle: bool = False,
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
         maxlengths: Optional[Dict[str, int]] = None,
-        options: Optional[List[Dict[str, str]]] = None,
+        choices: Optional[List[Dict[str, str]]] = None,
     ) -> List[Dict[str, str]]:
         """
         Generate fields for capturing pronoun information.
@@ -1354,13 +1354,13 @@ class ALIndividual(Individual):
             shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
             show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
             maxlengths (Dict[str, int], optional): A dictionary of field names and their maximum lengths. Default is None.
-            options (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. If not provided, global magic variable `al_pronoun_choices` will be used.
+            choices (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. If not provided, global magic variable `al_pronoun_choices` will be used.
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
-        if options:
-            shuffled_choices = options
+        if choices:
+            shuffled_choices = choices
         else:
             shuffled_choices = value("al_pronoun_choices")
         if shuffle:

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -34,6 +34,7 @@ from docassemble.base.util import (
     validation_error,
     word,
     your,
+    value,
 )
 import random
 import re
@@ -1341,7 +1342,6 @@ class ALIndividual(Individual):
         shuffle: bool = False,
         show_unknown: Optional[Union[Literal["guess"], bool]] = "guess",
         maxlengths: Optional[Dict[str, int]] = None,
-        exclude_ze: Optional[bool] = None,
         choices: Optional[List[Dict[str, str]]] = None,
     ) -> List[Dict[str, str]]:
         """
@@ -1354,29 +1354,15 @@ class ALIndividual(Individual):
             shuffle (bool): Whether to shuffle the order of pronouns. Defaults to False.
             show_unknown (Union[Literal["guess"], bool]): Whether to show an "unknown" option. Can be "guess", True, or False. Defaults to "guess".
             maxlengths (Dict[str, int], optional): A dictionary of field names and their maximum lengths. Default is None.
-            exclude_ze (bool): Whether to include the "ze/zir/zirs" pronoun option. Respects a custom value. if omitted defaults to global configuration option "assembly line: include ze pronouns", and defaults to True for backwards compatibility.
-            choices (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. Overrides `include_ze`
+            choices (Optional[List[Dict[str, str]]]): A list of custom pronoun choices. Defaults to None. If not provided, global magic variable `al_pronoun_choices` will be used.
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
-        if exclude_ze is None:
-            include_ze = get_config("assembly line", {}).get(
-                "include ze pronouns", True
-            )
-        else:
-            include_ze = not exclude_ze
-
         if choices:
             shuffled_choices = choices
         else:
-            shuffled_choices = [
-                {str(self.pronoun_she_label): "she/her/hers"},
-                {str(self.pronoun_he_label): "he/him/his"},
-                {str(self.pronoun_they_label): "they/them/theirs"},
-            ]
-            if include_ze:
-                shuffled_choices.append({str(self.pronoun_zir_label): "ze/zir/zirs"})
+            shuffled_choices = value("al_pronoun_choices")
         if shuffle:
             random.shuffle(shuffled_choices)
         final_choices = [

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1361,7 +1361,9 @@ class ALIndividual(Individual):
             List[Dict[str, str]]: A list of dictionaries with field prompts for pronouns.
         """
         if exclude_ze is None:
-            include_ze = get_config("assembly line", {}).get("include ze pronouns", True)
+            include_ze = get_config("assembly line", {}).get(
+                "include ze pronouns", True
+            )
         else:
             include_ze = not exclude_ze
 

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2438,25 +2438,12 @@ template: x.pronouns_label
 content: |
   Choose one or more pronouns
 ---
-generic object: ALIndividual
-template: x.pronoun_he_label
-content: |
-  He/him/his
----
-generic object: ALIndividual
-template: x.pronoun_she_label
-content: |
-  She/her/hers
----
-generic object: ALIndividual
-template: x.pronoun_they_label
-content: |
-  They/them/theirs
----
-generic object: ALIndividual
-template: x.pronoun_zir_label
-content: |
-  Ze/zir/zirs
+variable name: al_pronoun_choices
+data:
+  - He/him/his: he/him/his
+  - She/her/hers: she/her/hers
+  - They/them/theirs: they/them/theirs
+  - Ze/zir/zirs: ze/zir/zirs
 ---
 generic object: ALIndividual
 template: x.pronoun_prefer_not_to_say_label

--- a/docassemble/AssemblyLine/data/questions/test_question_library.yml
+++ b/docassemble/AssemblyLine/data/questions/test_question_library.yml
@@ -40,7 +40,7 @@ subquestion: |
   % elif item == "pronouns":
   Your pronouns are: ${ users[0].list_pronouns() }.
 
-  In the past, ${users[0].pronoun_subjective(person="2") } called ${ users[0].pronoun_reflexive(person="2") } ${ users[0].pronoun_objective(person="1") }.
+  In the past, ${users[0].pronoun_subjective(person="3") } called ${ users[0].pronoun_reflexive(person="3") } ${ users[0].pronoun_possessive('', person="3") }.
   % else:
   ${ getattr(users[0], item) }
   % endif

--- a/docassemble/AssemblyLine/data/questions/test_question_library.yml
+++ b/docassemble/AssemblyLine/data/questions/test_question_library.yml
@@ -17,18 +17,41 @@ code: |
 
   if which_to_test == 'address':
     users[0].address.address
-  if which_to_test == 'address_no_address':
+  elif which_to_test == 'address_no_address':
     users[0].address.has_no_address
-  if which_to_test == 'contact':
+  elif which_to_test == 'contact':
     users[0].phone_number
+  elif which_to_test == 'pronouns':
+    users[0].pronouns
   all_done
 ---
 event: all_done
 question: All done!
+subquestion: |
+  % for item in ["name", "pronouns", "address", "address_no_address", "contact"]:
+  % if which_to_test == item:
+  % if item == "contact":
+  Your contact information is:
+  ${ users[0].email }[BR]
+  ${ users[0].phone_numbers() }[BR]
+  ${ users[0].other_contact_method}[BR]
+  % elif item == "address_no_address":
+  ${ users[0].address_block() }
+  % elif item == "pronouns":
+  Your pronouns are: ${ users[0].list_pronouns() }.
+
+  In the past, ${users[0].pronoun_subjective(person="2") } called ${ users[0].pronoun_reflexive(person="2") } ${ users[0].pronoun_objective(person="1") }.
+  % else:
+  ${ getattr(users[0], item) }
+  % endif
+  % endif
+  % endfor
 ---
 question: Which question do you want to test?
 field: which_to_test
 choices:
+  - Name: name
+  - Pronouns: pronouns
   - Address: address
   - Address (with the option to not have one): address_no_address
   - Contact Information: contact


### PR DESCRIPTION
Adds a new parameter to the ALIndividual.pronoun_fields() method, `choices`, which allows overriding the default list of choices for `pronoun_fields()`

If the parameter is not provided, we will use a magic variable (from the interview) `al_pronoun_choices`.

The most common expected use case is to remove `ze/zir/zirs` from the list.

(discussion below reflects previous version of this description)

Fix #927