### PR TITLE
[codex] Render translatable document titles at string boundaries

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -1936,7 +1936,7 @@ class ALDocumentBundle(DAList):
             if isinstance(document, ALDocumentBundle):
                 flat_list.extend(document.get_titles(key=key, refresh=refresh))
             else:
-                flat_list.append(document.title)
+                flat_list.append(str(document.title))
         return flat_list
 
     def as_pdf_list(

--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -2160,7 +2160,7 @@ code: |
 generic object: ALDocumentUpload
 id: Upload a document for a bundle that will not be transformed
 question: |
-  ${ x.title.capitalize() }
+  ${ str(x.title).capitalize() }
 fields:
   - I do not have a ${ x.title }: x.has_no_file
     datatype: yesno

--- a/docassemble/AssemblyLine/test_al_document.py
+++ b/docassemble/AssemblyLine/test_al_document.py
@@ -1,7 +1,7 @@
 # do not pre-load
 
 import unittest
-from docassemble.base.util import DAFile
+from docassemble.base.util import DAFile, DATemplate
 from .al_document import ALDocument, ALDocumentBundle, ALAddendumField
 
 
@@ -102,6 +102,27 @@ class TestSingleDocumentFilename(unittest.TestCase):
         self.assertEqual(result.filename, "document-output.pdf")
         self.assertEqual(result.attribute_filenames, ["document-output.pdf"])
         self.assertEqual(result.mimetype, "application/pdf")
+
+
+class TestTranslatableDocumentTitles(unittest.TestCase):
+    def test_get_titles_returns_rendered_strings(self):
+        document = ALDocument(
+            "document",
+            title=DATemplate(content="Translated document title"),
+            filename="document",
+            enabled=True,
+        )
+        bundle = ALDocumentBundle(
+            "bundle",
+            elements=[document],
+            filename="bundle",
+            enabled=True,
+        )
+
+        titles = bundle.get_titles()
+
+        self.assertEqual(titles, ["Translated document title"])
+        self.assertIsInstance(titles[0], str)
 
 
 class test_aladdendum(unittest.TestCase):


### PR DESCRIPTION
## Summary

- render `ALDocument` titles to strings when `ALDocumentBundle.get_titles()` returns its documented `List[str]`
- convert upload document titles to strings before calling `.capitalize()`
- add regression coverage for template-backed document titles

## Why

Document and bundle titles can be supplied through docassemble template blocks (new default in https://github.com/SuffolkLITLab/docassemble-ALWeaver/pull/980) so they remain lazy and translate in the current interview language. Most rendering contexts already call `str()` implicitly, but `get_titles()` promises strings and `.capitalize()` requires a real string. Converting only at these boundaries preserves late translation and avoids freezing titles during object creation or background document caching.

## Validation

- `python -m pytest -q docassemble/AssemblyLine/test_al_document.py` (`8 passed`)
- `git diff --check`