### PR TITLE
Warn user when an uploaded exhibit could not be processed

### DIFF
--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2203,6 +2203,30 @@ class ALDocumentBundle(DAList):
 
         return results, bundled_zip, bundled_pdf
 
+    def has_broken_documents(self) -> bool:
+        for document in self.enabled_documents():
+            if (
+                hasattr(document, "has_broken_exhibits")
+                and document.has_broken_exhibits()
+            ):
+                return True
+            if (
+                isinstance(document, ALDocumentBundle)
+                and document.has_broken_documents()
+            ):
+                return True
+        return False
+
+    def broken_documents_warning_html(self) -> str:
+        if not self.has_broken_documents():
+            return ""
+        return (
+            '<div class="alert alert-warning" role="alert">'
+            "One of your files did not upload correctly and it will not be included. "
+            "Please try uploading it again before you continue."
+            "</div>"
+        )
+
     def download_list_html(
         self,
         key: str = "final",
@@ -2299,7 +2323,8 @@ class ALDocumentBundle(DAList):
                 zip_format=zip_format,
             )
 
-        html = f'<div class="container al_table al_doc_table" id="{ html_safe_str(self.instanceName) }">'
+        html = self.broken_documents_warning_html()
+        html += f'<div class="container al_table al_doc_table" id="{ html_safe_str(self.instanceName) }">'
 
         for result in downloadable_files:
             title = result["title"]
@@ -2976,6 +3001,20 @@ class ALExhibit(DAObject):
             pages.append(page)
         return pages
 
+    def is_broken(self) -> bool:
+        """
+        Returns True if this exhibit's pages finished gathering but none of
+        them are currently valid, meaning as_pdf() will silently skip it.
+
+        Checks pages.gathered rather than the `complete` property, since
+        `complete` is a gathering trigger that always returns True and can
+        force docassemble to gather undefined attributes as a side effect
+        """
+        if not getattr(self.pages, "gathered", False):
+            return False
+        valid_pages = [p for p in self.ocr_pages() if p and p.ok]
+        return len(valid_pages) == 0
+
     def as_pdf(
         self,
         *,
@@ -3267,6 +3306,16 @@ class ALExhibitList(DAList):
             filename=filename,
             pdfa=pdfa,
         )
+
+    def broken_exhibits(self) -> List["ALExhibit"]:
+        """Returns exhibits that are complete but have no valid pages"""
+        if not self.gathered:
+            return []
+        return [exhibit for exhibit in self if exhibit.is_broken()]
+
+    def has_broken_exhibits(self) -> bool:
+        """True if any exhibit in this list will be skipped"""
+        return len(self.broken_exhibits()) > 0
 
     def size_in_bytes(self) -> int:
         """
@@ -3580,6 +3629,14 @@ class ALExhibitDocument(ALDocument):
                 )
             return exhibits_pdf
         return None
+
+    def has_broken_exhibits(self) -> bool:
+        """True if any exhibit in this document will be silently skipped"""
+        return self.exhibits.has_broken_exhibits()
+
+    def broken_exhibits(self) -> List["ALExhibit"]:
+        """Returns exhibits that are complete but have no valid pages"""
+        return self.exhibits.broken_exhibits()
 
     def as_docx(
         self,

--- a/docassemble/AssemblyLine/al_document.py
+++ b/docassemble/AssemblyLine/al_document.py
@@ -2204,6 +2204,13 @@ class ALDocumentBundle(DAList):
         return results, bundled_zip, bundled_pdf
 
     def has_broken_documents(self) -> bool:
+        """
+        Checks if anything in this bundle, including any content inside a nested
+        bundle, failed to process and will be silently skipped.
+
+        Returns:
+            bool: True if any document or nested bundle has broken content.
+        """
         for document in self.enabled_documents():
             if (
                 hasattr(document, "has_broken_exhibits")
@@ -2218,6 +2225,13 @@ class ALDocumentBundle(DAList):
         return False
 
     def broken_documents_warning_html(self) -> str:
+        """
+        Builds the warning banner shown on the download screen if any document in
+        this bundle has broken content.
+
+        Returns:
+            str: The warning HTML, or an empty string if nothing is broken.
+        """
         if not self.has_broken_documents():
             return ""
         return (
@@ -3009,6 +3023,9 @@ class ALExhibit(DAObject):
         Checks pages.gathered rather than the `complete` property, since
         `complete` is a gathering trigger that always returns True and can
         force docassemble to gather undefined attributes as a side effect
+
+        Returns:
+            bool: True if this exhibit will get skipped.
         """
         if not getattr(self.pages, "gathered", False):
             return False
@@ -3308,13 +3325,21 @@ class ALExhibitList(DAList):
         )
 
     def broken_exhibits(self) -> List["ALExhibit"]:
-        """Returns exhibits that are complete but have no valid pages"""
+        """Returns exhibits that are complete but have no valid pages
+
+        Returns:
+            List[ALExhibit]: The exhibits that will get skipped.
+        """
         if not self.gathered:
             return []
         return [exhibit for exhibit in self if exhibit.is_broken()]
 
     def has_broken_exhibits(self) -> bool:
-        """True if any exhibit in this list will be skipped"""
+        """True if any exhibit in this list will be skipped
+
+        Returns:
+            bool: True if at least one exhibit has no valid pages.
+        """
         return len(self.broken_exhibits()) > 0
 
     def size_in_bytes(self) -> int:
