### PR TITLE
Restore documented answer set import behavior which was broken accidentally

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -111,7 +111,7 @@ data from code:
     hidden: not get_config('assembly line',{}).get('enable answer sets')
   - url: |
       url_ask(["al_sessions_json_file", {"recompute": ["al_sessions_import_json"]}, "al_sessions_load_status"])
-    label: str(al_download_answer_set_string)
+    label: str(al_import_answer_set_string)
     hidden: |
       not (
         (
@@ -141,7 +141,7 @@ template: al_load_answer_set_string
 content: >-
   Load answer set
 ---
-template: al_download_answer_set_string
+template: al_import_answer_set_string
 content: >-
   Import answer set
 ---


### PR DESCRIPTION
09edd7d41e34490986aef9b498e406f4437be4b9 accidentally removed the menu item to allow answer set importing. This function needs more review, but it can be useful now on a development-only server when used by admins.

The commit looks a little funky because the old code had a few errors.

 1. Download current progress was not removed. It is still a separate menu item wired to the emergency document-
     download screen at al_visual.yml#L101, and that screen still renders the in-progress document downloads at
     al_visual.yml#L583.
  2. The latest commit changed the last menu item from a mislabeled Download answer set to a correctly labeled
     Import answer set. The new menu entry now points to the JSON upload flow at al_visual.yml#L113, and the label
     text was updated at al_visual.yml#L144. That upload screen is the JSON import screen at
     al_saved_sessions.yml#L232.
  3. Before this commit, that same menu item was already wrong: it said Download answer set but actually opened the
     emergency document download screen, not an answer-set export flow. So the latest change did not overwrite a
     working download screen; it fixed a long-standing miswire.
  4. There is still no dedicated main-menu Download answer set item. JSON export does exist, but it is exposed from
     the share flow at al_visual.yml#L292 and from the saved-answer-set detail screen at
     al_saved_sessions_store.yml#L41.

I consider this an experimental feature that should only be used by developers, and that's how we describe it everywhere in our documentation right now. The installer also does not turn this feature on by default. Server admins need to opt-in to it.

Therefore, restoring this should be low risk.

I'm working on a larger security plan to beef this feature's safety up.