### PR TITLE
Hide literacy-only screen reader from tab order; it's redundant for low-vision users

### DIFF
--- a/docassemble/AssemblyLine/data/static/al_audio.js
+++ b/docassemble/AssemblyLine/data/static/al_audio.js
@@ -68,7 +68,10 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
   audio_node.style.display = 'none';
   var $audio_container = $($(audio_node).closest('.daaudiovideo-control'));
   $audio_container.addClass( 'al_custom_media_controls al_audio_controls' );
-  $('<div id="' + id + '" class="btn-group">' +
+  // This widget is for pointer/touch users who benefit from spoken text; it
+  // must not compete with a screen reader. Keep it out of both the
+  // accessibility tree and keyboard tab order while retaining click/tap use.
+  $('<div id="' + id + '" class="btn-group" aria-hidden="true">' +
         audio_contents_html +
   '</div>').appendTo( $audio_container );
   al_js.translate_audio_controls( $audio_container );
@@ -131,19 +134,19 @@ al_js.replace_with_audio_minimal_controls = function( audio_node, id ) {
 
 // The DOM structure for every AL audio element with custom controls
 var audio_contents_html = '\
-  <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="Listen" value="play">\
+  <button class="media-action play btn btn-sm btn-outline-secondary" aria-label="Listen" value="play" tabindex="-1">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Listen&nbsp;</span>\
     <i class="fas fa-play"></i>\
   </button>\
-  <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="Restart" value="restart">\
+  <button class="media-action restart btn btn-sm btn-outline-secondary" aria-label="Restart" value="restart" tabindex="-1">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Restart&nbsp;</span>\
     <i class="fas fa-undo"></i>\
   </button>\
-  <button class="media-action pause btn btn-sm btn-outline-secondary" aria-label="Pause" value="pause">\
+  <button class="media-action pause btn btn-sm btn-outline-secondary" aria-label="Pause" value="pause" tabindex="-1">\
     <i class="fas fa-volume-up"></i><span>&nbsp;Pause&nbsp;</span>\
     <i class="fas fa-pause"></i>\
   </button>\
-  <button class="media-action stop btn btn-sm btn-outline-secondary" aria-label="Stop" value="stop">\
+  <button class="media-action stop btn btn-sm btn-outline-secondary" aria-label="Stop" value="stop" tabindex="-1">\
     <i class="fas fa-stop"></i>\
   </button>\
 ';

--- a/docassemble/AssemblyLine/test_audio.py
+++ b/docassemble/AssemblyLine/test_audio.py
@@ -16,6 +16,15 @@ def test_audio_control_labels_use_browser_translations() -> None:
         assert f"alTranslate('{label}')" in audio_javascript
 
 
+def test_audio_controls_are_hidden_from_assistive_technology_and_tab_order() -> None:
+    audio_javascript = (PACKAGE_PATH / "data" / "static" / "al_audio.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'class="btn-group" aria-hidden="true"' in audio_javascript
+    assert audio_javascript.count('tabindex="-1"') == 4
+
+
 def test_every_word_catalog_translates_audio_control_labels() -> None:
     source_path = PACKAGE_PATH / "data" / "sources"
     word_files = sorted(source_path.glob("*-words.yml"))


### PR DESCRIPTION
Fix #621 

