### PR TITLE
Fix 'reference to a variable html' error on interview load

### DIFF
--- a/docassemble/AssemblyLine/data/questions/al_visual.yml
+++ b/docassemble/AssemblyLine/data/questions/al_visual.yml
@@ -2,7 +2,7 @@
 include:
   - docassemble.ALToolbox:translation_strings.yml
 ---
-modules:
+imports:
   - json
   - html
 ---


### PR DESCRIPTION
## Problem

Since #1095 (`1f7b7cb`), loading any interview that includes `al_visual.yml` fails with:

```
Interview has an error. There was a reference to a variable 'html' that could
not be looked up in the question file (for language 'en') ...
```

## Cause

That PR added:

```yaml
modules:
  - json
  - html
```

In docassemble, `modules:` performs `from <module> import *`. That pulls in the module's public names (`escape`, `unescape`, `dumps`, ...) but never binds the module name itself. So the `html.escape(...)` call in the `al_menu_items_default_items` `data from code` block had no `html` in scope, and docassemble tried to resolve it as an interview variable. `json.dumps` would have failed the same way right after.

## Fix

Use `imports:`, which does `import <module>` — matching how `ql_baseline.yml` and `al_settings.yml` already import `humanize` and `importlib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)