### PR TITLE
Future proof docsig rules

### DIFF
--- a/docassemble/AssemblyLine/al_courts.py
+++ b/docassemble/AssemblyLine/al_courts.py
@@ -34,8 +34,8 @@ class ALCourt(Court):
         """Create a new court object.
 
         Args:
-            *pargs: Standard DAObject positional arguments
-            **kwargs: Standard DAObject keyword arguments
+            *pargs: Standard DAObject positional arguments.
+            **kwargs: Standard DAObject keyword arguments.
         """
         super().init(*pargs, **kwargs)
         if "address" not in kwargs:
@@ -58,11 +58,11 @@ class ALCourt(Court):
 
         Returns:
             List[Dict[str, Any]] - a list of dictionaries, each of which contains
-                the following keys:
-                    - latitude: float
-                    - longitude: float
-                    - info: str
-                    - icon: str (optional)
+                the following keys:.
+                    - latitude: float.
+                    - longitude: float.
+                    - info: str.
+                    - icon: str (optional).
         """
         the_info = str(self.name)
         the_info += "  [NEWLINE]  " + self.address.block()
@@ -83,7 +83,7 @@ class ALCourt(Court):
         list.
 
         Returns:
-            str: string representing the court's name, with city if needed to disambiguate
+            str: string representing the court's name, with city if needed to disambiguate.
         """
         # Avoid forcing the interview to define the court's address
         if hasattr(self, "address") and hasattr(self.address, "city"):
@@ -99,7 +99,7 @@ class ALCourt(Court):
         More concise version without description; suitable for a responsive case.
 
         Returns:
-            str: string representing the court's name and address
+            str: string representing the court's name and address.
         """
         return f"**{ self.short_label() }**[BR]{ self.address.on_one_line() }"
 
@@ -110,7 +110,7 @@ class ALCourt(Court):
         buttons.
 
         Returns:
-            str: string representing the court's name and description
+            str: string representing the court's name and description.
         """
         all_info = f"**{ self.short_label() }**"
         if hasattr(self, "address"):
@@ -127,8 +127,8 @@ class ALCourt(Court):
         with existing attributes or methods of DAObject
 
         Args:
-            df_row: Pandas Series object
-            ensure_lat_long: bool, whether to use Google Maps to geocode the address if we don't have coordinates
+            df_row: Pandas Series object.
+            ensure_lat_long: bool, whether to use Google Maps to geocode the address if we don't have coordinates.
         """
         # A few columns we expect to see:
         # name
@@ -219,8 +219,8 @@ class ALCourtLoader(DAObject):
         """Create a new courtloader object.
 
         Args:
-            *pargs: Standard DAObject positional arguments
-            **kwargs: Standard DAObject keyword arguments
+            *pargs: Standard DAObject positional arguments.
+            **kwargs: Standard DAObject keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.package = docassemble.base.functions.this_thread.current_question.package
@@ -253,7 +253,7 @@ class ALCourtLoader(DAObject):
             column_name (str): The name of the column in the dataframe.
 
         Returns:
-            Set[str]:
+            Set[str]:.
                 - A set containing unique values from the specified column.
                 - Returns an empty set if the column does not exist or an error occurs.
         """
@@ -272,7 +272,7 @@ class ALCourtLoader(DAObject):
             column_name (str): The name of the column in the dataframe.
 
         Returns:
-            Set[str]: A list of all unique values in the specified row in the given spreadsheet
+            Set[str]: A list of all unique values in the specified row in the given spreadsheet.
         """
         return self.unique_column_values(column_name)
 
@@ -341,7 +341,7 @@ class ALCourtLoader(DAObject):
             county_column (str, optional): Column heading which contains county name. Defaults to "address_county".
             display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
             search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
-            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with.
                 the search_string in a case-insensitive manner. Defaults to None.
 
         Returns:
@@ -370,12 +370,12 @@ class ALCourtLoader(DAObject):
         is determined by the `display_column`.
 
         Args:
-            court_types (Optional[Union[List[str], str]]): Exact string match or matches used to filter results
+            court_types (Optional[Union[List[str], str]]): Exact string match or matches used to filter results.
                 (inclusive). Examples include "District" or ["Municipal","Superior"].
             column (str, optional): Column heading to search. Defaults to "department".
             display_column (str, optional): Column heading used for display in the drop-down. Defaults to "name".
             search_string (Optional[str], optional): A keyword to filter the list of results. Defaults to None.
-            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with
+            search_columns (Optional[Union[List[str], str]], optional): Columns to aggregate and search across with.
                 the search_string in a case-insensitive manner. Defaults to None.
 
         Returns:

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -208,10 +208,10 @@ def pdf_page_parity(pdf_path: str) -> Literal["even", "odd"]:
     if it is not divisible by 2.
 
     Args:
-        pdf_path (str): Path to the PDF in the filesystem
+        pdf_path (str): Path to the PDF in the filesystem.
 
     Returns:
-        Literal["even", "odd"]: The parity of the number of pages in the PDF
+        Literal["even", "odd"]: The parity of the number of pages in the PDF.
     """
     with pikepdf.open(pdf_path) as pdf:
         num_pages = len(pdf.pages)
@@ -225,7 +225,7 @@ def add_blank_page(pdf_path: str) -> None:
     Add a blank page to the end of a PDF.
 
     Args:
-        pdf_path (str): Path to the PDF in the filesystem
+        pdf_path (str): Path to the PDF in the filesystem.
     """
     # Load the PDF
     with pikepdf.open(pdf_path, allow_overwriting_input=True) as pdf:
@@ -254,7 +254,7 @@ class ALAddendumField(DAObject):
 
     Attributes:
         field_name (str): The name of a docassemble variable that this object represents.
-        overflow_trigger (Union[int, bool]): Specifies the limit after which the text is truncated and moved
+        overflow_trigger (Union[int, bool]): Specifies the limit after which the text is truncated and moved.
             to an addendum. If set to `True`, it will always overflow. If set to `False`, it will never overflow.
             An integer value represents the maximum character count before overflow.
 
@@ -271,8 +271,8 @@ class ALAddendumField(DAObject):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
 
@@ -398,10 +398,10 @@ class ALAddendumField(DAObject):
             preserve_newlines (bool): Determines whether newlines are preserved in the "safe" text.
                 Defaults to False, which means all newlines are removed. This allows more text to appear
                 before being sent to the addendum.
-            _original_value (Any): for speed reasons, you can provide the full text and just use this
+            _original_value (Any): for speed reasons, you can provide the full text and just use this.
                 method to determine if the overflow trigger is exceeded. If no _original_value is
                 provided, this method will determine it using the value_if_defined() method.
-            preserve_words (bool): If True, the algorithm will try to preserve whole words when
+            preserve_words (bool): If True, the algorithm will try to preserve whole words when.
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
 
@@ -446,15 +446,15 @@ class ALAddendumField(DAObject):
             preserve_newlines (bool): Determines whether newlines are preserved in the "safe" text.
                 Defaults to False, which means all newlines are removed. This allows more text to appear
                 before being sent to the addendum.