@@ -3631,11 +3656,19 @@ class ALExhibitDocument(ALDocument):
         return None
 
     def has_broken_exhibits(self) -> bool:
-        """True if any exhibit in this document will be silently skipped"""
+        """True if any exhibit in this document will be silently skipped
+
+        Returns:
+            bool: True if at least one exhibit has no valid pages.
+        """
         return self.exhibits.has_broken_exhibits()
 
     def broken_exhibits(self) -> List["ALExhibit"]:
-        """Returns exhibits that are complete but have no valid pages"""
+        """Returns exhibits that are complete but have no valid pages
+
+        Returns:
+            List[ALExhibit]: The exhibits that will get skipped.
+        """
         return self.exhibits.broken_exhibits()
 
     def as_docx(

--- a/docassemble/AssemblyLine/test_al_document.py
+++ b/docassemble/AssemblyLine/test_al_document.py
@@ -3,7 +3,7 @@
 import json
 import unittest
 from html import unescape
-from docassemble.base.util import DAFile, DATemplate
+from docassemble.base.util import DAFile, DAFileList, DATemplate
 from .al_document import (
     ALAddendumField,
     ALDocument,
@@ -96,6 +96,17 @@ class FakeSingleDoc:
 
     def as_pdf(self, **kwargs):
         return self._pdf
+
+
+class FakeDocWithBrokenExhibits:
+    def __init__(self, broken):
+        self._broken = broken
+
+    def is_enabled(self, refresh=True):
+        return True
+
+    def has_broken_exhibits(self):
+        return self._broken
 
 
 class TestSingleDocumentBundleFilename(unittest.TestCase):
@@ -220,6 +231,81 @@ class TestExhibitWithNoValidPages(unittest.TestCase):
         result = exhibit.as_pdf()
 
         self.assertIsNone(result)
+
+
+class TestExhibitIsBroken(unittest.TestCase):
+    def test_valid_pages_and_gathered_is_not_broken(self):
+        exhibit = ALExhibit("exhibit")
+        exhibit.title = "Test Exhibit"
+        good_page = FakePdf(filename="good.pdf", title="page")
+        good_page.ok = True
+        exhibit.pages = DAFileList("exhibit.pages")
+        exhibit.pages.append(good_page)
+        exhibit.pages.gathered = True
+
+        self.assertFalse(exhibit.is_broken())
+
+    def test_no_valid_pages_and_gathered_is_broken(self):
+        exhibit = ALExhibit("exhibit")
+        exhibit.title = "Test Exhibit"
+        exhibit.pages = DAFileList("exhibit.pages")
+        exhibit.pages.gathered = True
+
+        self.assertTrue(exhibit.is_broken())
+
+    def test_no_pages_and_not_gathered_is_not_broken(self):
+        exhibit = ALExhibit("exhibit")
+        exhibit.title = "Test Exhibit"
+        exhibit.pages = DAFileList("exhibit.pages")
+        exhibit.pages.gathered = False
+
+        self.assertFalse(exhibit.is_broken())
+
+
+class TestBundleWarnsOnBrokenDocuments(unittest.TestCase):
+    def test_bundle_with_broken_exhibit_doc_shows_warning(self):
+        bundle = ALDocumentBundle(
+            "bundle",
+            elements=[FakeDocWithBrokenExhibits(broken=True)],
+            title="Bundle title",
+            filename="bundle-output.pdf",
+            enabled=True,
+        )
+
+        self.assertTrue(bundle.has_broken_documents())
+        self.assertIn(
+            "did not upload correctly", bundle.broken_documents_warning_html()
+        )
+
+    def test_bundle_all_valid_shows_no_warning(self):
+        bundle = ALDocumentBundle(
+            "bundle",
+            elements=[FakeDocWithBrokenExhibits(broken=False)],
+            title="Bundle title",
+            filename="bundle-output.pdf",
+            enabled=True,
+        )
+
+        self.assertFalse(bundle.has_broken_documents())
+        self.assertEqual(bundle.broken_documents_warning_html(), "")
+
+    def test_bundle_detects_broken_document_in_nested_bundle(self):
+        inner_bundle = ALDocumentBundle(
+            "inner_bundle",
+            elements=[FakeDocWithBrokenExhibits(broken=True)],
+            title="Inner",
+            filename="inner.pdf",
+            enabled=True,
+        )
+        outer_bundle = ALDocumentBundle(
+            "outer_bundle",
+            elements=[inner_bundle],
+            title="Outer",
+            filename="outer.pdf",
+            enabled=True,
+        )
+
+        self.assertTrue(outer_bundle.has_broken_documents())
 
 
 class test_aladdendum(unittest.TestCase):


### PR DESCRIPTION
Follow up to #1098, which made broken exhibits fail silently instead of crashing the download, but it also means someone could end up missing a file from their packet and never know it. This adds a check for exhibits that finished uploading but came back with no valid pages, and shows a warning on the download screen when that happens.

It's built into `download_list_html()` itself so that way every interview using it gets the warning automatically. One thing worth knowing, this only catches broken exhibits, not other kinds of documents in a bundle. If a plain attachment fails for some other reason, this warning won't catch it.