### PR TITLE
Automatically prefix 'required' and 'maxlength' dictionaries

### DIFF
--- a/docassemble/AssemblyLine/al_general.py
+++ b/docassemble/AssemblyLine/al_general.py
@@ -275,12 +275,18 @@ class ALAddress(Address):
                 }
             )
 
+        # All 'field' entries start with the full name of the object (i.e. 'users[1].address...'),
+        # so make sure the keys in maxlengths and required have that prefix
+        prefix = self.attr_name("")
+        rename_key = lambda key: key if key.startswith(prefix) else prefix + key
         if maxlengths:
+            maxlengths = {rename_key(k): v for k, v in maxlengths.items()}
             for field in fields:
                 if field["field"] in maxlengths:
                     field["maxlength"] = maxlengths[field["field"]]
 
         if required:
+            required = {rename_key(k): v for k, v in required.items()}
             for field in fields:
                 if field["field"] in required:
                     field["required"] = required[field["field"]]
@@ -1223,17 +1229,6 @@ class ALIndividual(Individual):
                 for field in fields:
                     field["show if"] = show_if
 
-            if maxlengths:
-                for field in fields:
-                    if field["field"] in maxlengths:
-                        field["maxlength"] = maxlengths[field["field"]]
-
-            if required:
-                for field in fields:
-                    if field["field"] in required:
-                        field["required"] = required[field["field"]]
-
-            return fields
         elif person_or_business == "business":
             fields = [
                 {
@@ -1244,17 +1239,6 @@ class ALIndividual(Individual):
             if show_if:
                 fields[0]["show if"] = show_if
 
-            if maxlengths:
-                for field in fields:
-                    if field["field"] in maxlengths:
-                        field["maxlength"] = maxlengths[field["field"]]
-
-            if required:
-                for field in fields:
-                    if field["field"] in required:
-                        field["required"] = required[field["field"]]
-
-            return fields
         else:
             # Note: the labels are template block objects: if they are keys,
             # they should be converted to strings first
@@ -1317,17 +1301,23 @@ class ALIndividual(Individual):
                 }
             )
 
-            if maxlengths:
-                for field in fields:
-                    if field["field"] in maxlengths:
-                        field["maxlength"] = maxlengths[field["field"]]
+        # All 'field' entries start with the full name of the object (i.e. 'users[1].address...'),
+        # so make sure the keys in maxlengths and required have that prefix
+        prefix = self.attr_name("name.")
+        rename_key = lambda key: key if key.startswith(prefix) else prefix + key
+        if maxlengths:
+            maxlengths = {rename_key(k): v for k, v in maxlengths.items()}
+            for field in fields:
+                if field["field"] in maxlengths:
+                    field["maxlength"] = maxlengths[field["field"]]
 
-            if required:
-                for field in fields:
-                    if field["field"] in required:
-                        field["required"] = required[field["field"]]
+        if required:
+            required = {rename_key(k): v for k, v in required.items()}
+            for field in fields:
+                if field["field"] in required:
+                    field["required"] = required[field["field"]]
 
-            return fields
+        return fields
 
     def address_fields(
         self,
@@ -1428,12 +1418,18 @@ class ALIndividual(Individual):
         if show_if:
             fields[0]["show if"] = show_if
 
+        # All 'field' entries start with the full name of the object (i.e. 'users[1].address...'),
+        # so make sure the keys in maxlengths and required have that prefix
+        prefix = self.attr_name("")
+        rename_key = lambda key: key if key.startswith(prefix) else prefix + key
         if maxlengths:
+            maxlengths = {rename_key(k): v for k, v in maxlengths.items()}
             for field in fields:
                 if field["field"] in maxlengths:
                     field["maxlength"] = maxlengths[field["field"]]
 
         if required:
+            required = {rename_key(k): v for k, v in required.items()}
             for field in fields:
                 if field["field"] in required:
                     field["required"] = required[field["field"]]
@@ -1590,12 +1586,18 @@ class ALIndividual(Individual):
         if show_if:
             fields[0]["show if"] = show_if
 
+        # All 'field' entries start with the full name of the object (i.e. 'users[1].address...'),
+        # so make sure the keys in maxlengths and required have that prefix
+        prefix = self.attr_name("")
+        rename_key = lambda key: key if key.startswith(prefix) else prefix + key
         if maxlengths:
+            maxlengths = {rename_key(k): v for k, v in maxlengths.items()}
             for field in fields:
                 if field["field"] in maxlengths:
                     field["maxlength"] = maxlengths[field["field"]]
 
         if required:
+            required = {rename_key(k): v for k, v in required.items()}
             for field in fields:
                 if field["field"] in required:
                     field["required"] = required[field["field"]]

--- a/docassemble/AssemblyLine/test_al_general.py
+++ b/docassemble/AssemblyLine/test_al_general.py
@@ -28,6 +28,10 @@ class test_aladdress(unittest.TestCase):
         for field in fields:
             if "zip" in field["field"]:
                 self.assertTrue(field["required"])
+        fields = addr.address_fields(required={"zip": True})
+        for field in fields:
+            if "zip" in field["field"]:
+                self.assertTrue(field["required"])
         fields = addr.address_fields()
         for field in fields:
             if "zip" in field["field"]:
@@ -586,7 +590,7 @@ class TestALIndividual(unittest.TestCase):
         # Test business case with required parameter
         fields = self.individual.name_fields(
             person_or_business="business",
-            required={"test_individual.name.first": True},
+            required={"first": True},
             title_choices=["a title"],
             suffix_choices=["Jr.", "Sr."],
         )
@@ -613,9 +617,7 @@ class TestALIndividual(unittest.TestCase):
         )  # Should not have required by default
 
         # Test with required parameter
-        fields = self.individual.gender_fields(
-            required={"test_individual.gender": True}
-        )
+        fields = self.individual.gender_fields(required={"gender": True})
         gender_field = fields[0]
         self.assertEqual(gender_field["required"], True)
 


### PR DESCRIPTION
Iterates through the `required` and `maxlength` dictionaries, so the caller doesn't have to prefix the label name with the full object name themselves.

The params now become:  `users[i].address_fields(required={'zip': True})`
Instead of the current: `users[i].address_fields(required={users[i].address.attr_name('zip'): True}`)