-            _original_value (Any): for speed reasons, you can provide the full text and just use this
+            _original_value (Any): for speed reasons, you can provide the full text and just use this.
                 method to determine if the overflow trigger is exceeded. If no _original_value is
                 provided, this method will determine it using the value_if_defined() method.
-            preserve_words (bool): If True, the algorithm will try to preserve whole words when
+            preserve_words (bool): If True, the algorithm will try to preserve whole words when.
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
 
         Returns:
-            Union[str, List[Any]]: Either a string representing the overflow message or the original value
+            Union[str, List[Any]]: Either a string representing the overflow message or the original value.
         """
         if _original_value:
             val = _original_value
@@ -501,7 +501,7 @@ class ALAddendumField(DAObject):
             preserve_newlines (bool): Determines whether newlines are preserved in the "safe" text.
                 Defaults to False, which means all newlines are removed. This allows more text to appear
                 before being sent to the addendum.
-            _original_value (Optional[str]): For speed reasons, you can provide the full text and just use this
+            _original_value (Optional[str]): For speed reasons, you can provide the full text and just use this.
                 method to determine if the overflow trigger is exceeded. If no `_original_value` is
                 provided, this method will determine it using the `value_if_defined()` method.
             preserve_words (bool): Indicates whether words should be preserved in their entirety without being split.
@@ -784,7 +784,7 @@ class ALAddendumFieldDict(DAOrderedDict):
     Adding a new entry will implicitly set the `field_name` attribute of the field
 
     Attributes:
-        style (str): Determines the display behavior. If set to "overflow_only",
+        style (str): Determines the display behavior. If set to "overflow_only",.
                      only the overflow text will be displayed.
     """
 
@@ -792,8 +792,8 @@ class ALAddendumFieldDict(DAOrderedDict):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super(ALAddendumFieldDict, self).init(*pargs, **kwargs)
         self.object_type = ALAddendumField
@@ -812,9 +812,9 @@ class ALAddendumFieldDict(DAOrderedDict):
         its own field name by setting the `field_name` attribute.
 
         Args:
-            *pargs: List of arguments to use to create the dict entry. The 0th arg is
+            *pargs: List of arguments to use to create the dict entry. The 0th arg is.
                 also used to set the `field_name` attribute.
-            **kwargs: List of keyword arguments used to create the dict entry
+            **kwargs: List of keyword arguments used to create the dict entry.
 
         Returns:
           The new dictionary entry created
@@ -829,7 +829,7 @@ class ALAddendumFieldDict(DAOrderedDict):
         Populate the dictionary using a list of field data.
 
         Args:
-            data (list): List of dictionaries containing ield data with keys "field_name"
+            data (list): List of dictionaries containing ield data with keys "field_name".
                 and "overflow_trigger".
         """
         for entry in data:
@@ -843,7 +843,7 @@ class ALAddendumFieldDict(DAOrderedDict):
         Fetch a list of fields that are defined.
 
         Args:
-            style (str, optional): If set to "overflow_only", only the fields with overflow values
+            style (str, optional): If set to "overflow_only", only the fields with overflow values.
                 will be returned. Defaults to "overflow_only".
 
         Returns:
@@ -937,20 +937,20 @@ class ALDocument(DADict):
     on the final download screen.
 
     Attributes:
-        filename (str): name used for output PDF
-        title (str): display name for the output PDF
+        filename (str): name used for output PDF.
+        title (str): display name for the output PDF.
         enabled (bool): if this document should be created. See examples.
-        addendum (DAFile | DAFileCollection): (optional) an attachment block
-        overflow_fields (ALAddendumField): (optional) ALAddendumFieldDict
+        addendum (DAFile | DAFileCollection): (optional) an attachment block.
+        overflow_fields (ALAddendumField): (optional) ALAddendumFieldDict.
           instance. These values will be used to detect and handle overflow.
-        has_addendum (bool): (optional) Defaults to False. Set to True if the
+        has_addendum (bool): (optional) Defaults to False. Set to True if the.
           document could have overflow, like for a PDF template.
-        default_overflow_message (str): The message appended to truncated text when it overflows
+        default_overflow_message (str): The message appended to truncated text when it overflows.
           to the addendum. Defaults to `"..."`. This is used as the fallback whenever
-          `overflow_message=None` is passed to :meth:`safe_value`,
+          `overflow_message=None` is passed to :meth:`safe_value`,.
           :meth:`overflow_value`, or :meth:`original_or_overflow_message`.
           Override per-document by setting `my_doc.default_overflow_message`.
-        suffix_to_append (str): When the document key matches this value, it is appended to
+        suffix_to_append (str): When the document key matches this value, it is appended to.
           the output filename to distinguish it from other versions. Defaults to `"preview"`
           so the preview version is saved as e.g. `myDoc_preview.pdf` while the final
           version is saved as `myDoc.pdf`.
@@ -1045,8 +1045,8 @@ class ALDocument(DADict):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super(ALDocument, self).init(*pargs, **kwargs)
         self.initializeAttribute("overflow_fields", ALAddendumFieldDict)
@@ -1270,10 +1270,10 @@ class ALDocument(DADict):
             preserve_newlines (bool): Determines whether newlines are preserved in the "safe" text.
                 Defaults to False, which means all newlines are removed. This allows more text to appear
                 before being sent to the addendum.
-            _original_value (Any): for speed reasons, you can provide the full text and just use this
+            _original_value (Any): for speed reasons, you can provide the full text and just use this.
                 method to determine if the overflow trigger is exceeded. If no _original_value is
                 provided, this method will determine it using the value_if_defined() method.
-            preserve_words (bool): If True, the algorithm will try to preserve whole words when
+            preserve_words (bool): If True, the algorithm will try to preserve whole words when.
                 truncating the text. If False, the algorithm will truncate the text at the overflow
                 trigger, regardless of whether it is in the middle of a word.
 
@@ -1336,7 +1336,7 @@ class ALDocument(DADict):
 
         Args:
             field_name (str): The name of the field to retrieve the overflow value from.
-            overflow_message (Optional[str]): Message appended when the safe portion of the field
+            overflow_message (Optional[str]): Message appended when the safe portion of the field.
                 value is truncated. If `None`, falls back to `self.default_overflow_message`
                 (`"..."` by default).
             preserve_newlines (bool): Whether to maintain newlines in the output. Defaults to False.
@@ -1413,8 +1413,8 @@ class ALStaticDocument(DAStaticFile):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -1525,7 +1525,7 @@ class ALStaticDocument(DAStaticFile):
         This method provides a workaround for problems generating thumbnails.
 
         Args:
-            **kwargs: Args to pass to DAFile's show function
+            **kwargs: Args to pass to DAFile's show function.
 
         Returns:
             DAFile: Displayable version of the document.
@@ -1538,7 +1538,7 @@ class ALStaticDocument(DAStaticFile):
         """Check if the document is enabled.
 
         Args:
-            **kwargs: Unused (for signature compatibility only)
+            **kwargs: Unused (for signature compatibility only).
 
         Returns:
             bool: True if the document is enabled, otherwise False.
@@ -1565,60 +1565,60 @@ class ALDocumentBundle(DAList):
         auto_gather (bool, optional): Automatically gathers attributes. Defaults to False.
         gathered (bool, optional): Specifies if attributes have been gathered. Defaults to True.
         default_parity (Optional[Literal["even", "odd"]]): Default parity to enforce on the PDF.
