### PR TITLE
Fix SyntaxWarning starting in 3.12

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -2404,7 +2404,7 @@ def is_phone_or_email(text: str) -> bool:
         DAValidationError if the string is neither a valid phone number nor a valid email address.
     """
     sms_enabled = is_sms_enabled()
-    if re.match("\S+@\S+", text) or (sms_enabled and phone_number_is_valid(text)):
+    if re.match(r"\S+@\S+", text) or (sms_enabled and phone_number_is_valid(text)):
         return True
     else:
         if sms_enabled:


### PR DESCRIPTION
This warning has started showing up when installing AssemblyLine on Python 3.12 and later:

```
SyntaxWarning: invalid escape sequence '\S'
  if re.match("\S+@\S+", text) or (sms_enabled and phone_number_is_valid(text)):
```

It's because the regex string isn't a raw string, so it's acting as escape sequences on `S` instead of the regex characters `\S`. The intended behavior is kept whether or not we have the raw string, but the warning goes away if we use the raw string.