### PR TITLE
Fix #1036

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1755,6 +1755,7 @@ class ALDocumentBundle(DAList):
                 font_size=self.page_number_font_size,
                 offset_horizontal=self.page_number_offset_horizontal,
                 offset_vertical=self.page_number_offset_vertical,
+                filename=pdf.filename,
             )
         pdf.title = self.title
         setattr(self.cache, safe_key, pdf)


### PR DESCRIPTION
When ALDocumentBundles were nested and used bates numbering, the filename would always end up as "file.pdf". This is because docassemble doesn't use a normal default for the file name in bates number. Directly passing the correct filename to the function fixes this.

Tested manually on the MLH Divorce and Custody interview: https://github.com/mplp/docassemble-MLHDivorceAndCustody/blob/main/docassemble/MLHDivorceAndCustody/data/questions/main_judgment_of_divorce.yml. 