-            When set, :meth:`as_pdf` will append a blank page if necessary to reach the desired
+            When set, :meth:`as_pdf` will append a blank page if necessary to reach the desired.
             parity. Defaults to `None` (no enforcement).
-        suffix_to_append (str): When the document key matches this value, it is appended to the
+        suffix_to_append (str): When the document key matches this value, it is appended to the.
             output filename to distinguish it from other versions. Defaults to `"preview"`
             so the preview bundle is saved as e.g. `bundle_preview.pdf` while the final is
             saved as `bundle.pdf`.
-        view_label (DALazyTemplate): Template providing the label for "View" buttons in
-            :meth:`download_list_html`. Defined generically in `ql_baseline.yml`; resolves to
+        view_label (DALazyTemplate): Template providing the label for "View" buttons in.
+            :meth:`download_list_html`. Defined generically in `ql_baseline.yml`; resolves to.
             `"View"` (or its translation). Override by assigning a new template to
             `your_bundle.view_label` in your interview YAML.
-        download_label (DALazyTemplate): Template providing the label for "Download" buttons in
-            :meth:`download_list_html`. Defined generically in `ql_baseline.yml`; resolves to
+        download_label (DALazyTemplate): Template providing the label for "Download" buttons in.
+            :meth:`download_list_html`. Defined generically in `ql_baseline.yml`; resolves to.
             `"Download"` (or its translation).
-        send_label (DALazyTemplate): Template providing the label for "Send" buttons in
-            :meth:`download_list_html`, :meth:`send_email_table_row`, and
-            :meth:`send_button_to_html`. Defined generically in `ql_baseline.yml`; resolves to
+        send_label (DALazyTemplate): Template providing the label for "Send" buttons in.
+            :meth:`download_list_html`, :meth:`send_email_table_row`, and.
+            :meth:`send_button_to_html`. Defined generically in `ql_baseline.yml`; resolves to.
             `"Send"` (or its translation).
-        zip_label (DALazyTemplate): Template providing the label for the "Download all" zip
-            button in :meth:`download_list_html`. Defined generically in `al_document.yml`;
+        zip_label (DALazyTemplate): Template providing the label for the "Download all" zip.
+            button in :meth:`download_list_html`. Defined generically in `al_document.yml`;.
             resolves to `"Download all"` (or its translation).
-        full_pdf_label (DALazyTemplate): Template providing the label for the "Download as one
-            PDF" button in :meth:`download_list_html`. Defined generically in
+        full_pdf_label (DALazyTemplate): Template providing the label for the "Download as one.
+            PDF" button in :meth:`download_list_html`. Defined generically in.
             `al_document.yml`; resolves to `"Download as one PDF"` (or its translation).
-        send_email_template (DALazyTemplate): Template used as the default email subject and
-            body in :meth:`send_email` when `template=None`. Defined generically in
+        send_email_template (DALazyTemplate): Template used as the default email subject and.
+            body in :meth:`send_email` when `template=None`. Defined generically in.
             `al_document.yml`. The subject defaults to
             `"Your <document> document from <app> is ready"` and the body to
             `"Your document is attached. Visit <homepage> to learn more."`
             Override by assigning a new template block to `your_bundle.send_email_template`
             in your interview YAML.
-        get_email_copy (DALazyTemplate): Template providing the header text for the email input
-            section rendered by :meth:`send_button_html`. Defined generically in
+        get_email_copy (DALazyTemplate): Template providing the header text for the email input.
+            section rendered by :meth:`send_button_html`. Defined generically in.
             `al_document.yml`; resolves to `"Get a copy of the documents in email"`
             (or its translation).
-        include_editable_documents (DALazyTemplate): Template providing the label for the
-            "include editable copy" checkbox in :meth:`send_button_html`. Defined generically
+        include_editable_documents (DALazyTemplate): Template providing the label for the.
+            "include editable copy" checkbox in :meth:`send_button_html`. Defined generically.
             in `al_document.yml`; resolves to `"Include an editable copy"`
             (or its translation).
-        add_page_numbers (bool): If `True`, Bates-style page numbers are stamped onto the
+        add_page_numbers (bool): If `True`, Bates-style page numbers are stamped onto the.
             merged PDF produced by :meth:`as_pdf`. Defaults to `False`.
         page_number_prefix (str): Text prepended to each stamped page number (e.g. `"EX-"`).
             Defaults to `""`.
         page_number_start (int): The first page number used when stamping page numbers.
             Defaults to `1`.
-        page_number_digits (int): Minimum number of digits in each stamped page number;
+        page_number_digits (int): Minimum number of digits in each stamped page number;.
             shorter numbers are left-padded with zeros. Defaults to `5`.
         page_number_area (Optional[str]): Location on the page where numbers are stamped.
-            Accepted values: `"TOP_LEFT"`, `"TOP_RIGHT"`, `"BOTTOM_LEFT"`,
+            Accepted values: `"TOP_LEFT"`, `"TOP_RIGHT"`, `"BOTTOM_LEFT"`,.
             `"BOTTOM_RIGHT"`. Defaults to `None` (bottom-right).
         page_number_font_size (float): Font size in points for stamped page numbers.
             Defaults to `10`.
-        page_number_offset_horizontal (float): Horizontal inset in pixels from the nearest
+        page_number_offset_horizontal (float): Horizontal inset in pixels from the nearest.
             page edge for stamped page numbers. Defaults to `15`.
-        page_number_offset_vertical (float): Vertical inset in pixels from the nearest page
+        page_number_offset_vertical (float): Vertical inset in pixels from the nearest page.
             edge for stamped page numbers. Defaults to `15`.
 
     Examples:
@@ -1644,8 +1644,8 @@ class ALDocumentBundle(DAList):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         if "auto_gather" not in kwargs:
@@ -1696,7 +1696,7 @@ class ALDocumentBundle(DAList):
             pdfa (bool): If True, generates a PDF/A compliant document, defaults to False.
             append_matching_suffix (bool): Flag to determine if matching suffix should be appended to file name, default is True.
                                             Used primarily to enhance automated tests.
-            ensure_parity (Optional[Literal["even", "odd"]]): Ensures the number of pages in the PDF is even or odd. If omitted,
+            ensure_parity (Optional[Literal["even", "odd"]]): Ensures the number of pages in the PDF is even or odd. If omitted,.
                 no parity is enforced. Defaults to None.
 
         Returns:
@@ -2038,7 +2038,7 @@ class ALDocumentBundle(DAList):
             zip_format (Optional[str]): Format of the primary version of each document.
 
         Returns:
