### PR TITLE
Use code block for examples with code in docstrings

### DIFF
--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -518,6 +518,7 @@ def find_matching_sessions(
         List[Dict[str, Any]]: A list of saved sessions for the specified filename that match the search keyword and metadata filters
 
     Example:
+    ```python
         matching_sessions = find_matching_sessions(
             "smith",
             user_id="all",
@@ -529,9 +530,8 @@ def find_matching_sessions(
             }
         )
 
-    Example:
         {"owner": ("samantha", "ILIKE", None), "age": (30, ">=", "int"), "status": ("%complete%", "LIKE", None)}
-
+    ```
     """
     if not metadata_column_names:
         metadata_column_names = {"title", "auto_title", "description"}


### PR DESCRIPTION
Shows up better on the documentation site


What it looks like currently:

<img width="1740" height="710" alt="image" src="https://github.com/user-attachments/assets/43c3b7e9-82c3-466c-9ad8-90b9a9472e4d" />


What it looks like after this change: 

<img width="650" height="359" alt="Screenshot 2026-01-16 at 2 22 41 PM" src="https://github.com/user-attachments/assets/c50b55d3-ff37-45cb-88cc-c72297dacf3b" />
