### PR TITLE
Actually use `.view_label` and `.download_label`

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2058,13 +2058,13 @@ class ALDocumentBundle(DAList):
             str: HTML representation of a table with documents and their associated actions.
         """
         if not view_label:
-            view_label = self.view_label or word("View")
+            view_label = str(self.view_label) or word("View")
 
         if not download_label:
-            download_label = self.download_label or word("Download")
+            download_label = str(self.download_label) or word("Download")
 
         if not send_label:
-            send_label = self.send_label or word("Send")
+            send_label = str(self.send_label) or word("Send")
 
         if zip_format is None:
             zip_format = format
@@ -2275,7 +2275,7 @@ class ALDocumentBundle(DAList):
             str: The generated HTML string for the table row.
         """
         if not send_label:
-            send_label = self.send_label or word("Send")
+            send_label = str(self.send_label) or word("Send")
 
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents
@@ -2342,7 +2342,7 @@ class ALDocumentBundle(DAList):
             str: The generated HTML string for the button.
         """
         if label is None:
-            label = self.send_label or word("Send")
+            label = str(self.send_label) or word("Send")
 
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents


### PR DESCRIPTION
`action_button_html` expects a string for the label, and if it doesn't get it, it just shows the default of "Edit". We started passing `DALazyTemplates` in #992, and hadn't done enough testing to ensure that the labels shown there are correct.

This patch fixes the issue by running the `DALazyTemplate` through `str()` before passing to `action_button_html`.

Pre fix:

<img width="534" height="119" alt="Screenshot 2025-12-05 at 10 22 53 AM" src="https://github.com/user-attachments/assets/e07946e0-abc8-4e78-bbee-b8f17d320432" />



Post fix:

<img width="561" height="121" alt="Screenshot 2025-12-05 at 10 21 27 AM" src="https://github.com/user-attachments/assets/f9b5e4ce-3c8b-41d2-85d9-5b5d114457e1" />