-            Tuple[List[Dict[str, DAFile]], Optional[DAFile], Optional[DAFile]]: A list of dictionaries containing the enabled documents, a zip file of the whole bundle, and a PDF of the whole
+            Tuple[List[Dict[str, DAFile]], Optional[DAFile], Optional[DAFile]]: A list of dictionaries containing the enabled documents, a zip file of the whole bundle, and a PDF of the whole.
         """
         # reduce idempotency delays
         enabled_docs = self.enabled_documents(refresh=refresh)
@@ -2143,23 +2143,23 @@ class ALDocumentBundle(DAList):
             refresh (bool): Flag to reconsider the 'enabled' attribute, default is True.
             pdfa (bool): Flag to return documents in PDF/A format, default is False.
             include_zip (bool): Flag to include a zip option, default is True.
-            view_label (str): Label for the 'view' button. If `None`, falls back to
+            view_label (str): Label for the 'view' button. If `None`, falls back to.
                 `self.view_label` (a translatable template defined in `ql_baseline.yml`,
                 defaulting to `"View"`).
             view_icon (str): Icon for the 'view' button, default is "eye".
-            download_label (str): Label for the 'download' button. If `None`, falls back to
+            download_label (str): Label for the 'download' button. If `None`, falls back to.
                 `self.download_label` (a translatable template defined in `ql_baseline.yml`,
                 defaulting to `"Download"`).
             download_icon (str): Icon for the 'download' button, default is "download".
-            send_label (str): Label for the 'send' button. If `None`, falls back to
+            send_label (str): Label for the 'send' button. If `None`, falls back to.
                 `self.send_label` (a translatable template defined in `ql_baseline.yml`,
                 defaulting to `"Send"`).
             send_icon (str): Fontawesome icon for the 'send' button. Default is "envelope".
-            zip_label (Optional[str]): Label for the zip button. If `None`, falls back to
+            zip_label (Optional[str]): Label for the zip button. If `None`, falls back to.
                 `self.zip_label` (a translatable template defined in `al_document.yml`,
                 defaulting to `"Download all"`).
             zip_icon (str): Icon for the zip option, default is "file-archive".
-            zip_row_label (str, optional): Text to go in the left-most column
+            zip_row_label (str, optional): Text to go in the left-most column.
                 of the table's zip row. Will default to the value of `self.title`.
             append_matching_suffix (bool): Flag to determine if matching suffix should be appended to file name, default is True.
             include_email (bool): Flag to include an option, default is False.
@@ -2383,7 +2383,7 @@ class ALDocumentBundle(DAList):
 
         Args:
             key (str): A key used to identify which version of the ALDocument to send. Defaults to "final".
-            send_label (str): Label for the 'send' button. If `None`, falls back to
+            send_label (str): Label for the 'send' button. If `None`, falls back to.
                 `self.send_label` (a translatable template defined in `ql_baseline.yml`,
                 defaulting to `"Send"`).
             send_icon (str): Icon for the 'send' button. Default is "envelope".
@@ -2447,9 +2447,9 @@ class ALDocumentBundle(DAList):
 
         Args:
             email (str): The recipient's email address.
-            editable (bool, optional): Flag indicating if the bundle is editable. Defaults to False. (deprecated; use preferred_formats instead)
+            editable (bool, optional): Flag indicating if the bundle is editable. Defaults to False. (deprecated; use preferred_formats instead).
             template_name (str, optional): The name of the template to be used. Defaults to an empty string.
-            label (str, optional): The label for the button. If `None`, falls back to
+            label (str, optional): The label for the button. If `None`, falls back to.
                 `self.send_label` (a translatable template defined in `ql_baseline.yml`,
                 defaulting to `"Send"`).
             icon (str, optional): The Fontawesome icon for the button. Defaults to "envelope".
@@ -2517,16 +2517,16 @@ class ALDocumentBundle(DAList):
 
         Args:
             key (str, optional): A key used to identify which version of the ALDocument to send. Defaults to "final".
-            show_editable_checkbox (bool, optional): Flag indicating if the checkbox
+            show_editable_checkbox (bool, optional): Flag indicating if the checkbox.
                 for deciding the inclusion of an editable (Word) copy should be displayed.
                 Defaults to True. If preferred_formats = ["pdf"], this will be ignored and no checkbox will be shown.
-            template_name (str, optional): Name of the template variable that is used to fill
+            template_name (str, optional): Name of the template variable that is used to fill.
                 the email contents. By default, the `x.send_email_template` template will be used.
             label (str, optional): The label for the button. Defaults to "Send".
-            icon (str, optional): The Fontawesome icon for the button. Defaults
+            icon (str, optional): The Fontawesome icon for the button. Defaults.
                 to "envelope".
             preferred_formats (Optional[Union[str,List[str]]], optional): A list of allowed formats for the document. Defaults to "pdf" if not specified.
-            email_legend_class (str, optional): CSS class applied to the email
+            email_legend_class (str, optional): CSS class applied to the email.
                 section legend. Defaults to "h4".
 
         Returns:
@@ -2621,8 +2621,8 @@ class ALDocumentBundle(DAList):
         Args:
             to (Any): The email address, list of email addresses, or list of Individuals with a .email attribute to send to.
             key (str, optional): Specifies which version of the document to send. Defaults to "final".
-            editable (bool, optional): If True, sends the editable documents. Defaults to False. (Deprecated)
-            template (Any, optional): The template variable for the subject and body of the email,
+            editable (bool, optional): If True, sends the editable documents. Defaults to False. (Deprecated).
+            template (Any, optional): The template variable for the subject and body of the email,.
                 similar to the `template` parameter of docassemble's `send_email` function.
                 If `None`, falls back to `self.send_email_template`, a template defined
                 generically in `al_document.yml`. Its subject defaults to
@@ -2783,18 +2783,18 @@ class ALExhibit(DAObject):
 
     Attributes:
         pages (list): List of individual DAFiles representing uploaded images or documents.
-        cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block
+        cover_page (DAFile | DAFileCollection): (optional) A DAFile or DAFileCollection object created by an `attachment:` block.
           Will typically say something like "Exhibit 1"
-        label (str): A label, like "A" or "1" for this exhibit in the cover page and table of contents
-        starting_page (int): first page number to use in table of contents
+        label (str): A label, like "A" or "1" for this exhibit in the cover page and table of contents.
+        starting_page (int): first page number to use in table of contents.
     """
 
     def init(self, *pargs, **kwargs) -> None:
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.initializeAttribute("_cache", DALazyAttribute)
@@ -2887,12 +2887,12 @@ class ALExhibit(DAObject):
         Note that these are keyword only parameters, not positional.
 
         Args:
-            refresh (bool): If True, forces the exhibit to refresh before generating the PDF. (unused, provided for signature compatibility)
+            refresh (bool): If True, forces the exhibit to refresh before generating the PDF. (unused, provided for signature compatibility).
             pdfa (bool): If True, the generated PDF will be in PDF/A format.
             add_page_numbers (bool): If True, apply Bates numbering starting from 'self.start_page'.
             page_number_prefix (str): If add_page_numbers is True, this gets added to the beginning on the bates number each page (e.g. `EX-`).
-            page_number_digits (int): How many digits (i.e. leading 0s) that the bates number will have
-            page_number_area (str): Where on the page the bates number will go ("TOP_LEFT", "TOP_RIGHT", "BOTTOM_LEFT", "BOTTOM_RIGHT" (default))
+            page_number_digits (int): How many digits (i.e. leading 0s) that the bates number will have.
+            page_number_area (str): Where on the page the bates number will go ("TOP_LEFT", "TOP_RIGHT", "BOTTOM_LEFT", "BOTTOM_RIGHT" (default)).
             page_number_font_size (float): How big the bates page number will be in points (default is 10).
             page_number_offset_horizontal (float): The number of pixels that the bates page number is offset from the left / right of the page.
             page_number_offset_vertical (float): The number of pixels that the bates page number is offset from the top / bottom of the page.
