### PR TITLE
Use new ALToolbox translation string catalog for audio controls

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -1,4 +1,7 @@
 ---
+include:
+  - docassemble.ALToolbox:translation_strings.yml
+---
 objects:
   - al_logo: DAStaticFile.using(filename="ma_logo.png", alt_text="")
 ---

--- a/docassemble/AssemblyLine/data/questions/interview_list.yml
+++ b/docassemble/AssemblyLine/data/questions/interview_list.yml
@@ -92,6 +92,7 @@ comment: |
 ---
 include:
   - docassemble.ALToolbox:display_template.yml
+  - docassemble.ALToolbox:translation_strings.yml
 ---
 # clear playground errors
 objects:

--- a/docassemble/AssemblyLine/data/sources/ar-words.yml
+++ b/docassemble/AssemblyLine/data/sources/ar-words.yml
@@ -262,7 +262,7 @@ ar: {'%(username_or_email)s does not exist': '%(username_or_email)s غير مو�
   Lebanon: لبنان, Lesotho: ليسوتو, Liberia: ليبيريا, Libya: ليبيا, License: رخصة,
   Liechtenstein: ليختنشتاين, Limited Permissions: أذونات محدودة, Link copied to clipboard.: تم
     نسخ الرابط إلى الحافظة., Linked folder: المجلد المرتبط, Links: الروابط, List of ISO-639-1 language codes: قائمة
-    رموز لغة ISO-639-1, Listen: يستمع, Lithuania: ليتوانيا, Live chat: الدردشة المباشرة,
+    رموز لغة ISO-639-1, Listen: استمع, Lithuania: ليتوانيا, Live chat: الدردشة المباشرة,
   Live chat is available: الدردشة المباشرة متاحة, Loading . . .: تحميل . . ., 'Loading.  Please wait . . . ': 'جاري
     التحميل. الرجاء الانتظار. ', Log: سجل, Logs: السجلات, Luxembourg: لوكسمبورغ, Macao: ماكاو,
   Madagascar: مدغشقر, Malawi: ملاوي, Malaysia: ماليزيا, Maldives: جزر المالديف, Mali: مالي,
@@ -393,8 +393,8 @@ ar: {'%(username_or_email)s does not exist': '%(username_or_email)s غير مو�
     كل مثيل لـ Null بترجمة مقتبسة., Request Developer Account: طلب حساب المطور, Resend Confirmation Email: إعادة
     إرسال رسالة التأكيد, Resend email confirmation email: إعادة إرسال رسالة تأكيد
     البريد الإلكتروني, Reset Password: إعادة تعيين كلمة المرور, Reset e-mail confirmation: إعادة
-    تعيين تأكيد البريد الإلكتروني, Reset password: إعادة تعيين كلمة المرور, Restart: إعادة
-    تشغيل, Restarting: إعادة التشغيل, Resume: استئناف, Resume an interview: استئناف
+    تعيين تأكيد البريد الإلكتروني, Reset password: إعادة تعيين كلمة المرور, Restart: أعد
+    التشغيل, Restarting: إعادة التشغيل, Resume: استئناف, Resume an interview: استئناف
     المقابلة, Retry: إعادة المحاولة, Return: يعود, Retype New Password: أعد كتابة
     كلمة المرور الجديدة, Retype Password: أعد كتابة كلمة المرور, Role: دور, Romania: رومانيا,
   Room: غرفة, Run: يجري, Running in other tab.: تشغيل في علامة تبويب أخرى., Russian Federation: الاتحاد
@@ -750,4 +750,5 @@ ar: {'%(username_or_email)s does not exist': '%(username_or_email)s غير مو�
   them: هم, themself: أنفسهم, themselves: أنفسهم, they: هم, to proceed.: للمتابعة.,
   'true': حقيقي, unavailable: غير متاح, us: نحن, v.: فعل, was saved at: تم حفظه في,
   we: نحن, x: س, y: ي, year: سنة, yes: نعم, you: أنت, yourself: نفسك, yourselves: أنفسكم,
+  Pause: إيقاف مؤقت, Stop: إيقاف,
   Åland Islands: جزر آلاند, Month: شهر, Day: يوم, Year: سنة}

--- a/docassemble/AssemblyLine/data/sources/es-words.yml
+++ b/docassemble/AssemblyLine/data/sources/es-words.yml
@@ -299,7 +299,7 @@ es: {'%(username_or_email)s does not exist': '%(username_or_email)s no existe', 
   Libya: Libia, License: Licencia, Liechtenstein: Liechtenstein, Limited Permissions: Permisos
     limitados, Link copied to clipboard.: Enlace copiado al portapapeles., Linked folder: Carpeta
     vinculada, Links: Campo de golf, List of ISO-639-1 language codes: Lista de códigos
-    de idioma ISO-639-1, Listen: Escucha, Lithuania: Lituania, Live chat: Chat en
+    de idioma ISO-639-1, Listen: Escuchar, Lithuania: Lituania, Live chat: Chat en
     vivo, Live chat is available: Chat en vivo está disponible, Loading . . .: Cargando
     . . ., 'Loading.  Please wait . . . ': Cargando. Por favor espera . . ., Log: Registro,
   Logs: Troncos, Luxembourg: Luxemburgo, Macao: Macao, Madagascar: Madagascar, Malawi: Malawi,
@@ -860,4 +860,5 @@ es: {'%(username_or_email)s does not exist': '%(username_or_email)s no existe', 
   t: t, them: ellos, themself: ellos mismos, themselves: ellos mismos, they: ellos,
   to proceed.: para proceder., 'true': cierto, unavailable: indisponible, us: a nosotros,
   v.: v., was saved at: fue guardado en, we: nosotros, x: X, y: y, year: año, yes: sí,
-  you: tú, yourself: tú mismo, yourselves: vosotros, Åland Islands: Islas Åland}
+  you: tú, yourself: tú mismo, yourselves: vosotros, Pause: Pausar, Stop: Detener,
+  Åland Islands: Islas Åland}

--- a/docassemble/AssemblyLine/data/sources/fr-words.yml
+++ b/docassemble/AssemblyLine/data/sources/fr-words.yml
@@ -456,7 +456,7 @@ fr: {'%(username_or_email)s does not exist': '%(nom_utilisateur_ou_email)s n''ex
     un compte développeur, Resend Confirmation Email: Renvoyer l'e-mail de confirmation,
   Resend email confirmation email: Renvoyer l'e-mail de confirmation, Reset Password: Réinitialiser
     le mot de passe, Reset e-mail confirmation: Réinitialiser la confirmation par
-    e-mail, Reset password: Réinitialiser le mot de passe, Restart: Redémarrage, Restarting: Redémarrage,
+    e-mail, Reset password: Réinitialiser le mot de passe, Restart: Recommencer, Restarting: Redémarrage,
   Resume: Reanudar, Resume an interview: Reprendre un entretien, Retry: Réessayer, Return: Retour,
   Retype New Password: Retapez le nouveau mot de passe, Retype Password: Retaper le
     mot de passe, Role: Rôle, Romania: Roumanie, Room: Chambre, Run: Courir, Running in other tab.: Exécution
@@ -875,4 +875,4 @@ fr: {'%(username_or_email)s does not exist': '%(nom_utilisateur_ou_email)s n''ex
   themself: eux-mêmes, themselves: eux-mêmes, they: ils, to proceed.: pour continuer.,
   'true': vrai, unavailable: indisponible, us: nous, v.: v., was saved at: a été sauvé
     à, we: nous, x: x, y: et, year: année, yes: Oui, you: toi, yourself: toi-même,
-  yourselves: vous-mêmes, Åland Islands: Îles Åland}
+  yourselves: vous-mêmes, Pause: Pause, Stop: Arrêter, Åland Islands: Îles Åland}

--- a/docassemble/AssemblyLine/data/sources/ht-words.yml
+++ b/docassemble/AssemblyLine/data/sources/ht-words.yml
@@ -10,3 +10,7 @@ ht:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': 'Nimewo telefòn sa a pa sanble kòrèk. Tanpri sonje yon nimewo ki pa ameriken bezwen yon "+" anvan nimewo a.'
   "You have entered %d character.": "Ou antre %d karaktè."
   "You have entered %d characters.": "Ou antre %d karaktè."
+  "Listen": "Koute"
+  "Restart": "Rekòmanse"
+  "Pause": "Pòz"
+  "Stop": "Sispann"

--- a/docassemble/AssemblyLine/data/sources/km-words.yml
+++ b/docassemble/AssemblyLine/data/sources/km-words.yml
@@ -10,3 +10,7 @@ km:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': 'លេខទូរសព្ទនេះមើលទៅមិនត្រឹមត្រូវទេ។ សូមចំណាំថា លេខទូរសព្ទដែលមិនមែនជាលេខអាមេរិក ត្រូវដាក់សញ្ញា "+" នៅពីមុខលេខ។'
   "You have entered %d character.": "អ្នកបានបញ្ចូល %d តួអក្សរ។"
   "You have entered %d characters.": "អ្នកបានបញ្ចូល %d តួអក្សរ។"
+  "Listen": "ស្តាប់"
+  "Restart": "ចាប់ផ្តើមឡើងវិញ"
+  "Pause": "ផ្អាក"
+  "Stop": "បញ្ឈប់"

--- a/docassemble/AssemblyLine/data/sources/ne-words.yml
+++ b/docassemble/AssemblyLine/data/sources/ne-words.yml
@@ -837,5 +837,6 @@ Resume: जारी राख्नुहोस्, Resume an interview: अन
   skip: छोड्नुहोस्, something: केहि, system: प्रणाली, t: ट, them: तिनीहरूलाई, themself: आफैं,
   themselves: आफैं, they: तिनीहरू, to proceed.: अगाडि बढ्न।, 'true': सत्य, unavailable: उपलब्ध
     छैन, us: हामीलाई, v.: वि., was saved at: मा सुरक्षित गरिएको थियो, we: हामी, x: x,
-  y: र, year: वर्ष, yes: हो, you: तिमी, yourself: आफैँ, yourselves: आफैं, Åland Islands: अलान्ड
+  y: र, year: वर्ष, yes: हो, you: तिमी, yourself: आफैँ, yourselves: आफैं, Pause: पज गर्नुहोस्,
+  Stop: रोक्नुहोस्, Åland Islands: अलान्ड
     टापुहरू}

--- a/docassemble/AssemblyLine/data/sources/pt-words.yml
+++ b/docassemble/AssemblyLine/data/sources/pt-words.yml
@@ -10,3 +10,7 @@ pt:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': 'Este número de telefone não parece correto. Observe que um número que não seja dos EUA precisa de um "+" antes do número.'
   "You have entered %d character.": "Você digitou %d caractere."
   "You have entered %d characters.": "Você digitou %d caracteres."
+  "Listen": "Ouvir"
+  "Restart": "Reiniciar"
+  "Pause": "Pausar"
+  "Stop": "Parar"

--- a/docassemble/AssemblyLine/data/sources/vi-words.yml
+++ b/docassemble/AssemblyLine/data/sources/vi-words.yml
@@ -10,3 +10,7 @@ vi:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': 'Số điện thoại này có vẻ không đúng. Lưu ý rằng số điện thoại không phải của Hoa Kỳ cần có dấu "+" trước số.'
   "You have entered %d character.": "Bạn đã nhập %d ký tự."
   "You have entered %d characters.": "Bạn đã nhập %d ký tự."
+  "Listen": "Nghe"
+  "Restart": "Khởi động lại"
+  "Pause": "Tạm dừng"
+  "Stop": "Dừng"

--- a/docassemble/AssemblyLine/data/sources/zh-Hans-words.yml
+++ b/docassemble/AssemblyLine/data/sources/zh-Hans-words.yml
@@ -10,6 +10,10 @@ zh-Hans:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': '此电话号码似乎不正确。请注意，非美国电话号码需要在号码前加上“+”。'
   "You have entered %d character.": "您已输入 %d 个字符。"
   "You have entered %d characters.": "您已输入 %d 个字符。"
+  "Listen": "听"
+  "Restart": "重新开始"
+  "Pause": "暂停"
+  "Stop": "停止"
 
 # Keep the common regional code working as an alias.
 zh-CN:
@@ -24,3 +28,7 @@ zh-CN:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': '此电话号码似乎不正确。请注意，非美国电话号码需要在号码前加上“+”。'
   "You have entered %d character.": "您已输入 %d 个字符。"
   "You have entered %d characters.": "您已输入 %d 个字符。"
+  "Listen": "听"
+  "Restart": "重新开始"
+  "Pause": "暂停"
+  "Stop": "停止"

--- a/docassemble/AssemblyLine/data/sources/zh-Hant-words.yml
+++ b/docassemble/AssemblyLine/data/sources/zh-Hant-words.yml
@@ -10,6 +10,10 @@ zh-Hant:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': '此電話號碼似乎不正確。請注意，非美國電話號碼需要在號碼前加上「+」。'
   "You have entered %d character.": "您已輸入 %d 個字元。"
   "You have entered %d characters.": "您已輸入 %d 個字元。"
+  "Listen": "聽"
+  "Restart": "重新開始"
+  "Pause": "暫停"
+  "Stop": "停止"
 
 # Keep the common regional code working as an alias.
 zh-TW:
@@ -24,3 +28,7 @@ zh-TW:
   'This phone number doesn''t look right. Note that a non-US number needs a "+" before the number.': '此電話號碼似乎不正確。請注意，非美國電話號碼需要在號碼前加上「+」。'
   "You have entered %d character.": "您已輸入 %d 個字元。"
   "You have entered %d characters.": "您已輸入 %d 個字元。"
+  "Listen": "聽"
+  "Restart": "重新開始"
+  "Pause": "暫停"
+  "Stop": "停止"

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -13,6 +13,28 @@ $(document).on('daPageLoad', function(event) {
   } catch ( error ) { console.log( 'AL audio instantiation error:', error, 'event was ', event ) }
 });
 
