### PR TITLE
Make 'Email' input translatable

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1602,6 +1602,9 @@ class ALDocumentBundle(DAList):
         email_input_label (DALazyTemplate): Template providing the label for the email input
             field in :meth:`send_button_html`. Defined generically in
             `ql_baseline.yml`; resolves to `"Email"` (or its translation).
+        email_alt_text (DALazyTemplate): Template providing the alt text for the email input
+            field. Defined generically in `ql_baseline.yml`; resolves to
+            `"Email address for document"` (or its translation).
         include_editable_documents (DALazyTemplate): Template providing the label for the.
             "include editable copy" checkbox in :meth:`send_button_html`. Defined generically.
             in `al_document.yml`; resolves to `"Include an editable copy"`
@@ -2415,7 +2418,7 @@ class ALDocumentBundle(DAList):
         input_html = f"""
         <span class="al_email_input_container {name} form-group da-field-container da-field-container-datatype-email">
           <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
-          <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control al_doc_email_field al_button" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+          <input value="{user_info().email if user_logged_in() else ''}" alt="{str(self.email_alt_text)}" class="form-control al_doc_email_field al_button" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
         </span>
         """
 
@@ -2602,7 +2605,7 @@ class ALDocumentBundle(DAList):
   
     <span class="al_email_address {html_safe_str(self.instanceName)} container form-group row da-field-container da-field-container-datatype-email">
       <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">{email_label}</label>
-      <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
+      <input value="{user_info().email if user_logged_in() else ''}" alt="{str(self.email_alt_text)}" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
     </span>
     
     {action_button_html(javascript_string, label=label, icon=icon, color="primary", size="md", classname="al_send_email_button", id_tag=al_send_button_id)}

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2539,7 +2539,7 @@ class ALDocumentBundle(DAList):
         """
         if label is None:
             label = str(self.send_label) or word("Send")
-            
+
         if email_label is None:
             email_label = str(self.email_input_label) or word("Email")
 

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1599,6 +1599,9 @@ class ALDocumentBundle(DAList):
             section rendered by :meth:`send_button_html`. Defined generically in
             `al_document.yml`; resolves to `"Get a copy of the documents in email"`
             (or its translation).
+        email_input_label (DALazyTemplate): Template providing the label for the email input
+            field in :meth:`send_button_html`. Defined generically in
+            `ql_baseline.yml`; resolves to `"Email"` (or its translation).
         include_editable_documents (DALazyTemplate): Template providing the label for the
             "include editable copy" checkbox in :meth:`send_button_html`. Defined generically
             in `al_document.yml`; resolves to `"Include an editable copy"`
@@ -2507,6 +2510,7 @@ class ALDocumentBundle(DAList):
         icon: str = "envelope",
         preferred_formats: Optional[Union[str, List[str]]] = None,
         email_legend_class: str = "h4",
+        email_label: Optional[str] = None,
     ) -> str:
         """
         Generate HTML for an input box and button that allows someone to send the bundle
@@ -2528,12 +2532,16 @@ class ALDocumentBundle(DAList):
             preferred_formats (Optional[Union[str,List[str]]], optional): A list of allowed formats for the document. Defaults to "pdf" if not specified.
             email_legend_class (str, optional): CSS class applied to the email
                 section legend. Defaults to "h4".
+            email_label (str, optional): The label for the email input. Defaults to "Email".
 
         Returns:
             str: The generated HTML string for the input box and button.
         """
         if label is None:
             label = str(self.send_label) or word("Send")
+            
+        if email_label is None:
+            email_label = str(self.email_input_label) or word("Email")
 
         if not self.has_enabled_documents():
             return ""  # Don't let people email an empty set of documents
@@ -2593,7 +2601,7 @@ class ALDocumentBundle(DAList):
   <div class="al_email_container">
   
     <span class="al_email_address {html_safe_str(self.instanceName)} container form-group row da-field-container da-field-container-datatype-email">
-      <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">Email</label>
+      <label for="{al_email_input_id}" class="col-form-label da-form-label datext-right">{email_label}</label>
       <input value="{user_info().email if user_logged_in() else ''}" alt="Email address for document" class="form-control" type="email" size="35" name="{al_email_input_id}" id="{al_email_input_id}">
     </span>
     

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2679,3 +2679,11 @@ content: |
 generic object: ALDocumentBundle
 template: x.email_input_label
 content: "Email"
+---
+generic object: ALDocumentBundle
+template: x.email_alt_text
+content: "Email address for document"
+---
+generic object: ALDocument
+template: x.email_alt_text
+content: "Email address for document"

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2675,3 +2675,7 @@ generic object: ALDocumentBundle
 template: x.send_button_to_label
 content: |
   Send <span class="visually-hidden">${ x.title } documents</span>
+---
+generic object: ALDocumentBundle
+template: x.email_input_label
+content: "Email"


### PR DESCRIPTION
This is a string we had overlooked from translatability (discovered by Matt)