### PR TITLE
feat: update language setting code to prioritize session language when available

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_language.yml
+++ b/docassemble/AssemblyLine/data/questions/al_language.yml
@@ -40,6 +40,14 @@ code: |
 ---
 event: al_change_language
 code: |
+  # Set browser-specific language for this interview session
   if "lang" in action_arguments():
     session_local.al_user_language = action_argument("lang")
     set_language(session_local.al_user_language)
+---
+event: al_get_language_list_change_language
+code: |
+  # Set "global" language for this interview session instead of user-specific
+  if "lang" in action_arguments():
+    al_user_language = action_argument("lang")
+    set_language(al_user_language)

--- a/docassemble/AssemblyLine/language.py
+++ b/docassemble/AssemblyLine/language.py
@@ -173,7 +173,7 @@ def get_language_list(
     current="",
     lang_codes: Optional[List[str]] = None,
     languages_path: Optional[str] = None,
-    event_name="al_change_language",
+    event_name="al_get_language_list_change_language",
 ) -> str:
     """
     Given a list of language codes, returns


### PR DESCRIPTION
As discussed with @nonprofittechy , this commit (9c6a08cd2033d241818634e5a376c11507807049) checks the `session_local` special variable for a language value before checking the interview-wide `al_user_language`.

This commit (73d3eaecfb3bcfacba45deaaef8024aef0577a0e) updates the event that the language dropdown calls so that the user's chosen language is stored in the `session_local`.

These together allows individual users to have a language selection that is unique to their session and doesn't change the interview-wide `al_user_language`.

If an interview is sent via URL then that still changes the interview-wide `al_user_language`.