### PR TITLE
Remove hardcoded CourtFormsOnline fallback; use proper global config appname, not app name

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -89,7 +89,7 @@ code: |
   # Used in the email subject line when email is triggered on download screen.
   # This defaults to the interview title. For example, if the
   # interview title is "Guardianship Helper", the email
-  # subject would be "Your Guardianship Helper document from CourtFormsOnline is ready".
+  # subject would be "Your Guardianship Helper document from docassemble is ready".
   # Customize this if you prefer something like "Your guardianship document is ready"
   x.document_label = str(
     all_variables(special="titles").get(

--- a/docassemble/AssemblyLine/data/questions/al_settings.yml
+++ b/docassemble/AssemblyLine/data/questions/al_settings.yml
@@ -7,13 +7,13 @@ code: |
   # Set this to the name of your application
   # Defaults to checking for a possible name from global docassemble config
   al_app_name = get_config(
-    "appname", get_config("external hostname", "CourtFormsOnline.org")
+    "appname", get_config("external hostname", "docassemble")
   )
 ---
 code: |
   # The name of your organization. Defaults to a similar value as `al_app_name`,
   # but is still distinct
-  AL_ORGANIZATION_TITLE = get_config("appname", "CourtFormsOnline")
+  AL_ORGANIZATION_TITLE = get_config("appname", "docassemble")
 ---
 code: |
   AL_ORGANIZATION_HOMEPAGE = get_config("app homepage", "https://courtformsonline.org")

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -158,7 +158,7 @@ default screen parts:
     % elif showifdef("AL_ORGANIZATION_TITLE"):
     ${ AL_ORGANIZATION_TITLE }
     % else:
-    ${ get_config("app name", "CourtFormsOnline") }
+    ${ get_config("appname", "docassemble") }
     % endif
   short title: |
     % if PAGE_TITLE:
@@ -166,7 +166,7 @@ default screen parts:
     % elif showifdef("AL_ORGANIZATION_TITLE"):
     ${ AL_ORGANIZATION_TITLE }
     % else:
-    ${ get_config("app name", "CourtFormsOnline") }
+    ${ get_config("appname", "docassemble") }
     % endif
   title url: |
     % if LOGO_URL:
@@ -197,7 +197,7 @@ default screen parts:
     % elif showifdef("AL_ORGANIZATION_TITLE"):
         <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>    
     % else:
-        <span class="title-row-1">${ get_config("app name", "CourtFormsOnline") }</span>    
+        <span class="title-row-1">${ get_config("appname", "docassemble") }</span>    
     % endif
     % if LOGO_TITLE_ROW_2:
         <span class="title-row-2">${ LOGO_TITLE_ROW_2 }</span>
@@ -223,7 +223,7 @@ default screen parts:
     % elif showifdef("AL_ORGANIZATION_TITLE"):
         <span class="title-row-1">${ AL_ORGANIZATION_TITLE }</span>    
     % else:
-        <span class="title-row-1">${ get_config("app name", "CourtFormsOnline") }</span>    
+        <span class="title-row-1">${ get_config("appname", "docassemble") }</span>    
     % endif
     % if LOGO_TITLE_ROW_2:
         <span class="title-row-2">${ LOGO_TITLE_ROW_2 }</span>


### PR DESCRIPTION
We've kind of been polluting the brand "CourtFormsOnline" in the interview list on servers that aren't part of CourtFormsOnline because of two issues:

1) We're not using the `appname` config--we had a typo `app name` which isn't normally defined in a Docassemble config
2) The default when `appname` isn't defined was CourtFormsOnline. There's no good reason for that--we have 100% control over the servers where we want the interview list title to be CourtFormsOnline.

This PR just corrects the typo and removes the default CourtFormsOnline language, which is really a specific brand name for apps.suffolklitlab.org only.