+// Translate both the visible button text and the accessible labels. The
+// translation catalog may arrive after the controls are first rendered, so we
+// also run this again when ALToolbox announces that the catalog has loaded.
+al_js.translate_audio_controls = function( $audio_container ) {
+  var labels = {
+    play: alTranslate('Listen'),
+    restart: alTranslate('Restart'),
+    pause: alTranslate('Pause'),
+    stop: alTranslate('Stop'),
+  };
+
+  for ( var control_name in labels ) {
+    var $button = $audio_container.find('.' + control_name);
+    $button.attr('aria-label', labels[control_name]);
+    $button.find('span').text('\u00a0' + labels[control_name] + '\u00a0');
+  }
+};
+
+window.addEventListener('alTranslationsLoaded', function() {
+  al_js.translate_audio_controls($('.al_audio_controls'));
+});
+
 // We are not providing a way to rewind or scan through the audio.
 // TODO: Show user the audio still needs to load:
 // - https://stackoverflow.com/questions/9337300/html5-audio-load-event,
@@ -46,6 +68,7 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
   $('<div id="' + id + '" class="btn-group">' +
         audio_contents_html +
   '</div>').appendTo( $audio_container );
+  al_js.translate_audio_controls( $audio_container );
   
   // Start of all the right selectors
   var id_s = '#' + id + ' ';
