### PR TITLE
Modify `phone_numbers()` method to support other logical attribute names

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -958,6 +958,14 @@ class ALIndividual(Individual):
     ) -> str:
         """Fetches and formats the phone numbers of the individual.
 
+        Supports the following attributes:
+
+        - `mobile_number`: Mobile phone number
+        - `phone_number`: Other phone number
+        - `work_number`: Work phone number
+        - `other_number`: Any other phone number
+        - `home_number`: Home phone number (if applicable)
+
         Args:
             country (str, optional): The country for phone number formatting. Defaults to the country of the docassemble server.
             show_impounded (bool): If True, shows the phone numbers even if impounded. Defaults to False.
@@ -986,6 +994,36 @@ class ALIndividual(Individual):
                 nums.append({fmt_number: "other"})
             else:
                 nums.append({self.phone_number: "other"})
+        if hasattr(self, "work_number") and self.work_number:
+            fmt_number = None
+            try:
+                fmt_number = phone_number_formatted(self.work_number, country=country)
+            except:
+                fmt_number = None
+            if fmt_number:
+                nums.append({fmt_number: "work"})
+            else:
+                nums.append({self.work_number: "work"})
+        if hasattr(self, "other_number") and self.other_number:
+            fmt_number = None
+            try:
+                fmt_number = phone_number_formatted(self.other_number, country=country)
+            except:
+                fmt_number = None
+            if fmt_number:
+                nums.append({fmt_number: "other"})
+            else:
+                nums.append({self.other_number: "other"})
+        if hasattr(self, "home_number") and self.home_number:
+            fmt_number = None
+            try:
+                fmt_number = phone_number_formatted(self.home_number, country=country)
+            except:
+                fmt_number = None
+            if fmt_number:
+                nums.append({fmt_number: "home"})
+            else:
+                nums.append({self.home_number: "home"})
         if len(nums) < 1:
             return ""
         # Check for impounded phone number

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1173,6 +1173,30 @@ fields:
   - Phone: x.mobile_number
     datatype: al_international_phone
 ---
+id: persons home number
+generic object: ALIndividual
+question: |
+  What is ${x}'s home number?
+fields:
+  - Phone: x.home_number
+    datatype: al_international_phone
+---
+id: persons work number
+generic object: ALIndividual
+question: |
+  What is ${x}'s work number?
+fields:
+  - Phone: x.work_number
+    datatype: al_international_phone
+---
+id: persons other number
+generic object: ALIndividual
+question: |
+  What is ${x}'s other number?
+fields:
+  - Phone: x.other_number
+    datatype: al_international_phone
+---
 id: persons fax number
 generic object: ALIndividual
 question: |


### PR DESCRIPTION
Modifies `ALIndividual.phone_numbers()` so it will return:

* `phone_number`
* `mobile_number`
* `work_number`
* `other_number`
* `home_number`

if any of these attributes are defined.

Also defines some new questions relative to the new attributes.