### PR TITLE
Resolve bug with logging multiple emails

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -41,10 +41,10 @@ code: |
     email_str = str(email_arg)
   if email_success:
     # Exact phrase below is in Docassemble's words dictionary
-    log(word("E-mail was sent to") + " " + action_argument("email"), "success")
+    log(f" {word('E-mail was sent to')} {email_str}", "success")
   else:
     # E-mail failed is not in the default Docassemble words dictionary
-    log(word("E-mail failed"), "error")
+    log(f" {word('E-mail failed')} to {email_str}", "error")
 ---
 generic object: ALDocumentBundle
 event: x.send_email_to_action_event
@@ -78,9 +78,9 @@ code: |
   else:
     email_str = str(email_arg)
   if email_success:
-    log("Email sent to " + action_argument("email"))  # to log file
+    log(f"Email sent to {email_str}")  # to log file
   else:
-    log(word("E-mail failed to ") + action_argument("email"))
+    log(f" {word('E-mail failed to ')} {email_str}")
 
   json_response({"success": email_success})
 ---


### PR DESCRIPTION
Fix #1000

On a screen with ALDocumentBundle.send_email(), entering multiple email addresses would send the message but when it was trying to log the sending, trigger an error screen.

Reproduced the bug and confirmed this fix on apps-dev.suffolklitlab.org

This resolves it by coercing the list to a string prior to logging.

@ekressmiller thanks for your clear error report and sorry it took this long to resolve!