@@ -109,15 +132,15 @@ var audio_contents_html = '\
     <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
     <i class="fas fa-play"></i>\
   </button>\
-  <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="restart" value="restart">\
+  <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="Restart" value="restart">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Restart&nbsp;</span>\
     <i class="fas fa-undo"></i>\
   </button>\
-  <button class="media-action pause btn btn-sm btn-outline-secondary" aria-label="pause" value="pause">\
+  <button class="media-action pause btn btn-sm btn-outline-secondary" aria-label="Pause" value="pause">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Pause&nbsp;</span>\
     <i class="fas fa-pause"></i>\
   </button>\
-  <button class="media-action stop btn btn-sm btn-outline-secondary" aria-label="stop" value="stop">\
+  <button class="media-action stop btn btn-sm btn-outline-secondary" aria-label="Stop" value="stop">\
     <i class="fas fa-stop"></i>\
   </button>\
 ';

--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -17,6 +17,8 @@ $(document).on('daPageLoad', function(event) {
 // translation catalog may arrive after the controls are first rendered, so we
 // also run this again when ALToolbox announces that the catalog has loaded.
 al_js.translate_audio_controls = function( $audio_container ) {
+  if ( typeof alTranslate !== 'function' ) { return; }
+
   var labels = {
     play: alTranslate('Listen'),
     restart: alTranslate('Restart'),
@@ -25,6 +27,7 @@ al_js.translate_audio_controls = function( $audio_container ) {
   };
 
   for ( var control_name in labels ) {
+    if ( !Object.prototype.hasOwnProperty.call(labels, control_name) ) { continue; }
     var $button = $audio_container.find('.' + control_name);
     $button.attr('aria-label', labels[control_name]);
     $button.find('span').text('\u00a0' + labels[control_name] + '\u00a0');

--- a/docassemble/AssemblyLine/test_all_imports.py
+++ b/docassemble/AssemblyLine/test_all_imports.py
@@ -1,3 +1,4 @@
+# do not pre-load
 # Makes sure that loading each module file works.
 # Includes all imports not covered by other test files.
 

--- a/docassemble/AssemblyLine/test_audio.py
+++ b/docassemble/AssemblyLine/test_audio.py
@@ -23,6 +23,6 @@ def test_every_word_catalog_translates_audio_control_labels() -> None:
 
     for word_file in word_files:
         catalogs = yaml.safe_load(word_file.read_text(encoding="utf-8"))
-        assert len(catalogs) == 1
-        translations = next(iter(catalogs.values()))
-        assert AUDIO_LABELS <= translations.keys(), word_file.name
+        assert catalogs
+        for language, translations in catalogs.items():
+            assert AUDIO_LABELS <= translations.keys(), f"{word_file.name}:{language}"

--- a/docassemble/AssemblyLine/test_audio.py
+++ b/docassemble/AssemblyLine/test_audio.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import yaml
 
-
 PACKAGE_PATH = Path(__file__).parent
 AUDIO_LABELS = {"Listen", "Restart", "Pause", "Stop"}
 

--- a/docassemble/AssemblyLine/test_audio.py
+++ b/docassemble/AssemblyLine/test_audio.py
@@ -1,0 +1,29 @@
+# do not pre-load
+from pathlib import Path
+
+import yaml
+
+
+PACKAGE_PATH = Path(__file__).parent
+AUDIO_LABELS = {"Listen", "Restart", "Pause", "Stop"}
+
+
+def test_audio_control_labels_use_browser_translations() -> None:
+    audio_javascript = (PACKAGE_PATH / "data" / "static" / "al_audio.js").read_text(
+        encoding="utf-8"
+    )
+
+    for label in AUDIO_LABELS:
+        assert f"alTranslate('{label}')" in audio_javascript
+
+
+def test_every_word_catalog_translates_audio_control_labels() -> None:
+    source_path = PACKAGE_PATH / "data" / "sources"
+    word_files = sorted(source_path.glob("*-words.yml"))
+    assert word_files
+
+    for word_file in word_files:
+        catalogs = yaml.safe_load(word_file.read_text(encoding="utf-8"))
+        assert len(catalogs) == 1
+        translations = next(iter(catalogs.values()))
+        assert AUDIO_LABELS <= translations.keys(), word_file.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name="Suffolk Legal Innovation and Technology Lab", email="litlab@suffolk.edu" },
 ]
 dependencies = [
-    "docassemble.ALToolbox>=0.18.0",
+    "docassemble.ALToolbox>=0.19.0",
     "docassemble.GitHubFeedbackForm>=0.4.1.1",
 ]
 license="MIT"


### PR DESCRIPTION
update translations in our own words.ymls so audio controls are translatable (and translated)

Fix #1053 

Once merged, the "Listen" audio control should match the currently selected language of the user. Depends on ALToolbox>=0.19.0