### PR TITLE
Fix versions of docassemble to test with

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ ignore_missing_imports = true
 
 [dependency-groups]
 dev = [
-    "docassemble.base>=1.7",
-    "docassemble.webapp>=1.7",
+    "docassemble.base==1.9.8",
+    "docassemble.webapp==1.9.8",
     "pytest>=7.0",
     "mypy",
     "pandas-stubs",


### PR DESCRIPTION
Newer versions of docassemble have extra typing information that is incompatible with our current code. Will have to address once we upgrade to 1.10.X.