### PR TITLE
Set al_user_language & session_local.al_user_language always

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_language.yml
+++ b/docassemble/AssemblyLine/data/questions/al_language.yml
@@ -42,6 +42,7 @@ event: al_change_language
 code: |
   # Set browser-specific language for this interview session
   if "lang" in action_arguments():
+    al_user_language = action_argument("lang")
     session_local.al_user_language = action_argument("lang")
     set_language(session_local.al_user_language)
 ---
@@ -50,4 +51,5 @@ code: |
   # Set "global" language for this interview session instead of user-specific
   if "lang" in action_arguments():
     al_user_language = action_argument("lang")
-    set_language(al_user_language)
+    session_local.al_user_language = action_argument("lang")
+    set_language(session_local.al_user_language)


### PR DESCRIPTION
I'm unsure how to test this change and I'm hunting that down now. It's a suggestion to handle a user report:

> When I change the language at the beginning of the interview using:
> 
> ${ get_language_list(lang_codes=al_interview_languages, current=al_user_language) }
> 
> the interview screens translate, but the program assembles English forms. Usually when I get to the code block that determines which ALDocuments are enabled, this check will work:
> 
> if session_local.attr("al_user_language") == "es"
> 
> For some reason it isn't when I use the get_language_list() function to change the language. If I use the language picker in the menu bar, and cycle es > en > es, then the correct Spanish documents assemble.