### PR TITLE
Update unittest action to use main branch

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     name: Run python only unit tests
     steps:
-      - uses: SuffolkLITLab/ALActions/pythontests@add_bandid_13
+      - uses: SuffolkLITLab/ALActions/pythontests@main
       


### PR DESCRIPTION
Upstream has been merged now, and the branch referenced here has been deleted: https://github.com/SuffolkLITLab/ALActions/pull/69.