### PR TITLE
Support DALazyTemplate in ALAddendumField

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -156,10 +156,7 @@ def safeattr(object: Any, key: str) -> str:
                     object.location, LatitudeLongitude
                 ):
                     return ""
-            val = getattr(object, key)
-            if isinstance(val, DALazyTemplate):
-                return str(val)
-            return str(val)
+            return str(getattr(object, key))
         else:
             return ""
     except:


### PR DESCRIPTION

Fix #986

This helps when you have a few fields that you want to insert into a single box in a PDF. By putting each field into a `template` block, you can respect the final line/character count in a single field without complex calculations. By using a DALazyTemplate, the calculations will be done fresh for "free" without requiring you to use a `depends on` modifier or `reconsider: True`.