### PR TITLE
Correct filename when only one file in bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist/**
 # IDE related
 .vscode/**
 ~*
+.codex

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1108,6 +1108,7 @@ class ALDocument(DADict):
 
         if isinstance(main_doc, DAFileCollection):
             main_doc = main_doc.pdf
+        if isinstance(main_doc, DAFile):
             main_doc.title = self.title
             main_doc.filename = filename
             try:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1730,7 +1730,14 @@ class ALDocumentBundle(DAList):
                 pdfa=pdfa,
                 append_matching_suffix=append_matching_suffix,
             )
+            bundle_filename = f"{base_name(self.filename)}{append_suffix}.pdf"
             pdf.title = self.title
+            pdf.filename = bundle_filename
+            try:
+                pdf.set_attributes(filename=bundle_filename)
+                pdf.set_mimetype("application/pdf")
+            except:
+                pass
         else:
             pdf = pdf_concatenate(
                 [document.as_pdf(key=key, refresh=refresh) for document in files],

--- a/docassemble/AssemblyLine/test_al_document.py
+++ b/docassemble/AssemblyLine/test_al_document.py
@@ -35,6 +35,52 @@ class test_dont_assume_pdf(unittest.TestCase):
         pass
 
 
+class FakePdf:
+    def __init__(self, filename="file.pdf", title="child"):
+        self.filename = filename
+        self.title = title
+        self.attribute_filenames = []
+        self.mimetype = None
+
+    def set_attributes(self, **kwargs):
+        if "filename" in kwargs:
+            self.attribute_filenames.append(kwargs["filename"])
+
+    def set_mimetype(self, mimetype):
+        self.mimetype = mimetype
+
+
+class FakeSingleDoc:
+    def __init__(self, pdf):
+        self._pdf = pdf
+
+    def is_enabled(self, refresh=True):
+        return True
+
+    def as_pdf(self, **kwargs):
+        return self._pdf
+
+
+class TestSingleDocumentBundleFilename(unittest.TestCase):
+    def test_bundle_as_pdf_renames_single_document_to_bundle_filename(self):
+        child_pdf = FakePdf()
+        bundle = ALDocumentBundle(
+            "bundle",
+            elements=[FakeSingleDoc(child_pdf)],
+            title="Bundle title",
+            filename="bundle-output.pdf",
+            enabled=True,
+        )
+
+        result = bundle.as_pdf()
+
+        self.assertIs(result, child_pdf)
+        self.assertEqual(result.title, "Bundle title")
+        self.assertEqual(result.filename, "bundle-output.pdf")
+        self.assertEqual(result.attribute_filenames, ["bundle-output.pdf"])
+        self.assertEqual(result.mimetype, "application/pdf")
+
+
 class test_aladdendum(unittest.TestCase):
     def test_safe_value(self):
         text_testcase1 = """Charged by my father with a very delicate mission, I repaired, towards the end of May, 1788, to the château of Ionis, situated a dozen leagues distant, in the lands lying between Angers and Saumur. I was twenty-two, and already practising the profession of lawyer, for which I experienced but slight inclination, although neither the study of business nor of argument had presented serious difficulties to me. Taking my youth into consideration, I was not esteemed without talent, and the standing of my father, a lawyer renowned in the locality, assured me a brilliant patronage in the future, in return for any paltry efforts I might make to be worthy of replacing him. But I would have preferred literature, a more dreamy life, a more independent and more individual use of my faculties, a responsibility less submissive to the passions and interests of others. As my family was well off, and I an only son, greatly spoiled and petted, I might have chosen my own career, but I would have thus afflicted my father, who took pride in his ability to direct me 4in the road which he had cleared in advance, and I loved him too tenderly to permit my instinct to outweigh his wishes.

--- a/docassemble/AssemblyLine/test_al_document.py
+++ b/docassemble/AssemblyLine/test_al_document.py
@@ -35,8 +35,10 @@ class test_dont_assume_pdf(unittest.TestCase):
         pass
 
 
-class FakePdf:
+class FakePdf(DAFile):
     def __init__(self, filename="file.pdf", title="child"):
+        self.instanceName = "fake_pdf"
+        self.has_nonrandom_instance_name = True
         self.filename = filename
         self.title = title
         self.attribute_filenames = []
@@ -78,6 +80,27 @@ class TestSingleDocumentBundleFilename(unittest.TestCase):
         self.assertEqual(result.title, "Bundle title")
         self.assertEqual(result.filename, "bundle-output.pdf")
         self.assertEqual(result.attribute_filenames, ["bundle-output.pdf"])
+        self.assertEqual(result.mimetype, "application/pdf")
+
+
+class TestSingleDocumentFilename(unittest.TestCase):
+    def test_document_as_pdf_renames_plain_dafile_to_document_filename(self):
+        child_pdf = FakePdf()
+        doc = ALDocument(
+            "doc",
+            title="Document title",
+            filename="document-output.pdf",
+            enabled=True,
+            has_addendum=False,
+        )
+        doc["final"] = child_pdf
+
+        result = doc.as_pdf(refresh=False)
+
+        self.assertIs(result, child_pdf)
+        self.assertEqual(result.title, "Document title")
+        self.assertEqual(result.filename, "document-output.pdf")
+        self.assertEqual(result.attribute_filenames, ["document-output.pdf"])
         self.assertEqual(result.mimetype, "application/pdf")
 
 


### PR DESCRIPTION
fix #1036, fix #1035

Explicitly sets filename in more circumstances. This fixes filename issue with https://github.com/mplp/docassemble-MLHDivorceAndCustody in interactive end to end test; before upgrade, can reproduce file.pdf behavior. after switching to this branch, file is correctly named.