### PR TITLE
Add translations for ALToolbox ThreePartDate component

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -443,6 +443,9 @@ question: |
 fields:
   - Birthdate: x.birthdate
     datatype: BirthDate
+    alMonthLabel: ${ word('Month') }
+    alDayLabel: ${ word('Day') }
+    alYearLabel: ${ word('Year') }
 ---
 id: user i's address
 question: |

--- a/docassemble/AssemblyLine/data/sources/ar-words.yml
+++ b/docassemble/AssemblyLine/data/sources/ar-words.yml
@@ -750,4 +750,4 @@ ar: {'%(username_or_email)s does not exist': '%(username_or_email)s غير مو�
   them: هم, themself: أنفسهم, themselves: أنفسهم, they: هم, to proceed.: للمتابعة.,
   'true': حقيقي, unavailable: غير متاح, us: نحن, v.: فعل, was saved at: تم حفظه في,
   we: نحن, x: س, y: ي, year: سنة, yes: نعم, you: أنت, yourself: نفسك, yourselves: أنفسكم,
-  Åland Islands: جزر آلاند}
+  Åland Islands: جزر آلاند, Month: شهر, Day: يوم, Year: سنة}

--- a/docassemble/AssemblyLine/data/sources/es-words.yml
+++ b/docassemble/AssemblyLine/data/sources/es-words.yml
@@ -113,7 +113,7 @@ es: {'%(username_or_email)s does not exist': '%(username_or_email)s no existe', 
     un nuevo proyecto, Create an interview with the wizard: Crea una entrevista con
     el mago, 'Created new Markdown file called ': Creado nuevo archivo de Markdown
     llamado, Croatia: Croacia, Cuba: Cuba, Curaçao: Curazao, Current: Corriente, Cyprus: Chipre,
-  Czechia: Chequia, Decorations: Decoraciones, Default Playground: Patio de juegos
+  Czechia: Chequia, Day: Día, Decorations: Decoraciones, Default Playground: Patio de juegos
     predeterminado, Defined in: Definido en, Delete: Borrar, Delete Account: Eliminar
     cuenta, Delete All: Eliminar todo, Delete account and shared sessions: Eliminar
     cuenta y sesiones compartidas, Delete account but keep shared sessions: Eliminar
@@ -311,7 +311,7 @@ es: {'%(username_or_email)s does not exist': '%(username_or_email)s no existe', 
     nuevos datos con los datos existentes, Methods: Los metodos, Mexico: México, 'Micronesia, Federated States of': 'Micronesia,
     Estados Federados de', Models: Modelos, Modules: Módulos, Modules available in Playground: Módulos
     disponibles en Playground, Modules defined: Modulos definidos, 'Moldova, Republic of': 'Moldavia,
-    República de', Monaco: Mónaco, Mongolia: Mongolia, Monitor: Monitor, Montenegro: Montenegro,
+    República de', Monaco: Mónaco, Mongolia: Mongolia, Monitor: Monitor, Montenegro: Montenegro, Month: Mes,
   Montserrat: Montserrat, Morocco: Marruecos, Move down: Mover hacia abajo, Mozambique: Mozambique,
   Multiselect box: cuadro de selección múltiple, Must be a two-letter code: Debe ser
     un código de dos letras, Must be a valid e-mail address: Debe ser una dirección
@@ -699,7 +699,7 @@ es: {'%(username_or_email)s does not exist': '%(username_or_email)s no existe', 
     archivo desea importar?', 'When you type inside Jinja2 brackets, auto-complete options will appear here.': 'Cuando
     escribas dentro de los corchetes Jinja2, aparecerán aquí las opciones de autocompletar.',
   Wizard: Mago, 'Would you like to reconfigure two-factor authentication?': '¿Te gustaría
-    reconfigurar la autenticación de dos factores?', Yemen: Yemen, Yes: Sí, 'You are available for the following roles: ': 'Estás
+    reconfigurar la autenticación de dos factores?', Year: Año, Yemen: Yemen, Yes: Sí, 'You are available for the following roles: ': 'Estás
     disponible para los siguientes puestos: ', You are not allowed to access this interview.: No
     tienes permiso para acceder a esta entrevista., You are not authorized to access: No
     estás autorizado para acceder, You are now set up with two factor authentication.: Ahora

--- a/docassemble/AssemblyLine/data/sources/fr-words.yml
+++ b/docassemble/AssemblyLine/data/sources/fr-words.yml
@@ -113,7 +113,7 @@ fr: {'%(username_or_email)s does not exist': '%(nom_utilisateur_ou_email)s n''ex
     un nouveau projet, Create an interview with the wizard: Créez une interview avec
     le magicien, 'Created new Markdown file called ': 'Création d''un nouveau fichier
     Markdown appelé ', Croatia: Croatie, Cuba: Cuba, Curaçao: Curaçao, Current: Actuel,
-  Cyprus: Chypre, Czechia: Tchéquie, Decorations: Décorations, Default Playground: Terrain
+  Cyprus: Chypre, Czechia: Tchéquie, Day: Jour, Decorations: Décorations, Default Playground: Terrain
     de jeu par défaut, Defined in: Défini dans, Delete: Supprimer, Delete Account: Supprimer
     le compte, Delete All: Supprimer tout, Delete account and shared sessions: Supprimer
     le compte et les sessions partagées, Delete account but keep shared sessions: Supprimer
@@ -317,7 +317,7 @@ fr: {'%(username_or_email)s does not exist': '%(nom_utilisateur_ou_email)s n''ex
   'Micronesia, Federated States of': 'Micronésie, États fédérés de', Models: Modèles,
   Modules: Modules, Modules available in Playground: Modules disponibles dans Playground,
   Modules defined: Modules définis, 'Moldova, Republic of': 'Moldavie, République
-    de', Monaco: Monaco, Mongolia: Mongolie, Monitor: Moniteur, Montenegro: Monténégro,
+    de', Monaco: Monaco, Mongolia: Mongolie, Monitor: Moniteur, Montenegro: Monténégro, Month: Mois,
   Montserrat: Montserrat, Morocco: Maroc, Move down: Descendre, Mozambique: Mozambique,
   Multiselect box: boîte à sélection multiple, Must be a two-letter code: Doit être
     un code à deux lettres, Must be a valid e-mail address: Doit être une adresse
@@ -712,7 +712,7 @@ fr: {'%(username_or_email)s does not exist': '%(nom_utilisateur_ou_email)s n''ex
     fichier souhaitez-vous importer ?', 'When you type inside Jinja2 brackets, auto-complete options will appear here.': 'Lorsque
     vous saisissez du texte entre les crochets Jinja2, des options de saisie automatique
     s''affichent ici.', Wizard: Magicien, 'Would you like to reconfigure two-factor authentication?': 'Souhaitez-vous
-    reconfigurer l''authentification à deux facteurs ?', Yemen: Yémen, Yes: Oui, 'You are available for the following roles: ': 'Vous
+    reconfigurer l''authentification à deux facteurs ?', Year: Année, Yemen: Yémen, Yes: Oui, 'You are available for the following roles: ': 'Vous
     êtes disponible pour les rôles suivants : ', You are not allowed to access this interview.: Vous
     n'êtes pas autorisé à accéder à cet entretien., You are not authorized to access: Vous
     n'êtes pas autorisé à accéder, You are now set up with two factor authentication.: L'authentification

--- a/docassemble/AssemblyLine/data/sources/ne-words.yml
+++ b/docassemble/AssemblyLine/data/sources/ne-words.yml
@@ -111,7 +111,7 @@ ne: {'%(username_or_email)s does not exist': '%(username_or_email)s अवस्
     परियोजना सिर्जना गर्नुहोस्, Create an interview with the wizard: विजार्डसँग अन्तर्वार्ता
     सिर्जना गर्नुहोस्, 'Created new Markdown file called ': 'नयाँ मार्कडाउन फाइल सिर्जना
     गरियो जसलाई भनिन्छ ', Croatia: क्रोएसिया, Cuba: क्युबा, Curaçao: कुराकाओ, Current: हालको,
-  Cyprus: साइप्रस, Czechia: चेकिया, Decorations: सजावटहरू, Default Playground: पूर्वनिर्धारित
+  Cyprus: साइप्रस, Czechia: चेकिया, Day: दिन, Decorations: सजावटहरू, Default Playground: पूर्वनिर्धारित
     खेल मैदान, Defined in: मा परिभाषित, Delete: मेटाउनुहोस्, Delete Account: खाता
     मेटाउनुहोस्, Delete All: सबै मेटाउनुहोस्, Delete account and shared sessions: खाता
     र साझा सत्रहरू मेटाउनुहोस्, Delete account but keep shared sessions: खाता मेटाउनुहोस्
@@ -307,7 +307,7 @@ ne: {'%(username_or_email)s does not exist': '%(username_or_email)s अवस्
     डेटामा मर्ज गर्नुहोस्, Methods: विधिहरू, Mexico: मेक्सिको, 'Micronesia, Federated States of': 'माइक्रोनेसिया,
     संघीय राज्यहरू', Models: मोडेलहरू, Modules: मोड्युलहरू, Modules available in Playground: खेल
     मैदानमा उपलब्ध मोड्युलहरू, Modules defined: मोड्युलहरू परिभाषित गरियो, 'Moldova, Republic of': 'मोल्डोभा,
-    गणतन्त्र', Monaco: मोनाको, Mongolia: मङ्गोलिया, Monitor: मनिटर, Montenegro: मोन्टेनेग्रो,
+    गणतन्त्र', Monaco: मोनाको, Mongolia: मङ्गोलिया, Monitor: मनिटर, Montenegro: मोन्टेनेग्रो, Month: महिना,
   Montserrat: मोन्टसेराट, Morocco: मोरक्को, Move down: तल सार्नुहोस्, Mozambique: मोजाम्बिक,
   Multiselect box: बहुचयन बाकस, Must be a two-letter code: दुई-अक्षरको कोड हुनुपर्छ,
   Must be a valid e-mail address: मान्य इमेल ठेगाना हुनुपर्छ।, Must be in E.164 format.  U.S. phone numbers begin with +1.: E.164
@@ -679,7 +679,7 @@ Resume: जारी राख्नुहोस्, Resume an interview: अन
     कुन फाइल आयात गर्न चाहनुहुन्छ?', 'When you type inside Jinja2 brackets, auto-complete options will appear here.': 'जब
     तपाईंले Jinja2 कोष्ठक भित्र टाइप गर्नुहुन्छ, यहाँ स्वत: पूर्ण विकल्पहरू देखा पर्नेछन्।',
   Wizard: विजार्ड, 'Would you like to reconfigure two-factor authentication?': 'के
-    तपाईं दुई-कारक प्रमाणीकरण पुन: कन्फिगर गर्न चाहनुहुन्छ?', Yemen: यमन, Yes: हो,
+    तपाईं दुई-कारक प्रमाणीकरण पुन: कन्फिगर गर्न चाहनुहुन्छ?', Year: वर्ष, Yemen: यमन, Yes: हो,
   'You are available for the following roles: ': 'तपाईं निम्न भूमिकाहरूको लागि उपलब्ध
     हुनुहुन्छ: ', You are not allowed to access this interview.: तपाईंलाई यो अन्तर्वार्तामा
     पहुँच गर्न अनुमति छैन।, You are not authorized to access: तपाईंलाई पहुँच गर्न


### PR DESCRIPTION
For French, Spanish, Arabic, and Nepalese. Provided by Kelly McGuire!

We did have these translated strings already, but they were lowercase only, and the uppercase versions are used for the Month/Day/Year labels in the three-part date.

It needs https://github.com/SuffolkLITLab/docassemble-ALToolbox/pull/317 to actually have any affect; by itself, it won't fix the translation issue, and will actually break the birthday question (as we give the custom data type new parameters that docassemble doesn't recognize).