### PR TITLE
Change `et. al.` to `et al.`

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -803,12 +803,12 @@ class ALPeopleList(DAList):
             [person.familiar(**kwargs) for person in self], and_string=word("or")
         )
 
-    def short_list(self, limit: int, truncate_string: str = ", et. al.") -> str:
-        """Return a subset of the list, truncated with 'et. al.' if it exceeds a given limit.
+    def short_list(self, limit: int, truncate_string: str = ", et al.") -> str:
+        """Return a subset of the list, truncated with 'et al.' if it exceeds a given limit.
 
         Args:
             limit (int): The maximum number of items to display before truncating.
-            truncate_string (str, optional): The string to append when truncating. Defaults to ', et. al.'.
+            truncate_string (str, optional): The string to append when truncating. Defaults to ', et al.'.
 
         Returns:
             str: Formatted string of names, truncated if needed.


### PR DESCRIPTION
`et al.` commonly only has one abbreviation period, as `et` is the full latin word.

It's only other presence in our repos is in the documentation (which will be overwritten with the latest changes in this repo), and in literal mis-uses of it in form explorer example documents.

https://github.com/search?q=org%3ASuffolkLITLab+%22et.+al.%22&type=code