@@ -3027,7 +3027,7 @@ class ALExhibitList(DAList):
 
     Attributes:
         maximum_size (int): The maximum allowed size in bytes of the entire document.
-        maximum_size_per_doc (int): The maximum allowed size in bytes per document in the list
+        maximum_size_per_doc (int): The maximum allowed size in bytes per document in the list.
         auto_label (bool): If True, automatically numbers exhibits for cover page and table of contents. Defaults to True.
         auto_labeler (Callable): An optional function or lambda to transform the exhibit's index to a label.
                                  Uses A..Z labels by default.
@@ -3038,8 +3038,8 @@ class ALExhibitList(DAList):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         if not hasattr(self, "auto_label"):
@@ -3082,8 +3082,8 @@ class ALExhibitList(DAList):
             pdfa (bool): If True, generates the PDF in PDF/A format.
             add_page_numbers (bool): If True, adds page numbers to the generated PDF.
             page_number_prefix (str): What the bates number added to each page should start with (e.g. `EX-`).
-            page_number_digits (int): How many digits (i.e. leading 0s) that the bates number will have
-            page_number_area (str): Where on the page the bates number will go ("TOP_LEFT", "TOP_RIGHT", "BOTTOM_LEFT", "BOTTOM_RIGHT" (default))
+            page_number_digits (int): How many digits (i.e. leading 0s) that the bates number will have.
+            page_number_area (str): Where on the page the bates number will go ("TOP_LEFT", "TOP_RIGHT", "BOTTOM_LEFT", "BOTTOM_RIGHT" (default)).
             page_number_font_size (float): How big the bates page number will be in points (default is 10).
             page_number_offset_horizontal (float): The number of pixels that the bates page number is offset from the left / right of the page.
             page_number_offset_vertical (float): The number of pixels that the bates page number is offset from the top / bottom of the page.
@@ -3200,10 +3200,10 @@ class ALExhibitDocument(ALDocument):
     or an exhibit list, complete with an optional table of contents and page numbering.
 
     Attributes:
-        exhibits (ALExhibitList): A list of ALExhibit documents. Each item represents
+        exhibits (ALExhibitList): A list of ALExhibit documents. Each item represents.
                                   a distinct exhibit, which can span multiple pages.
         table_of_contents (DAFile or DAFileCollection): Generated by an `attachment:` block.
-        _cache (DAFile): A cached version of the exhibit list. Caching is used due to
+        _cache (DAFile): A cached version of the exhibit list. Caching is used due to.
                          potential long processing times.
         include_table_of_contents (bool): Indicates if a table of contents should be generated.
         include_exhibit_cover_pages (bool): Determines if cover pages should accompany each exhibit.
@@ -3261,8 +3261,8 @@ class ALExhibitDocument(ALDocument):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.initializeAttribute("exhibits", ALExhibitList)
@@ -3453,8 +3453,8 @@ class ALTableDocument(ALDocument):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -3516,12 +3516,12 @@ class ALTableDocument(ALDocument):
 
         Args:
             key (str): Identifier key for the document, mainly for compatibility with ALDocument.
-            refresh (bool): For signature compatibility
-            pdfa (bool): For signature compatibility
-            append_matching_suffix (bool): For signature compatibility
+            refresh (bool): For signature compatibility.
+            pdfa (bool): For signature compatibility.
+            append_matching_suffix (bool): For signature compatibility.
 
         Returns:
-            DAFile: The table rendered as an XLSX spreadsheet
+            DAFile: The table rendered as an XLSX spreadsheet.
         """
         if not hasattr(self, "suffix_to_append"):
             # When the key is "preview", append it to the file name
@@ -3545,12 +3545,12 @@ class ALTableDocument(ALDocument):
 
         Args:
             key (str): Identifier key for the document, mainly for compatibility with ALDocument.
-            refresh (bool): For signature compatibility
-            pdfa (bool): For signature compatibility
-            append_matching_suffix (bool): For signature compatibility
+            refresh (bool): For signature compatibility.
+            pdfa (bool): For signature compatibility.
+            append_matching_suffix (bool): For signature compatibility.
 
         Returns:
-            DAFile: The table rendered as an XLSX spreadsheet
+            DAFile: The table rendered as an XLSX spreadsheet.
         """
         return self.as_pdf()
 
@@ -3570,8 +3570,8 @@ class ALUntransformedDocument(ALDocument):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.has_addendum = False
@@ -3668,7 +3668,7 @@ class ALDocumentUpload(ALUntransformedDocument):
 def unpack_dafilelist(the_file: DAFileList) -> DAFile:
     """Creates a plain DAFile out of the first item in a DAFileList
     Args:
-        the_file (DAFileList): an item representing an uploaded document in a Docassemble interview
+        the_file (DAFileList): an item representing an uploaded document in a Docassemble interview.
 
     Returns:
         A DAFile representing the first item in the DAFileList, with a fixed instanceName attribute.

--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -138,7 +138,7 @@ class ALAddress(Address):
             allow_no_address (bool): Allow users to specify they don't have an address. Defaults to False.
             ask_if_impounded (Optional[bool]): Whether to ask if the address is impounded. Defaults to False.
             maxlengths (Optional[Dict[str, int]]): A dictionary of field names and their maximum lengths. Defaults to None.
-            required (Dict[str, bool], optional): A dictionary of field names and if they should be required. Default is None (everything but unit and zip is required)
+            required (Dict[str, bool], optional): A dictionary of field names and if they should be required. Default is None (everything but unit and zip is required).
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries representing address fields.
@@ -295,13 +295,13 @@ class ALAddress(Address):
 
         Args:
             language (str, optional): The language in which to format the unit. Defaults to None (which uses system language).
-            require (bool, optional): A flag indicating whether the unit is required. If set to True, the function will
+            require (bool, optional): A flag indicating whether the unit is required. If set to True, the function will.
                                     raise an error if the unit attribute does not exist. Defaults to False.
-            bare (bool, optional): A flag indicating whether to add the word 'Unit' before the unit number. If set to
+            bare (bool, optional): A flag indicating whether to add the word 'Unit' before the unit number. If set to.
                                 True, the function will not add 'Unit' regardless of other conditions. Defaults to False.
 
         Returns:
-            str:
+            str:.
                 The formatted unit. If the unit attribute does not exist and require is set to False, this will be an
                 empty string. If the unit attribute exists and is not None or an empty string, the function will return
                 the unit number, possibly prefixed with 'Unit'. If the unit attribute exists and is None or an empty
@@ -636,7 +636,7 @@ class ALAddress(Address):
         Warning: currently the normalized address will not be redacted if the address is impounded.
 
         Returns:
-            Union[Address, "ALAddress"]:
+            Union[Address, "ALAddress"]:.
                 Normalized address if geocoding is successful, otherwise
                 the original address.
         """
