### PR TITLE
Improve custom error action screen - formatting, default open, and avoid chance for user to accidentally delete answers

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -527,13 +527,13 @@ subquestion: |
   % endfor
 
   % if not get_config("verbose error messages") == False:
-  ${ collapse_template(al_formatted_error_message) }
+  ${ collapse_template(al_formatted_error_message, collapsed=(not get_config("debug"))) }
   % endif
 back button label: Back
 buttons:
   - Exit: leave
     url: ${ AL_ORGANIZATION_HOMEPAGE }
-  - Start over: restart
+  - Start over: new_session
 ---
 code: |
   al_show_email_to_user_on_errors = get_config("assembly line", {}).get("show email to user on errors")
@@ -564,7 +564,7 @@ subquestion: |
   ${ al_user_bundle.download_list_html(key="emergency_download") }
 buttons:
   - Leave: leave
-  - Start over: restart
+  - Start over: new_session
 ---
 template: al_formatted_error_message
 subject: |
@@ -588,9 +588,7 @@ content: |
 
   % if get_config("debug") and action_argument("error_trace"):
   <h2 class="h4">${ word("Log") }</h2>
-  <pre>
-  ${ action_argument("error_trace")}
-  </pre>
+  ${ indent(action_argument("error_trace")) }
   % endif
 ---
 # This image reference is deprecated and may be removed by the end of 2023


### PR DESCRIPTION
Fix #914 - use new_session instead of restart, fix #797
fix #944 formatting on error screen
fix #770, expand error screen on debug

<img width="891" height="966" alt="image" src="https://github.com/user-attachments/assets/834692a0-ad96-4963-a21c-d09c239e9b4f" />

<img width="937" height="611" alt="image" src="https://github.com/user-attachments/assets/04120fea-6072-4d32-9b3a-b2523e0251aa" />

# Without change

<img width="875" height="757" alt="image" src="https://github.com/user-attachments/assets/b6ba1d1d-3872-452c-8874-e80e9fad3fe7" />
