### PR TITLE
Add project to pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 tests/chromedriver
 *DS_Store*
 node_modules*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,34 @@
+[build-system]
+requires = [
+    "setuptools==80.9.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "docassemble.AssemblyLine"
+version = "4.2.0"
+description = "Quickly go from a paper court form to a runnable, guided, step-by-step web application powered by Docassemble. Swap out branding and pre-built questions to meet your needs."
+readme = "README.md"
+authors = [
+    { name="Suffolk Legal Innovation and Technology Lab", email="litlab@suffolk.edu" },
+]
+dependencies = [
+    "docassemble.ALToolbox>=0.12.0",
+    "docassemble.GitHubFeedbackForm>=0.4.1.1",
+]
+license="MIT"
+license-files = [
+    "LICENSE"
+]
+
+[project.urls]
+Homepage = "https://courtformsonline.org"
+
+[tool.setuptools.packages.find]
+where = [
+    ".",
+]
+
 [tool.black]
 extend-exclude = '(__init__.py|setup.py)'
 


### PR DESCRIPTION
Necessary for dainstall 0.0.24 and above to let us actually install this package in the playground / to servers.

Just stuck with what Docassemble spits out for now. Can look into additional parts of the pyproject.toml that we can use later (I know you can load the version number from the `__init__.py` file, which will be nice eventually).

Tested with dainstall 0.0.25 and on a local docassemble server (1.8.18), can install this package into the playground and otherwise.