### PR TITLE
Switched to PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,49 @@
-name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI and announce to teams
+name: Publish Python distribution to PyPI
 
-on: push
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 jobs:
-  build-n-publish:
-    runs-on: ubuntu-24.04
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
     steps:
-    - uses: SuffolkLITLab/ALActions/publish@main
-      with:
-        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        VERSION_TO_PUBLISH: ${{ env.GITHUB_REF_NAME }}
-        TEAMS_BUMP_WEBHOOK: ${{ secrets.TEAMS_BUMP_WEBHOOK }}
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install build tool
+        run: python3 -m pip install --user build
+      - name: Build a binary wheel and source tarball
+        run: python3 -m build
+      - name: Store distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: Publish distribution to PyPI
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docassemble-assemblyline
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Replaces the old PYPI_API_TOKEN publishing with PyPI's trusted publishing. This removes the need to store API secrets and generates temporary tokens automatically for each publish run.