### PR TITLE
fix: resolved import error of `this_thread` by changing the import to come from `functions` instead of `util` due to docassemble v1.9.2

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from typing import Callable, Dict, List, Literal, Union, Optional, Any
-from docassemble.base.functions import this_thread
 from docassemble.base.util import (
     Address,
     as_datetime,
@@ -38,6 +37,7 @@ from docassemble.base.util import (
     value,
 )
 from docassemble.ALToolbox.misc import fa_icon
+import docassemble.base.functions
 import random
 import re
 import pycountry
@@ -374,7 +374,7 @@ class ALAddress(Address):
         Returns:
             str: The one-line formatted address.
         """
-        if this_thread.evaluation_context == "docx":
+        if docassemble.base.functions.this_thread.evaluation_context == "docx":
             line_breaker = '</w:t><w:br/><w:t xml:space="preserve">'
         else:
             line_breaker = " [NEWLINE] "
@@ -1701,7 +1701,7 @@ class ALIndividual(Individual):
         Returns:
             str: The formatted address block.
         """
-        if this_thread.evaluation_context == "docx":
+        if docassemble.base.functions.this_thread.evaluation_context == "docx":
             if isinstance(self.address, ALAddress):
                 return self.address.block(
                     language=language,
@@ -1778,7 +1778,7 @@ class ALIndividual(Individual):
             else:
                 pronouns = self.pronouns
 
-        if self == this_thread.global_vars.user:
+        if self == docassemble.base.functions.this_thread.global_vars.user:
             output = word("you", **kwargs)
         elif hasattr(self, "pronouns") and self.pronouns:
             pronouns_to_use = []
@@ -1876,7 +1876,7 @@ class ALIndividual(Individual):
         else:
             default = self.name_full()
 
-        if self == this_thread.global_vars.user and (
+        if self == docassemble.base.functions.this_thread.global_vars.user and (
             "thirdperson" not in kwargs or not kwargs["thirdperson"]
         ):
             output = your(target, **kwargs)
@@ -1963,7 +1963,7 @@ class ALIndividual(Individual):
             else:
                 pronouns = self.pronouns
 
-        if self == this_thread.global_vars.user:
+        if self == docassemble.base.functions.this_thread.global_vars.user:
             output = word("you", **kwargs)
         elif hasattr(self, "pronouns") and self.pronouns:
             pronouns_to_use = []
@@ -2042,7 +2042,7 @@ class ALIndividual(Individual):
             if person == "2p":
                 return word("yourselves")
 
-        if self == this_thread.global_vars.user:
+        if self == docassemble.base.functions.this_thread.global_vars.user:
             output = word("yourself", **kwargs)
 
         if "default" in kwargs:
@@ -2058,7 +2058,7 @@ class ALIndividual(Individual):
         else:
             pronouns = None
 
-        if self == this_thread.global_vars.user:
+        if self == docassemble.base.functions.this_thread.global_vars.user:
             output = word("yourself", **kwargs)
         elif hasattr(self, "pronouns") and self.pronouns:
             pronouns_to_use = []


### PR DESCRIPTION
This PR fixes the import of `this_thread` to be from `docassemble.base.functions`. Docassemble v1.9.2 changed the handling of `this_thread` and instead of importing it into `docassemble.base.util`, now only references it by its full name, `docassemble.base.functions.this_thread`. This caused AssemblyLine's import of `this_thread` from `docassemble.base.util` to fail.

It might be worth considering a larger change to always directly reference `docassemble.base.functions.this_thread` like docassemble now does. Here is the relevant part of the commit,[ "changed way that this_thread is accessed to avoid any issues with it being redefined after being imported"](https://github.com/jhpyle/docassemble/commit/25240c65b3ff917481f08f122532fca31646b8b8).

Backwards compatibility note: `this_thread` has been defined in `docassemble.base.functions` for at least the past year, according to my quick search.