### PR TITLE
allow most _fields() methods to accept passing a list of options

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2494,3 +2494,55 @@ generic object: ALIndividual
 template: x.other_contact_method_label
 content: >-
   by
+---
+# Backwards compatible, but you may want to override with Jr., Sr., etc.
+variable name: al_name_suffixes
+data:
+  - Jr
+  - Junior
+  - Sr
+  - Senior
+  - I
+  - II
+  - III
+  - IV
+  - V
+  - VI
+  - Esq.
+  - Ph.D.
+  - M.D.
+  - J.D.
+  - D.D.S.
+  - D.V.M.
+  - Ed.D.
+  - Ret.
+  - OBE
+  - CBE
+  - MBE
+  - QC
+  - KC
+  - Bart.
+  - Bt.
+---
+variable name: al_name_titles
+data:
+  - Mr.
+  - Mrs.
+  - Miss
+  - Ms.
+  - Mx.
+  - Dr.
+  - Prof.
+  - Hon.
+  - Rev.
+  - Sir
+  - Lord
+  - Lady
+  - Dame
+  - Maj.
+  - Gen.
+  - Capt.
+  - Lt.
+  - Sgt.
+  - Fr.
+  - Sr.


### PR DESCRIPTION
Fix #657 

For `name_fields()` specifically, added a way to customize the list of options for both suffixes and titles globally without using a `language` function. 

Added two `data` blocks (so they are available in standard XLSX translation file) with two new global magic variables: `al_name_suffixes` and `al_name_titles`.

This is likely not considered backwards compatible because it ignores the definition of `name_suffix()` and the complicated language function translation system you can use with it. A simple `code` block in an interview can restore the old behavior, but the new extended list meets the needs of some of our community partners without removing any options and is translatable in a more standardized way.

When passed as parameters, you can use a `Callable` rather than a bare list. although this flexibility might not be important in most cases, I think it could help if you still want to use the standard `language` function method on an individual method-call basis.