### PR TITLE
Corrected collapse template param name

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -527,7 +527,7 @@ subquestion: |
   % endfor
 
   % if not get_config("verbose error messages") == False:
-  ${ collapse_template(al_formatted_error_message, collapsed=(not get_config("debug"))) }
+  ${ collapse_template(al_formatted_error_message, collapse=(not get_config("debug"))) }
   % endif
 back button label: Back
 buttons:


### PR DESCRIPTION
Should be 'collapse', was 'collapsed'. Results in a gnarly 500 error.

Bug that got through https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/945/files.

```
Traceback (most recent call last):
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/flask/app.py", line 809, in handle_user_exception
    return self.ensure_sync(handler)(e)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/webapp/server.py", line 23450, in server_error
    return index(action_argument={'action': docassemble.base.functions.this_thread.interview.consolidated_metadata['error action'], 'arguments': {'error_message': orig_errmess, 'error_history': the_history, 'error_trace': the_trace}}, refer=['error'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/webapp/server.py", line 8506, in index
    interview.assemble(user_dict, interview_status, old_user_dict, force_question=special_question)
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/parse.py", line 9247, in assemble
    raise the_error
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/parse.py", line 9034, in assemble
    question_result = self.askfor(missingVariable, user_dict, old_user_dict, interview_status, seeking=interview_status.seeking, follow_mc=follow_mc, seeking_question=seeking_question)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/parse.py", line 9782, in askfor
    return question.ask(user_dict, old_user_dict, the_x, iterators, missing_var, origMissingVariable)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/parse.py", line 5618, in ask
    subquestion = self.subcontent.text(user_dict).rstrip()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/parse.py", line 1650, in text
    return self.template.render(**the_user_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/mako/template.py", line 444, in render
    return runtime._render(self, self.callable_, args, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/mako/runtime.py", line 874, in _render
    _render_context(
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/mako/runtime.py", line 916, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/share/docassemble/local3.12/lib/python3.12/site-packages/docassemble/base/mako/runtime.py", line 943, in _exec_template
    callable_(context, *args, **kwargs)
  File "memory:0xffff72ce1d00", line 163, in render_body
TypeError: collapse_template() got an unexpected keyword argument 'collapsed'
```