### PR TITLE
In signature flow choice screen, use the actual signer's name in the example for /s/, not just `users[0]`

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -1440,6 +1440,17 @@ code: |
 code: |
   signature_fields = ['users[0].signature']
 ---
+code: |
+  if len(signature_fields):    
+    if ".signature" in next(iter(signature_fields)):
+      # the id: signature choice question has to assume the object exists, so we don't guard against that here
+      # note: this does not need to be an ALIndividual, so just use str() instead of .full_name()
+      slash_s_example_name = str(value( next(iter(signature_fields)).split('.')[0] ))
+    else:
+      slash_s_example_name = "Signer's Name"
+  else:
+    slash_s_example_name = "Signer's Name"
+---
 id: signature choice
 decoration: file-signature
 question: |
@@ -1458,7 +1469,7 @@ fields:
           We can share a link with your phone on the next screen
           % endif
       - On this device: this_device
-      - With a typed signature, like "${ al_typed_signature_prefix }${ users[0] }": typed_signature
+      - With a typed signature, like "${ al_typed_signature_prefix }${ slash_s_example_name }": typed_signature
     show if:
       code: |
         al_form_requires_digital_signature and not (device() and (device().is_mobile or device().is_touch_capable))
@@ -1467,7 +1478,7 @@ fields:
     input type: radio
     choices:
       - On this device: this_device
-      - With a typed signature, like "${ al_typed_signature_prefix }${ users[0] }": typed_signature
+      - With a typed signature, like "${ al_typed_signature_prefix }${ slash_s_example_name }": typed_signature
     show if:
       code: |
         al_form_requires_digital_signature and (device() and (device().is_mobile or device().is_touch_capable))
@@ -1483,7 +1494,7 @@ fields:
           We can share a link with your phone on the next screen
           % endif
       - On this device: this_device
-      - With a typed signature, like "${ al_typed_signature_prefix }${ users[0] }": typed_signature
+      - With a typed signature, like "${ al_typed_signature_prefix }${ slash_s_example_name }": typed_signature
       - On the paper with a pen after I print the documents: sign_after_printing
     show if:
       code: |
@@ -1493,7 +1504,7 @@ fields:
     input type: radio
     choices:
       - On this device: this_device
-      - With a typed signature, like "${ al_typed_signature_prefix }${ users[0] }": typed_signature
+      - With a typed signature, like "${ al_typed_signature_prefix }${ slash_s_example_name }": typed_signature
       - On the paper with a pen after I print the documents: sign_after_printing
     show if:
       code: |


### PR DESCRIPTION
Fix #964

This is a minimal fix ignoring the larger refactor suggested in #964 of making the signature choice screen a per-user item. That is a good idea but would take more testing to make sure it doesn't break existing developer expectations - maybe a signature choice v2.