### PR TITLE
Return unique results based on the session ID

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -379,7 +379,7 @@ def get_saved_interview_list(
     filenames_to_exclude.extend([current_filename, filename_to_exclude])
 
     query_draft = """
-        SELECT userdict.indexno
+        SELECT DISTINCT ON (userdict.key) userdict.indexno
             ,userdict.filename as filename
             ,num_keys
             ,userdictkeys.user_id as user_id
@@ -589,7 +589,7 @@ def find_matching_sessions(
 
     get_sessions_query = text(
         f"""
-        SELECT  userdict.indexno,
+        SELECT DISTINCT ON (userdict.key) userdict.indexno,
                 userdict.filename as filename,
                 num_keys,
                 userdictkeys.user_id as user_id,


### PR DESCRIPTION
Previously, it was possible to get duplicate results from find_matching_sessions and get_saved_interview_list. It seems this mostly would be the case when an advocate joined a session created by a user from the general public.

This is a modest fix that just adds SELECT DISTINCT to those queries.

Fix #888