### PR TITLE
[codex] Avoid duplicate BirthDate labels

### DIFF
--- a/docassemble/AssemblyLine/data/questions/ql_baseline.yml
+++ b/docassemble/AssemblyLine/data/questions/ql_baseline.yml
@@ -446,9 +446,6 @@ question: |
 fields:
   - Birthdate: x.birthdate
     datatype: BirthDate
-    alMonthLabel: ${ word('Month') }
-    alDayLabel: ${ word('Day') }
-    alYearLabel: ${ word('Year') }
 ---
 id: user i's address
 question: |


### PR DESCRIPTION
## Summary

Removes the custom `alMonthLabel`, `alDayLabel`, and `alYearLabel` entries from the baseline `BirthDate` field.

## Why

On the local docassemble 1.7.7 container, the integrated MATC 1A divorce package failed to assemble because the `BirthDate` field treated those label keys as duplicate field labels.

## Validation

Locally deployed AssemblyLine editable into the docassemble Docker container and ran the MATC1AJointPetition API driver end to end to the final download screen.