### PR TITLE
Make send_button_html legend class configurable

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2385,6 +2385,7 @@ class ALDocumentBundle(DAList):
         label: str = "Send",
         icon: str = "envelope",
         preferred_formats: Optional[Union[str, List[str]]] = None,
+        email_legend_class: str = "h4",
     ) -> str:
         """
         Generate HTML for an input box and button that allows someone to send the bundle
@@ -2404,6 +2405,8 @@ class ALDocumentBundle(DAList):
             icon (str, optional): The Fontawesome icon for the button. Defaults
                 to "envelope".
             preferred_formats (Optional[Union[str,List[str]]], optional): A list of allowed formats for the document. Defaults to "pdf" if not specified.
+            email_legend_class (str, optional): CSS class applied to the email
+                section legend. Defaults to "h4".
 
         Returns:
             str: The generated HTML string for the input box and button.
@@ -2443,7 +2446,7 @@ class ALDocumentBundle(DAList):
         # Container of whole email section with header
         return_str = f"""
   <fieldset class="al_send_bundle al_send_section_alone {html_safe_str(self.instanceName)}" id="al_send_bundle_{name}" name="al_send_bundle_{name}">
-    <legend class="h4 al_doc_email_header">{str(self.get_email_copy)}</legend> 
+    <legend class="{email_legend_class} al_doc_email_header">{str(self.get_email_copy)}</legend> 
     """
         # "Editable" checkbox
         if (

--- a/docassemble/AssemblyLine/data/questions/test_aldocument.yml
+++ b/docassemble/AssemblyLine/data/questions/test_aldocument.yml
@@ -341,9 +341,9 @@ subquestion: |
 
   Send button which allows the user to edit the email address.
   
-  multi_bundle_1.send_button_html( key="test_key", show_editable_checkbox=False, label="Custom send label", icon="search" )
+  multi_bundle_1.send_button_html( key="test_key", show_editable_checkbox=False, label="Custom send label", icon="search", email_legend_class="h5" )
   
-  ${ multi_bundle_1.send_button_html( key="test_key", show_editable_checkbox=False, label="Custom send label", icon="search" ) }
+  ${ multi_bundle_1.send_button_html( key="test_key", show_editable_checkbox=False, label="Custom send label", icon="search", email_legend_class="h5" ) }
   
   ---
   single_pdf_bundle_1.send_button_html( key="test_key", show_editable_checkbox=False, label="Custom send label", icon="search" )


### PR DESCRIPTION
Fix #1017 

By default, we stick with using `class="h4"` which makes the heading visually match the look of an `h4` element.

This PR allows very simple customizations by removing/replacing the `h4` class.