### PR TITLE
Add test that imports all other python modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ docassemble.AssemblyLine.egg-info/*
 **/.mypy_cache/**
 dist/**
 .venv/**
+uv.lock
 
 # IDE related
 .vscode/**

--- a/docassemble/AssemblyLine/test_all_imports.py
+++ b/docassemble/AssemblyLine/test_all_imports.py
@@ -1,0 +1,12 @@
+# Makes sure that loading each module file works.
+# Includes all imports not covered by other test files.
+
+from .al_courts import *
+from .custom_jinja_filters import *
+from .language import *
+from .sign import *
+
+try:
+    from .sessions import *
+except SystemExit as ex:
+    print(f"Ignoring SystemExit error (expected from config.py: {ex})")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,14 +65,13 @@ ignore_missing_imports = true
 
 [dependency-groups]
 dev = [
-    "docassemble.base>=1.3",
-    "docassemble.webapp",
-    "pytest",
+    "docassemble.base>=1.7",
+    "docassemble.webapp>=1.7",
+    "pytest>=7.0",
     "mypy",
     "pandas-stubs",
-    "sqlalchemy[mypy]",
+    "sqlalchemy[mypy]>=1.3.0",
     "types-PyYAML",
-    "PyGithub",
     "types-requests",
     "types-psycopg2",
 ]


### PR DESCRIPTION
Does have to ignore SystemExit exceptions that happen because `config.py` always tries to load, even if it's not running in the docker image.

Have also been running a release testing strategy that checks the highest and lowest version of the dependencies, had to put some lower bounds on the dependencies for it to work correctly.