### PR TITLE
Run unit tests on pull requests from contributors

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -3,6 +3,8 @@ name: Run python only unit tests
 on:
   push:
   workflow_dispatch:
+  pull_request:
+    branches: [ main, master ]
 
 jobs:
   test-assemblyline:


### PR DESCRIPTION
The `push` workflow trigger only runs unit tests when it's the maintainers making PRs, and doesn't run when an outside contributor makes a PR to the project. We want it to run then too.