@@ -658,12 +658,12 @@ class ALAddress(Address):
         2. The country set in the global config for the server.
 
         Args:
-            country_code (str, optional): ISO-3166-1 alpha-2 code to override the country attribute of
-                the Address object. For valid codes, refer to:
-                https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements
+            country_code (str, optional): ISO-3166-1 alpha-2 code to override the country attribute of.
+                the Address object. For valid codes, refer to:.
+                https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements.
 
         Returns:
-            str: The full state name corresponding to the state abbreviation. If an error occurs
+            str: The full state name corresponding to the state abbreviation. If an error occurs.
             or the full name cannot be determined, returns the state abbreviation.
         """
         if country_code:
@@ -694,8 +694,8 @@ class ALAddressList(DAList):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super(ALAddressList, self).init(*pargs, **kwargs)
         self.object_type = ALAddress
@@ -722,8 +722,8 @@ class ALNameList(DAList):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super().init(*pargs, **kwargs)
         self.object_type = IndividualName
@@ -746,8 +746,8 @@ class ALPeopleList(DAList):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super(ALPeopleList, self).init(*pargs, **kwargs)
         self.object_type = ALIndividual
@@ -913,8 +913,8 @@ class ALIndividual(Individual):
         """Standard DAObject init method.
 
         Args:
-            *pargs: Positional arguments
-            **kwargs: Keyword arguments
+            *pargs: Positional arguments.
+            **kwargs: Keyword arguments.
         """
         super(ALIndividual, self).init(*pargs, **kwargs)
         # Initialize the attributes that are themselves objects. Requirement to work with Docassemble
@@ -1070,7 +1070,7 @@ class ALIndividual(Individual):
         Avoid using. Only used in 209A.
 
         Args:
-            new_letters (str): The new letters to add to the existing list of letters
+            new_letters (str): The new letters to add to the existing list of letters.
         """
         # TODO: move to 209A package
         if hasattr(self, "child_letters"):
@@ -1125,7 +1125,7 @@ class ALIndividual(Individual):
                 Default is True.
             show_title: (bool, optional): Determines if the name's title (e.g., Mr., Ms.) should be included in the prompts.
                 Default is False.
-            title_choices (Union[List[str], Callable], optional): A list or callable of title options to use in the prompts. Default is defined as a list
+            title_choices (Union[List[str], Callable], optional): A list or callable of title options to use in the prompts. Default is defined as a list.
                 of common titles in English-speaking countries, or overridden by value of global `al_name_titles`.
             show_if (Union[str, Dict[str, str], None], optional): Condition to determine which fields to show.
                 It can be a string, a dictionary with conditions, or None. Default is None.
@@ -1327,7 +1327,7 @@ class ALIndividual(Individual):
             allow_no_address (bool): Whether to permit entries with no address. Defaults to False.
             ask_if_impounded (bool): Whether to ask if the address is impounded. Defaults to False.
             maxlengths (Dict[str, int], optional): A dictionary of field names and their maximum lengths. Default is None.
-            required (Dict[str, bool], optional): A dictionary of field names and if they should be required. Default is None (everything but unit and zip is required)
+            required (Dict[str, bool], optional): A dictionary of field names and if they should be required. Default is None (everything but unit and zip is required).
 
         Returns:
             List[Dict[str, str]]: A list of dictionaries with field prompts for addresses.
@@ -1581,7 +1581,7 @@ class ALIndividual(Individual):
         Get the human-readable version of the individual's selected language.
 
         Returns:
