### PR TITLE
Don't explicitly close connection, instead use context manager

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -50,6 +50,7 @@ import os
 import re
 import hashlib
 import struct
+
 try:
     import zoneinfo  # type: ignore
 except ImportError:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -317,13 +317,11 @@ def get_interview_metadata(
     with closing(db.engine.connect()) as conn:
         row = conn.execute(
             sql,
-            {"filename": filename,
-             "tags": metadata_key_name,
-             "session_id": session_id},
+            {"filename": filename, "tags": metadata_key_name, "session_id": session_id},
         ).fetchone()
 
     if row:
-        return row[0]          # row is a RowMapping/tuple; data is column 0
+        return row[0]  # row is a RowMapping/tuple; data is column 0
     return {}
 
 
@@ -1635,9 +1633,9 @@ def get_filenames_having_sessions(
 
     if user_id == "all":
         if user_has_privilege(global_search_allowed_roles):
-            user_id = None                     # unrestricted query
+            user_id = None  # unrestricted query
         elif user_logged_in():
-            user_id = user_info().id           # downgrade to self
+            user_id = user_info().id  # downgrade to self
             log(
                 f"User {user_info().email} lacks permission to list sessions for other users"
             )
@@ -1645,10 +1643,8 @@ def get_filenames_having_sessions(
             log("Asked to get interview list for user that is not logged in")
             return []
 
-    sql_all   = text("SELECT DISTINCT filename FROM userdict")
-    sql_user  = text(
-        "SELECT DISTINCT filename FROM userdict WHERE user_id = :user_id"
-    )
+    sql_all = text("SELECT DISTINCT filename FROM userdict")
+    sql_user = text("SELECT DISTINCT filename FROM userdict WHERE user_id = :user_id")
 
     with db.connect() as conn:
         if user_id is None:

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -50,6 +50,7 @@ import os
 import re
 import hashlib
 import struct
+from contextlib import closing
 
 try:
     import zoneinfo  # type: ignore
@@ -301,15 +302,14 @@ def get_interview_metadata(
     Returns:
         Dict[str, Any]: The metadata associated with the interview
     """
-    conn = variables_snapshot_connection()
-    with conn.cursor() as cur:
-        query = "select data from jsonstorage where filename=%(filename)s and tags=%(tags)s and key=%(session_id)s"
-        cur.execute(
-            query,
-            {"filename": filename, "tags": metadata_key_name, "session_id": session_id},
-        )
-        val = cur.fetchone()
-    conn.close()
+    with closing(variables_snapshot_connection()) as conn:
+        with conn.cursor() as cur:
+            query = "select data from jsonstorage where filename=%(filename)s and tags=%(tags)s and key=%(session_id)s"
+            cur.execute(
+                query,
+                {"filename": filename, "tags": metadata_key_name, "session_id": session_id},
+            )
+            val = cur.fetchone()
     if val and len(val):
         return val[0]  # cur.fetchone() returns a tuple
     return val or {}

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -311,11 +311,8 @@ def get_interview_metadata(
            AND key         = :session_id
         """
     )
-
-    # engine.connect() returns an SQLAlchemy Connection that closes
-    # (and returns to the pool) when the with-block exits, solving possible race conditions
-    with closing(db.engine.connect()) as conn:
-        row = conn.execute(
+    with db.connect() as con:
+        row = con.execute(
             sql,
             {"filename": filename, "tags": metadata_key_name, "session_id": session_id},
         ).fetchone()

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -1172,13 +1172,13 @@ def rename_interview_answers(
 
     If exception is raised in set_session_variables, this will silently fail but log the error.
     """
-    existing_metadata = get_interview_metadata(
-        filename, session_id, metadata_key_name=metadata_key_name
+    update_session_metadata(
+        filename,
+        session_id,
+        {"title": new_name},
+        metadata_key_name=metadata_key_name,
     )
-    existing_metadata["title"] = new_name
-    set_interview_metadata(
-        filename, session_id, existing_metadata, metadata_key_name=metadata_key_name
-    )
+
     if session_id == current_context().session:
         set_parts(subtitle=new_name)
     else:


### PR DESCRIPTION
Fix #955 

Refactored both get_interview_metadata() and get_saved_interview_list() which were, by way of Docassemble's `variables_snapshot_connection()`, making use of raw psycopg2 connections instead of the higher-level sqlalchemy connections. Made better use of context manager which should also avoid premature session closing.

I don't recall a reason to use the variables_snapshot_connection() in these two functions, as the rest of the module uses the Docassemble shared `db` object.

`get_interview_metadata()` is used on the al_saved_sessions_store.yml page, and get_saved_interview_list() is used on the interview_list.yml page for basic testing. Testing the search feature particularly should validate this change.