### PR TITLE
Enforce ALToolbox to 0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.AssemblyLine',
       license='The MIT License (MIT)',
       url='https://courtformsonline.org',
       packages=find_namespace_packages(),
-      install_requires=['docassemble.ALToolbox>=0.11.1', 'docassemble.GithubFeedbackForm>=0.4.1.1'],
+      install_requires=['docassemble.ALToolbox>=0.12.0', 'docassemble.GithubFeedbackForm>=0.4.1.1'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/AssemblyLine/', package='docassemble.AssemblyLine'),
      )


### PR DESCRIPTION
Needed for #945; without that, our error screen breaks.

* ALToolbox 0.12.0: https://github.com/SuffolkLITLab/docassemble-ALToolbox/releases/tag/v0.12.0
* The specific PR needed there: https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/279