-            str: The human-readable version of the language. If 'other' is selected,
+            str: The human-readable version of the language. If 'other' is selected,.
             it returns the value in `language_other`. Otherwise, it uses the
             `language_name` function.
         """
@@ -1854,7 +1854,7 @@ class ALIndividual(Individual):
 
         Args:
             target (str): The target word to follow the pronoun.
-            **kwargs: Additional keyword arguments that can be passed to modify the behavior. These might include:
+            **kwargs: Additional keyword arguments that can be passed to modify the behavior. These might include:.
                 - `default` (Optional[str]): The default word to use if the pronoun is not defined, e.g., "the agent". If not defined, the default term is the user's name.
                 - `person` (Optional[Union[str, int]]): Whether to use a first, second, or third person pronoun. Can be one of 1/"1p", 2/"2p", or 3/"3p" (default is 3). See [upstream documentation](https://docassemble.org/docs/objects.html#language%20methods) for more information.
 
@@ -2167,7 +2167,7 @@ class ALIndividual(Individual):
         the first name, even if middle, last, or suffix are defined.
 
         Returns:
-            str: The individual'
+            str: The individual'.
         """
         if hasattr(self, "person_type") and self.person_type in [
             "business",
@@ -2428,7 +2428,7 @@ def is_sms_enabled() -> bool:
     See https://docassemble.org/docs/config.html#twilio for more info.
 
     Returns:
-        bool: True if there is a non-empty Twilio config on the server, False otherwise
+        bool: True if there is a non-empty Twilio config on the server, False otherwise.
     """
     twilio_config = get_config("twilio")
     if isinstance(twilio_config, list):
@@ -2568,7 +2568,7 @@ def has_parsable_pronouns(pronouns: str) -> bool:
     Returns True if the pronouns string can be parsed into a dictionary of pronouns.
 
     Args:
-        pronouns: a string of pronouns in the format "objective/subjective/possessive"
+        pronouns: a string of pronouns in the format "objective/subjective/possessive".
 
     Returns:
         True if the pronouns string can be parsed into a dictionary of pronouns, False otherwise
@@ -2585,10 +2585,10 @@ def parse_custom_pronouns(pronouns: str) -> Dict[str, str]:
     Parses a custom pronoun string into a dictionary of pronouns.
 
     Args:
-        pronouns: a string of pronouns in the format "objective/subjective/possessive"
+        pronouns: a string of pronouns in the format "objective/subjective/possessive".
 
     Returns:
-        a dictionary of pronouns in the format {"o": objective, "s": subjective, "p": possessive}
+        a dictionary of pronouns in the format {"o": objective, "s": subjective, "p": possessive}.
     """
     # test for presence of either 2 or 3 /'s
     if not (2 <= pronouns.count("/") <= 3):
@@ -2620,7 +2620,7 @@ def get_visible_al_nav_items(
     ]
 
     Args:
-        nav_items: a list of nav items
+        nav_items: a list of nav items.
 
     Returns:
         a list of nav items with hidden items removed

--- a/docassemble/AssemblyLine/language.py
+++ b/docassemble/AssemblyLine/language.py
@@ -18,10 +18,10 @@ def _package_name(package_name: Optional[str] = None) -> str:
     """Get package name without the name of the given module. By default this is `docassemble.AssemblyLine.language`
 
     Args:
-        package_name: the name of the package to get the package name from (defaults to `docassemble.AssemblyLine.language`)
+        package_name: the name of the package to get the package name from (defaults to `docassemble.AssemblyLine.language`).
 
     Returns:
-        str: the package name without the name of the given module
+        str: the package name without the name of the given module.
     """
     if not package_name:
         package_name = __name__
@@ -36,7 +36,7 @@ def get_local_languages_yaml() -> str:
     Get the path to the local languages.yml file. If it does not exist, it will return the path to the languages.yml
 
     Returns:
-        str: the path to the local languages.yml file if it exists, otherwise the path to the languages.yml file
+        str: the path to the local languages.yml file if it exists, otherwise the path to the languages.yml file.
     """
     try:
         local_yaml = path_and_mimetype("data/sources/languages.yml")[0]
@@ -61,8 +61,8 @@ def get_tuples(
     English name from pycountry. If neither is present, it will use the language code itself.
 
     Args:
-        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es'])
-        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml)
+        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es']).
+        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml).
 
     Returns:
         A list of tuples representing the language name, followed by language ISO 639-1 code.
@@ -112,12 +112,12 @@ def get_language_list_dropdown(
     Get a Bootstrap 5 dropdown menu for language selection that can be added to navigation bar.
 
     Args:
-        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es'])
-        current: the current language code
-        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml)
-        event_name: the name of the event to trigger when the language is changed
-        icon: the name of the icon to use for the dropdown menu (defaults to fa-solid fa-language fa-xl)
-        extra_class: additional classes to add to the link
+        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es']).
+        current: the current language code.
+        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml).
+        event_name: the name of the event to trigger when the language is changed.
+        icon: the name of the icon to use for the dropdown menu (defaults to fa-solid fa-language fa-xl).
+        extra_class: additional classes to add to the link.
     Returns:
       A string containing the HTML for a dropdown menu for language selection.
     """
@@ -154,9 +154,9 @@ def get_language_list_dropdown_item(
     given in the first part of the tuple.
 
     Args:
-        language: a tuple containing the language name and language code
-        link: whether to return a link or just the text
-        event_name: the name of the event to trigger when the language is changed
+        language: a tuple containing the language name and language code.
+        link: whether to return a link or just the text.
+        event_name: the name of the event to trigger when the language is changed.
 
     Returns:
         str: A string containing the HTML for a dropdown menu item for language selection.
@@ -183,11 +183,11 @@ def get_language_list(
     tuples containing the language name and language code. This is deprecated and may be removed in a future version.
 
     Args:
-        languages: a list of tuples containing the language name and language code (deprecated)
-        current: the current language code
-        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es'])
-        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml)
-        event_name: the name of the event to trigger when the language is changed
+        languages: a list of tuples containing the language name and language code (deprecated).
+        current: the current language code.
+        lang_codes: a list of ISO 639-1 language codes (e.g. ['en', 'es']).
+        languages_path: the path to the languages.yml file (defaults to data/sources/languages.yml).
+        event_name: the name of the event to trigger when the language is changed.
 
     Returns:
         A string containing the HTML for an unordered inline list of language selection.
@@ -217,9 +217,9 @@ def get_language_list_item(language, link=True, event_name="al_change_language")
     given in the first part of the tuple.
 
     Args:
-        language: a tuple containing the language name and language code
-        link: whether to return a link or just the text
-        event_name: the name of the event to trigger when the language is changed
+        language: a tuple containing the language name and language code.
+        link: whether to return a link or just the text.
+        event_name: the name of the event to trigger when the language is changed.
 
     Returns:
         str: A string containing the HTML for an unordered inline list item for language selection.

--- a/docassemble/AssemblyLine/sessions.py
+++ b/docassemble/AssemblyLine/sessions.py
@@ -216,7 +216,7 @@ def _package_name(package_name: Optional[str] = None):
     docassemble.ALWeaver.advertise_capabilities
 
     Args:
-        package_name (str, optional): The package name to process. If `None`, will use the existing package name `__name__` instead
+        package_name (str, optional): The package name to process. If `None`, will use the existing package name `__name__` instead.
 
     Returns:
         str: The package name without the current module name.
@@ -237,7 +237,7 @@ def is_file_like(obj: Any) -> bool:
     Return True if the object is a file-like object.
 
     Args:
-        obj (Any): The object to test
+        obj (Any): The object to test.
 
     Returns:
         bool: True if the object is a file-like object.
@@ -273,9 +273,9 @@ def set_interview_metadata(
     - variable_count
 
     Args:
-        filename (str): The filename of the interview to add metadata for
-        session_id (str): The session ID of the interview to add metadata for
-        data (Dict): The metadata to add
+        filename (str): The filename of the interview to add metadata for.
+        session_id (str): The session ID of the interview to add metadata for.
+        data (Dict): The metadata to add.
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
     """
     server.write_answer_json(
@@ -290,12 +290,12 @@ def get_interview_metadata(
     We implement this with the docassemble jsonstorage table and a dedicated `tag` which defaults to `metadata`.
 
     Args:
-        filename (str): The filename of the interview to retrieve metadata for
-        session_id (str): The session ID of the interview to retrieve metadata for
+        filename (str): The filename of the interview to retrieve metadata for.
+        session_id (str): The session ID of the interview to retrieve metadata for.
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
 
     Returns:
-        Dict[str, Any]: The metadata associated with the interview
+        Dict[str, Any]: The metadata associated with the interview.
     """
     sql = text("""
         SELECT data
@@ -345,7 +345,7 @@ def get_saved_interview_list(
         offset (int, optional): The offset to start returning results from. Defaults to 0.
         filename_to_exclude (str, optional): The filename to exclude from the results. Defaults to "".
         exclude_current_filename (bool, optional): Whether to exclude the current filename from the results. Defaults to True.
-        exclude_filenames (Optional[List[str]], optional): List of filenames to exclude. Defaults to None. If the `filename` does not contain a `:` it will be treated as a prefix, allowing you to filter out whole packages (e.g., any path starting with docassemble.ALDashboard or docassemble.playground)
+        exclude_filenames (Optional[List[str]], optional): List of filenames to exclude. Defaults to None. If the `filename` does not contain a `:` it will be treated as a prefix, allowing you to filter out whole packages (e.g., any path starting with docassemble.ALDashboard or docassemble.playground).
         exclude_newly_started_sessions (bool, optional): Whether to exclude sessions that are still on "step 1". Defaults to False.
 
     Returns:
@@ -490,7 +490,7 @@ def find_matching_sessions(
     The keyword search is case-insensitive and will match any part of the metadata column values.
 
     Args:
-        keyword (str): The keyword to search for in the metadata
+        keyword (str): The keyword to search for in the metadata.
         metadata_column_names (List[str], optional): The names of the metadata columns to search. If not provided, defaults to ["title", "auto_title", "description"].
         filenames (List[str], optional): The filename or filenames of the interviews to retrieve sessions for.
         user_id (Union[int, str, None], optional): The user ID to retrieve sessions for. Defaults to current user. Specify "all" if you want and have the necessary privileges to search all sessions.
@@ -504,12 +504,12 @@ def find_matching_sessions(
         global_search_allowed_roles (Union[Set[str],List[str]], optional): A list or set of roles that are allowed to search all sessions. Defaults to {'admin','developer', 'advocate'}. 'admin' and 'developer' are always allowed to search all sessions.
         metadata_filters (Optional[Dict[str, Tuple[Any, str, Optional[str]]]], optional): A dictionary of metadata column names and their corresponding filter tuples.
             Each tuple should contain (value, operator, cast_type).
-            - value: The value to compare against
-            - operator: One of '=', '!=', '<', '<=', '>', '>=', 'LIKE', 'ILIKE'
-            - cast_type: Optional. One of 'int', 'float', or None for string (default)
+            - value: The value to compare against.
+            - operator: One of '=', '!=', '<', '<=', '>', '>=', 'LIKE', 'ILIKE'.
+            - cast_type: Optional. One of 'int', 'float', or None for string (default).
 
     Returns:
-        List[Dict[str, Any]]: A list of saved sessions for the specified filename that match the search keyword and metadata filters
+        List[Dict[str, Any]]: A list of saved sessions for the specified filename that match the search keyword and metadata filters.
 
     Example:
     ```python
@@ -867,10 +867,10 @@ def nice_interview_title(
     4. Finally, return "Untitled interview" or translated phrase from system-wide words.yml
 
     Args:
-        answer (Dict[str, str]): The answer dictionary to get the interview title from
+        answer (Dict[str, str]): The answer dictionary to get the interview title from.
 
     Returns:
-        str: The human readable interview title
+        str: The human readable interview title.
     """
     if answer.get("filename"):
         for interview in system_interviews:
@@ -892,10 +892,10 @@ def pascal_to_zwspace(text: str) -> str:
     with word breaks on small viewports.
 
     Args:
-        text (str): The text to insert zero-width spaces into
+        text (str): The text to insert zero-width spaces into.
 
     Returns:
-        str: The text with zero-width spaces inserted
+        str: The text with zero-width spaces inserted.
     """
     re_outer = re.compile(r"([^A-Z ])([A-Z])")
     re_inner = re.compile(r"(?<!^)([A-Z])([^A-Z])")
@@ -909,11 +909,11 @@ def nice_interview_subtitle(answer: Dict[str, str], exclude_identical=True) -> s
     If exclude_identical, return empty string when title is the same as the subtitle.
 
     Args:
-        answer (Dict[str, str]): The answer dictionary to get the interview subtitle from
+        answer (Dict[str, str]): The answer dictionary to get the interview subtitle from.
         exclude_identical (bool, optional): If True, excludes the subtitle if it is identical to the title. Defaults to True.
 
     Returns:
-        str: The human readable interview subtitle
+        str: The human readable interview subtitle.
     """
     if answer.get("title"):
         return pascal_to_zwspace(answer["title"])
@@ -932,10 +932,10 @@ def radial_progress(answer: Dict[str, Union[str, int]]) -> str:
     Return HTML for a radial progress bar, or the number of steps if progress isn't available in the metadata.
 
     Args:
-        answer (Dict[str, Union[str, int]]): The answer dictionary to get the interview progress from
+        answer (Dict[str, Union[str, int]]): The answer dictionary to get the interview progress from.
 
     Returns:
-        str: the HTML as a string
+        str: the HTML as a string.
     """
     if not answer.get("progress"):
         return f"Page {answer.get('steps') or answer.get('num_keys') or 1}"
@@ -961,10 +961,10 @@ def local_date(utcstring: Optional[str]) -> DADateTime:
     Return a localized date from a UTC string.
 
     Args:
-        utcstring (Optional[str]): The UTC string to convert to a localized date
+        utcstring (Optional[str]): The UTC string to convert to a localized date.
 
     Returns:
-        DADateTime: The localized date
+        DADateTime: The localized date.
     """
     if not utcstring:
         return DADateTime()
@@ -1009,7 +1009,7 @@ def session_list_html(
         metadata_key_name (str, optional): Name of the metadata key. Defaults to "metadata".
         filename_to_exclude (str, optional): Name of the file to exclude. Defaults to `al_session_store_default_filename`.
         exclude_current_filename (bool, optional): If True, excludes the current filename. Defaults to True.
-        exclude_filenames (Optional[List[str]], optional): List of filenames to exclude. Defaults to None. If the `filename` does not contain a `:` it will be treated as a prefix, allowing you to filter out whole packages (e.g., any path starting with docassemble.ALDashboard or docassemble.playground)
+        exclude_filenames (Optional[List[str]], optional): List of filenames to exclude. Defaults to None. If the `filename` does not contain a `:` it will be treated as a prefix, allowing you to filter out whole packages (e.g., any path starting with docassemble.ALDashboard or docassemble.playground).
         exclude_newly_started_sessions (bool, optional): If True, excludes newly started sessions. Defaults to False.
         name_label (str, optional): Label for the session name/title. Defaults to translated word "Title".
         date_label (str, optional): Label for the date column. Defaults to translated word "Date modified".
@@ -1025,7 +1025,7 @@ def session_list_html(
         show_copy_button (bool, optional): If True, show a copy button for answer sets. Defaults to True.
         limit (int, optional): Limit for the number of sessions returned. Defaults to 50.
         offset (int, optional): Offset for the session list. Defaults to 0.
-        answers (Optional[List[Dict[str, Any]], optional): A list of answers to format and display. Defaults to showing all sessions for the current user.
+        answers (Optional[List[Dict[str, Any]]], optional): A list of answers to format and display. Defaults to showing all sessions for the current user.
 
 
     Returns:
@@ -1160,9 +1160,9 @@ def rename_interview_answers(
     metadata that may be present.
 
     Args:
-        filename (str): The filename of the interview to rename
-        session_id (str): The session ID of the interview to rename
-        new_name (str): The new name to set for the interview
+        filename (str): The filename of the interview to rename.
+        session_id (str): The session ID of the interview to rename.
+        new_name (str): The new name to set for the interview.
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
 
     If exception is raised in set_session_variables, this will silently fail but log the error.
@@ -1198,7 +1198,7 @@ def set_current_session_metadata(
     Set metadata for the current session, such as the title, in an unencrypted database entry.
 
     Args:
-        data (Dict[str, Any]): The metadata to set
+        data (Dict[str, Any]): The metadata to set.
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
     """
     return set_interview_metadata(
@@ -1217,7 +1217,7 @@ def rename_current_session(
     metadata that might be present.
 
     Args:
-        new_name (str): The new name to set for the interview
+        new_name (str): The new name to set for the interview.
         metadata_key_name (str, optional): The name of the metadata key. Defaults to "metadata".
     """
     return rename_interview_answers(
@@ -1523,7 +1523,7 @@ def export_interview_variables(
         additional_variables_to_filter (Union[Set, List[str], None], optional): List or set of additional variables to exclude. Defaults to None.
 
     Returns:
-        DAFile: DAFile with a JSON representation of the answers
+        DAFile: DAFile with a JSON representation of the answers.
     """
     if not output:
         output = DAFile()
@@ -1779,7 +1779,7 @@ def update_current_session_metadata(
 
     Args:
         data (Dict[str, Any]): A dictionary of metadata to add or update.
-        metadata_key_name (str, optional): The tag for the metadata in the
+        metadata_key_name (str, optional): The tag for the metadata in the.
                                            jsonstorage table. Defaults to "metadata".
     """
     return update_session_metadata(


### PR DESCRIPTION
New rule, SIG306, is causing test failures. It seems a little arbitrary, but it expects a `.` at the end of a documentation line.

Straightforward to fix and I think there's no strong reason to opt out of this rule.