### PR TITLE
Add visually hidden document labels to buttons for accessibility

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2224,7 +2224,7 @@ class ALDocumentBundle(DAList):
                 download_doc.url_for(
                     attachment=True, display_filename=download_filename
                 ),
-                label=download_label,
+                label=f'{download_label} <span class="visually-hidden">{title}</span>',
                 icon=download_icon,
                 color="primary",
                 size="md",
@@ -2239,7 +2239,7 @@ class ALDocumentBundle(DAList):
                     result["pdf"].url_for(
                         attachment=False, display_filename=view_filename
                     ),
-                    label=view_label,
+                    label=f'{view_label} <span class="visually-hidden">{title}</span>',
                     icon=view_icon,
                     color="secondary",
                     size="md",

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2503,7 +2503,7 @@ class ALDocumentBundle(DAList):
         key: str = "final",
         show_editable_checkbox: bool = True,
         template_name: str = "",
-        label: str = "Send",
+        label: Optional[str] = None,
         icon: str = "envelope",
         preferred_formats: Optional[Union[str, List[str]]] = None,
         email_legend_class: str = "h4",
@@ -2532,6 +2532,9 @@ class ALDocumentBundle(DAList):
         Returns:
             str: The generated HTML string for the input box and button.
         """
+        if label is None:
+            label = str(self.send_label) or word("Send")
+
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents
 

--- a/docassemble/AssemblyLine/data/questions/al_document.yml
+++ b/docassemble/AssemblyLine/data/questions/al_document.yml
@@ -123,12 +123,12 @@ content: |
 generic object: ALDocumentBundle
 template: x.zip_label
 content: |
-  Download all
+  Download all <span class="visually-hidden">${ x.title }</span> documents
 ---
 generic object: ALDocumentBundle
 template: x.full_pdf_label
 content: |
-  Download as one PDF
+  Download <span class="visually-hidden">${ x.title }</span> as one PDF
 ---
 id: al exhibit ocr pages bg
 event: al_exhibit_ocr_pages

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2668,8 +2668,10 @@ content: "Download"
 ---
 generic object: ALDocumentBundle
 template: x.send_label
-content: "Send"
+content: |
+  Send <span class="visually-hidden">${ x.title } documents</span>
 ---
 generic object: ALDocumentBundle
 template: x.send_button_to_label
-content: "Send"
+content: |
+  Send <span class="visually-hidden">${ x.title } documents</span>


### PR DESCRIPTION
Style is unchanged, but this allows screen reader users to be able to tell what button they are interacting with. Tested with Narrator and NVDA in Windows; this seems like a good fix.

Can revisit/discuss including full document text in visible label with more of our user base, but this should be compatible for now.

Fix #1054

Note: we should also update translations to match as this involves some Docassemble template edits, not just in the Python code.

I tested with the test_aldocument.yml file.

Edit: 94a5e35 moves the default text for send_button_html() to the right place; also has side effect of making this more consistently translatable (must have been missed in a prior change)